### PR TITLE
fix: 履歴記録対象拡大 / PhysicalPlot・ConstructionInfo 更新 strip 問題 (Closes #62, refs #51, #63)

### DIFF
--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -66,19 +66,18 @@ export const updatePlot = async (
 
       // 1.5. 物理区画情報の更新（issue #62）
       // フロントから input.physicalPlot が送られてきた場合のみ更新
-      const physicalPlotInput = (input as { physicalPlot?: Record<string, unknown> }).physicalPlot;
+      const physicalPlotInput = input.physicalPlot;
       if (physicalPlotInput) {
         const ppUpdateData: Record<string, unknown> = {};
-        if (physicalPlotInput['plotNumber'] !== undefined)
-          ppUpdateData['plot_number'] = physicalPlotInput['plotNumber'];
-        if (physicalPlotInput['areaName'] !== undefined)
-          ppUpdateData['area_name'] = physicalPlotInput['areaName'];
-        if (physicalPlotInput['areaSqm'] !== undefined)
-          ppUpdateData['area_sqm'] = new Prisma.Decimal(physicalPlotInput['areaSqm'] as number);
-        if (physicalPlotInput['status'] !== undefined)
-          ppUpdateData['status'] = physicalPlotInput['status'];
-        if (physicalPlotInput['notes'] !== undefined)
-          ppUpdateData['notes'] = physicalPlotInput['notes'];
+        if (physicalPlotInput.plotNumber !== undefined)
+          ppUpdateData['plot_number'] = physicalPlotInput.plotNumber;
+        if (physicalPlotInput.areaName !== undefined)
+          ppUpdateData['area_name'] = physicalPlotInput.areaName;
+        if (physicalPlotInput.areaSqm !== undefined)
+          ppUpdateData['area_sqm'] = new Prisma.Decimal(physicalPlotInput.areaSqm);
+        if (physicalPlotInput.status !== undefined)
+          ppUpdateData['status'] = physicalPlotInput.status;
+        if (physicalPlotInput.notes !== undefined) ppUpdateData['notes'] = physicalPlotInput.notes;
 
         if (Object.keys(ppUpdateData).length > 0) {
           const beforePp = existingContractPlot.physicalPlot;

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -34,535 +34,502 @@ export const updatePlot = async (
     const input: UpdatePlotRequest = req.body;
 
     // トランザクション処理
-    await prisma.$transaction(async (tx) => {
-      // 1. 既存のContractPlotを取得
-      const existingContractPlot = await tx.contractPlot.findUnique({
-        where: { id, deleted_at: null },
-        include: {
-          physicalPlot: true,
-          saleContractRoles: {
-            where: { deleted_at: null },
-            include: {
-              customer: {
-                include: {
-                  workInfo: true,
-                  billingInfo: true,
+    // updatePlot は履歴記録を含む多数の sequential query を 1 トランザクションで実行するため
+    // デフォルトの 5 秒タイムアウトでは P2028 が発生する。30 秒に延長。
+    await prisma.$transaction(
+      async (tx) => {
+        // 1. 既存のContractPlotを取得
+        const existingContractPlot = await tx.contractPlot.findUnique({
+          where: { id, deleted_at: null },
+          include: {
+            physicalPlot: true,
+            saleContractRoles: {
+              where: { deleted_at: null },
+              include: {
+                customer: {
+                  include: {
+                    workInfo: true,
+                    billingInfo: true,
+                  },
                 },
               },
             },
+            usageFee: true,
+            managementFee: true,
+            collectiveBurial: true,
           },
-          usageFee: true,
-          managementFee: true,
-          collectiveBurial: true,
-        },
-      });
+        });
 
-      if (!existingContractPlot) {
-        throw new NotFoundError('指定された契約区画が見つかりません');
-      }
+        if (!existingContractPlot) {
+          throw new NotFoundError('指定された契約区画が見つかりません');
+        }
 
-      const physicalPlotId = existingContractPlot.physical_plot_id;
-      const oldContractArea = existingContractPlot.contract_area_sqm.toNumber();
+        const physicalPlotId = existingContractPlot.physical_plot_id;
+        const oldContractArea = existingContractPlot.contract_area_sqm.toNumber();
 
-      // 1.5. 物理区画情報の更新（issue #62）
-      // フロントから input.physicalPlot が送られてきた場合のみ更新
-      const physicalPlotInput = input.physicalPlot;
-      if (physicalPlotInput) {
-        const ppUpdateData: Record<string, unknown> = {};
-        if (physicalPlotInput.plotNumber !== undefined)
-          ppUpdateData['plot_number'] = physicalPlotInput.plotNumber;
-        if (physicalPlotInput.areaName !== undefined)
-          ppUpdateData['area_name'] = physicalPlotInput.areaName;
-        if (physicalPlotInput.areaSqm !== undefined)
-          ppUpdateData['area_sqm'] = new Prisma.Decimal(physicalPlotInput.areaSqm);
-        if (physicalPlotInput.status !== undefined)
-          ppUpdateData['status'] = physicalPlotInput.status;
-        if (physicalPlotInput.notes !== undefined) ppUpdateData['notes'] = physicalPlotInput.notes;
+        // 1.5. 物理区画情報の更新（issue #62）
+        // フロントから input.physicalPlot が送られてきた場合のみ更新
+        const physicalPlotInput = input.physicalPlot;
+        if (physicalPlotInput) {
+          const ppUpdateData: Record<string, unknown> = {};
+          if (physicalPlotInput.plotNumber !== undefined)
+            ppUpdateData['plot_number'] = physicalPlotInput.plotNumber;
+          if (physicalPlotInput.areaName !== undefined)
+            ppUpdateData['area_name'] = physicalPlotInput.areaName;
+          if (physicalPlotInput.areaSqm !== undefined)
+            ppUpdateData['area_sqm'] = new Prisma.Decimal(physicalPlotInput.areaSqm);
+          if (physicalPlotInput.status !== undefined)
+            ppUpdateData['status'] = physicalPlotInput.status;
+          if (physicalPlotInput.notes !== undefined)
+            ppUpdateData['notes'] = physicalPlotInput.notes;
 
-        if (Object.keys(ppUpdateData).length > 0) {
-          const beforePp = existingContractPlot.physicalPlot;
-          const updatedPp = await tx.physicalPlot.update({
-            where: { id: physicalPlotId },
-            data: ppUpdateData,
-          });
-          await recordEntityUpdated(tx, {
-            entityType: 'PhysicalPlot',
-            entityId: physicalPlotId,
-            physicalPlotId,
-            beforeRecord: {
-              plot_number: beforePp.plot_number,
-              area_name: beforePp.area_name,
-              area_sqm: beforePp.area_sqm.toString(),
-              status: beforePp.status,
-              notes: beforePp.notes,
-            },
-            afterRecord: {
-              plot_number: updatedPp.plot_number,
-              area_name: updatedPp.area_name,
-              area_sqm: updatedPp.area_sqm.toString(),
-              status: updatedPp.status,
-              notes: updatedPp.notes,
-            },
-            req,
+          if (Object.keys(ppUpdateData).length > 0) {
+            const beforePp = existingContractPlot.physicalPlot;
+            const updatedPp = await tx.physicalPlot.update({
+              where: { id: physicalPlotId },
+              data: ppUpdateData,
+            });
+            await recordEntityUpdated(tx, {
+              entityType: 'PhysicalPlot',
+              entityId: physicalPlotId,
+              physicalPlotId,
+              beforeRecord: {
+                plot_number: beforePp.plot_number,
+                area_name: beforePp.area_name,
+                area_sqm: beforePp.area_sqm.toString(),
+                status: beforePp.status,
+                notes: beforePp.notes,
+              },
+              afterRecord: {
+                plot_number: updatedPp.plot_number,
+                area_name: updatedPp.area_name,
+                area_sqm: updatedPp.area_sqm.toString(),
+                status: updatedPp.status,
+                notes: updatedPp.notes,
+              },
+              req,
+            });
+          }
+        }
+
+        // 2. ContractPlot（販売契約情報統合済み）の更新
+        const updateData: any = {};
+
+        // 契約区画情報の更新
+        if (input.contractPlot) {
+          if (input.contractPlot.contractAreaSqm !== undefined) {
+            // 契約面積が変更された場合は妥当性検証
+            const newAreaSqm = input.contractPlot.contractAreaSqm;
+
+            // 他の契約の合計面積を計算（現在の契約を除く）
+            const otherContracts = await tx.contractPlot.findMany({
+              where: {
+                physical_plot_id: physicalPlotId,
+                id: { not: id },
+                deleted_at: null,
+              },
+            });
+
+            const otherContractsTotal = otherContracts.reduce(
+              (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
+              0
+            );
+
+            const totalAfterUpdate = otherContractsTotal + newAreaSqm;
+            const physicalPlotArea = existingContractPlot.physicalPlot.area_sqm.toNumber();
+
+            if (totalAfterUpdate > physicalPlotArea) {
+              throw new ValidationError(
+                `契約面積の合計が物理区画の面積を超えています（物理区画: ${physicalPlotArea}㎡、合計: ${totalAfterUpdate}㎡）`
+              );
+            }
+
+            updateData.contract_area_sqm = new Prisma.Decimal(newAreaSqm);
+          }
+
+          if (input.contractPlot.locationDescription !== undefined) {
+            updateData.location_description = input.contractPlot.locationDescription;
+          }
+        }
+
+        // 販売契約情報の更新（ContractPlotに統合済み）
+        if (input.saleContract) {
+          if (input.saleContract.contractDate !== undefined) {
+            updateData.contract_date = new Date(input.saleContract.contractDate);
+          }
+          if (input.saleContract.price !== undefined) {
+            updateData.price = new Prisma.Decimal(input.saleContract.price);
+          }
+          if (input.saleContract.paymentStatus !== undefined) {
+            updateData.payment_status = input.saleContract.paymentStatus;
+          }
+          if (input.saleContract.reservationDate !== undefined) {
+            updateData.reservation_date = input.saleContract.reservationDate
+              ? new Date(input.saleContract.reservationDate)
+              : null;
+          }
+          if (input.saleContract.acceptanceNumber !== undefined) {
+            updateData.acceptance_number = input.saleContract.acceptanceNumber;
+          }
+          if (input.saleContract.acceptanceDate !== undefined) {
+            updateData.acceptance_date = input.saleContract.acceptanceDate
+              ? new Date(input.saleContract.acceptanceDate)
+              : null;
+          }
+          if (input.saleContract.staffInCharge !== undefined) {
+            updateData.staff_in_charge = input.saleContract.staffInCharge;
+          }
+          if (input.saleContract.agentName !== undefined) {
+            updateData.agent_name = input.saleContract.agentName;
+          }
+          if (input.saleContract.permitNumber !== undefined) {
+            updateData.permit_number = input.saleContract.permitNumber || null;
+          }
+          if (input.saleContract.permitDate !== undefined) {
+            updateData.permit_date = input.saleContract.permitDate
+              ? new Date(input.saleContract.permitDate)
+              : null;
+          }
+          if (input.saleContract.startDate !== undefined) {
+            updateData.start_date = input.saleContract.startDate
+              ? new Date(input.saleContract.startDate)
+              : null;
+          }
+          if (input.saleContract.uncollectedAmount !== undefined) {
+            updateData.uncollected_amount = input.saleContract.uncollectedAmount;
+          }
+          if (input.saleContract.notes !== undefined) {
+            updateData.notes = input.saleContract.notes;
+          }
+        }
+
+        // ContractPlotの更新を実行
+        if (Object.keys(updateData).length > 0) {
+          await tx.contractPlot.update({
+            where: { id },
+            data: updateData,
           });
         }
-      }
 
-      // 2. ContractPlot（販売契約情報統合済み）の更新
-      const updateData: any = {};
-
-      // 契約区画情報の更新
-      if (input.contractPlot) {
-        if (input.contractPlot.contractAreaSqm !== undefined) {
-          // 契約面積が変更された場合は妥当性検証
-          const newAreaSqm = input.contractPlot.contractAreaSqm;
-
-          // 他の契約の合計面積を計算（現在の契約を除く）
-          const otherContracts = await tx.contractPlot.findMany({
+        // 3. 顧客役割の更新
+        if (input.saleContract?.roles !== undefined) {
+          // 既存役割を退避
+          const existingRoles = await tx.saleContractRole.findMany({
             where: {
-              physical_plot_id: physicalPlotId,
-              id: { not: id },
+              contract_plot_id: id,
               deleted_at: null,
             },
           });
 
-          const otherContractsTotal = otherContracts.reduce(
-            (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
-            0
-          );
-
-          const totalAfterUpdate = otherContractsTotal + newAreaSqm;
-          const physicalPlotArea = existingContractPlot.physicalPlot.area_sqm.toNumber();
-
-          if (totalAfterUpdate > physicalPlotArea) {
-            throw new ValidationError(
-              `契約面積の合計が物理区画の面積を超えています（物理区画: ${physicalPlotArea}㎡、合計: ${totalAfterUpdate}㎡）`
-            );
-          }
-
-          updateData.contract_area_sqm = new Prisma.Decimal(newAreaSqm);
-        }
-
-        if (input.contractPlot.locationDescription !== undefined) {
-          updateData.location_description = input.contractPlot.locationDescription;
-        }
-      }
-
-      // 販売契約情報の更新（ContractPlotに統合済み）
-      if (input.saleContract) {
-        if (input.saleContract.contractDate !== undefined) {
-          updateData.contract_date = new Date(input.saleContract.contractDate);
-        }
-        if (input.saleContract.price !== undefined) {
-          updateData.price = new Prisma.Decimal(input.saleContract.price);
-        }
-        if (input.saleContract.paymentStatus !== undefined) {
-          updateData.payment_status = input.saleContract.paymentStatus;
-        }
-        if (input.saleContract.reservationDate !== undefined) {
-          updateData.reservation_date = input.saleContract.reservationDate
-            ? new Date(input.saleContract.reservationDate)
-            : null;
-        }
-        if (input.saleContract.acceptanceNumber !== undefined) {
-          updateData.acceptance_number = input.saleContract.acceptanceNumber;
-        }
-        if (input.saleContract.acceptanceDate !== undefined) {
-          updateData.acceptance_date = input.saleContract.acceptanceDate
-            ? new Date(input.saleContract.acceptanceDate)
-            : null;
-        }
-        if (input.saleContract.staffInCharge !== undefined) {
-          updateData.staff_in_charge = input.saleContract.staffInCharge;
-        }
-        if (input.saleContract.agentName !== undefined) {
-          updateData.agent_name = input.saleContract.agentName;
-        }
-        if (input.saleContract.permitNumber !== undefined) {
-          updateData.permit_number = input.saleContract.permitNumber || null;
-        }
-        if (input.saleContract.permitDate !== undefined) {
-          updateData.permit_date = input.saleContract.permitDate
-            ? new Date(input.saleContract.permitDate)
-            : null;
-        }
-        if (input.saleContract.startDate !== undefined) {
-          updateData.start_date = input.saleContract.startDate
-            ? new Date(input.saleContract.startDate)
-            : null;
-        }
-        if (input.saleContract.uncollectedAmount !== undefined) {
-          updateData.uncollected_amount = input.saleContract.uncollectedAmount;
-        }
-        if (input.saleContract.notes !== undefined) {
-          updateData.notes = input.saleContract.notes;
-        }
-      }
-
-      // ContractPlotの更新を実行
-      if (Object.keys(updateData).length > 0) {
-        await tx.contractPlot.update({
-          where: { id },
-          data: updateData,
-        });
-      }
-
-      // 3. 顧客役割の更新
-      if (input.saleContract?.roles !== undefined) {
-        // 既存役割を退避
-        const existingRoles = await tx.saleContractRole.findMany({
-          where: {
-            contract_plot_id: id,
-            deleted_at: null,
-          },
-        });
-
-        // 既存の役割を論理削除
-        await tx.saleContractRole.updateMany({
-          where: {
-            contract_plot_id: id, // sale_contract_id → contract_plot_idに変更
-            deleted_at: null,
-          },
-          data: {
-            deleted_at: new Date(),
-          },
-        });
-        for (const oldRole of existingRoles) {
-          await recordEntityDeleted(tx, {
-            entityType: 'SaleContractRole',
-            entityId: oldRole.id,
-            physicalPlotId,
-            contractPlotId: id as string,
-            beforeRecord: {
-              id: oldRole.id,
-              role: oldRole.role,
-              customer_id: oldRole.customer_id,
+          // 既存の役割を論理削除
+          await tx.saleContractRole.updateMany({
+            where: {
+              contract_plot_id: id, // sale_contract_id → contract_plot_idに変更
+              deleted_at: null,
             },
-            req,
-          });
-        }
-
-        // 新しい役割を作成
-        for (const roleData of input.saleContract.roles) {
-          // customerId が指定されていない場合はエラー
-          if (!roleData.customerId) {
-            throw new ValidationError('役割更新時は customerId が必須です');
-          }
-
-          const created = await tx.saleContractRole.create({
             data: {
-              contract_plot_id: existingContractPlot.id, // sale_contract_id → contract_plot_idに変更
-              customer_id: roleData.customerId,
-              role: roleData.role,
-              role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
-              role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
-              notes: roleData.notes || null,
+              deleted_at: new Date(),
             },
           });
-          await recordEntityCreated(tx, {
-            entityType: 'SaleContractRole',
-            entityId: created.id,
-            physicalPlotId,
-            contractPlotId: id as string,
-            afterRecord: {
-              id: created.id,
-              role: created.role,
-              customer_id: created.customer_id,
-            },
-            req,
-          });
-        }
-      }
-
-      // 4. Customerの更新（主契約者を対象）
-      if (input.customer) {
-        // 主契約者を取得
-        const primaryRole = existingContractPlot.saleContractRoles?.find(
-          (role: any) => role.role === 'contractor'
-        );
-        const customerId = primaryRole?.customer.id;
-
-        if (customerId) {
-          const updateData: any = {};
-
-          if (input.customer.name !== undefined) updateData.name = input.customer.name;
-          if (input.customer.nameKana !== undefined) updateData.name_kana = input.customer.nameKana;
-          if (input.customer.birthDate !== undefined) {
-            updateData.birth_date = input.customer.birthDate
-              ? new Date(input.customer.birthDate)
-              : null;
-          }
-          if (input.customer.gender !== undefined) updateData.gender = input.customer.gender;
-          if (input.customer.postalCode !== undefined)
-            updateData.postal_code = input.customer.postalCode;
-          if (input.customer.address !== undefined) updateData.address = input.customer.address;
-          if (input.customer.addressLine2 !== undefined)
-            updateData.address_line_2 = input.customer.addressLine2;
-          if (input.customer.registeredAddress !== undefined)
-            updateData.registered_address = input.customer.registeredAddress;
-          if (input.customer.phoneNumber !== undefined)
-            updateData.phone_number = input.customer.phoneNumber;
-          if (input.customer.faxNumber !== undefined)
-            updateData.fax_number = input.customer.faxNumber;
-          if (input.customer.email !== undefined) updateData.email = input.customer.email;
-          if (input.customer.notes !== undefined) updateData.notes = input.customer.notes;
-
-          if (Object.keys(updateData).length > 0) {
-            await tx.customer.update({
-              where: { id: customerId },
-              data: updateData,
+          for (const oldRole of existingRoles) {
+            await recordEntityDeleted(tx, {
+              entityType: 'SaleContractRole',
+              entityId: oldRole.id,
+              physicalPlotId,
+              contractPlotId: id as string,
+              beforeRecord: {
+                id: oldRole.id,
+                role: oldRole.role,
+                customer_id: oldRole.customer_id,
+              },
+              req,
             });
           }
 
-          // 5. WorkInfoの更新/作成/削除
-          if (input.workInfo !== undefined) {
-            const existingWorkInfo = primaryRole?.customer.workInfo;
+          // 新しい役割を作成
+          for (const roleData of input.saleContract.roles) {
+            // customerId が指定されていない場合はエラー
+            if (!roleData.customerId) {
+              throw new ValidationError('役割更新時は customerId が必須です');
+            }
 
-            if (input.workInfo === null) {
-              // 削除
-              if (existingWorkInfo) {
-                await tx.workInfo.delete({
-                  where: { id: existingWorkInfo.id },
-                });
-                await recordEntityDeleted(tx, {
-                  entityType: 'WorkInfo',
-                  entityId: existingWorkInfo.id,
-                  physicalPlotId,
-                  contractPlotId: id as string,
-                  beforeRecord: {
-                    id: existingWorkInfo.id,
-                    company_name: existingWorkInfo.company_name,
-                    work_address: existingWorkInfo.work_address,
-                    work_phone_number: existingWorkInfo.work_phone_number,
-                  },
-                  req,
-                });
-              }
-            } else {
-              // 更新または作成
-              const workInfoData: any = {};
-              if (input.workInfo.companyName !== undefined)
-                workInfoData.company_name = input.workInfo.companyName;
-              if (input.workInfo.companyNameKana !== undefined)
-                workInfoData.company_name_kana = input.workInfo.companyNameKana;
-              if (input.workInfo.workPostalCode !== undefined)
-                workInfoData.work_postal_code = input.workInfo.workPostalCode;
-              if (input.workInfo.workAddress !== undefined)
-                workInfoData.work_address = input.workInfo.workAddress;
-              if (input.workInfo.workPhoneNumber !== undefined)
-                workInfoData.work_phone_number = input.workInfo.workPhoneNumber;
-              if (input.workInfo.dmSetting !== undefined)
-                workInfoData.dm_setting = input.workInfo.dmSetting;
-              if (input.workInfo.addressType !== undefined)
-                workInfoData.address_type = input.workInfo.addressType;
-              if (input.workInfo.notes !== undefined) workInfoData.notes = input.workInfo.notes;
+            const created = await tx.saleContractRole.create({
+              data: {
+                contract_plot_id: existingContractPlot.id, // sale_contract_id → contract_plot_idに変更
+                customer_id: roleData.customerId,
+                role: roleData.role,
+                role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
+                role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
+                notes: roleData.notes || null,
+              },
+            });
+            await recordEntityCreated(tx, {
+              entityType: 'SaleContractRole',
+              entityId: created.id,
+              physicalPlotId,
+              contractPlotId: id as string,
+              afterRecord: {
+                id: created.id,
+                role: created.role,
+                customer_id: created.customer_id,
+              },
+              req,
+            });
+          }
+        }
 
-              if (Object.keys(workInfoData).length > 0) {
+        // 4. Customerの更新（主契約者を対象）
+        if (input.customer) {
+          // 主契約者を取得
+          const primaryRole = existingContractPlot.saleContractRoles?.find(
+            (role: any) => role.role === 'contractor'
+          );
+          const customerId = primaryRole?.customer.id;
+
+          if (customerId) {
+            const updateData: any = {};
+
+            if (input.customer.name !== undefined) updateData.name = input.customer.name;
+            if (input.customer.nameKana !== undefined)
+              updateData.name_kana = input.customer.nameKana;
+            if (input.customer.birthDate !== undefined) {
+              updateData.birth_date = input.customer.birthDate
+                ? new Date(input.customer.birthDate)
+                : null;
+            }
+            if (input.customer.gender !== undefined) updateData.gender = input.customer.gender;
+            if (input.customer.postalCode !== undefined)
+              updateData.postal_code = input.customer.postalCode;
+            if (input.customer.address !== undefined) updateData.address = input.customer.address;
+            if (input.customer.addressLine2 !== undefined)
+              updateData.address_line_2 = input.customer.addressLine2;
+            if (input.customer.registeredAddress !== undefined)
+              updateData.registered_address = input.customer.registeredAddress;
+            if (input.customer.phoneNumber !== undefined)
+              updateData.phone_number = input.customer.phoneNumber;
+            if (input.customer.faxNumber !== undefined)
+              updateData.fax_number = input.customer.faxNumber;
+            if (input.customer.email !== undefined) updateData.email = input.customer.email;
+            if (input.customer.notes !== undefined) updateData.notes = input.customer.notes;
+
+            if (Object.keys(updateData).length > 0) {
+              await tx.customer.update({
+                where: { id: customerId },
+                data: updateData,
+              });
+            }
+
+            // 5. WorkInfoの更新/作成/削除
+            if (input.workInfo !== undefined) {
+              const existingWorkInfo = primaryRole?.customer.workInfo;
+
+              if (input.workInfo === null) {
+                // 削除
                 if (existingWorkInfo) {
-                  const updated = await tx.workInfo.update({
+                  await tx.workInfo.delete({
                     where: { id: existingWorkInfo.id },
-                    data: workInfoData,
                   });
-                  await recordEntityUpdated(tx, {
+                  await recordEntityDeleted(tx, {
                     entityType: 'WorkInfo',
                     entityId: existingWorkInfo.id,
                     physicalPlotId,
                     contractPlotId: id as string,
                     beforeRecord: {
+                      id: existingWorkInfo.id,
                       company_name: existingWorkInfo.company_name,
-                      company_name_kana: existingWorkInfo.company_name_kana,
-                      work_postal_code: existingWorkInfo.work_postal_code,
                       work_address: existingWorkInfo.work_address,
                       work_phone_number: existingWorkInfo.work_phone_number,
-                      dm_setting: existingWorkInfo.dm_setting,
-                      address_type: existingWorkInfo.address_type,
-                      notes: existingWorkInfo.notes,
-                    },
-                    afterRecord: {
-                      company_name: updated.company_name,
-                      company_name_kana: updated.company_name_kana,
-                      work_postal_code: updated.work_postal_code,
-                      work_address: updated.work_address,
-                      work_phone_number: updated.work_phone_number,
-                      dm_setting: updated.dm_setting,
-                      address_type: updated.address_type,
-                      notes: updated.notes,
-                    },
-                    req,
-                  });
-                } else {
-                  const created = await tx.workInfo.create({
-                    data: {
-                      customer_id: customerId,
-                      ...workInfoData,
-                    },
-                  });
-                  await recordEntityCreated(tx, {
-                    entityType: 'WorkInfo',
-                    entityId: created.id,
-                    physicalPlotId,
-                    contractPlotId: id as string,
-                    afterRecord: {
-                      id: created.id,
-                      customer_id: customerId,
-                      ...workInfoData,
                     },
                     req,
                   });
                 }
+              } else {
+                // 更新または作成
+                const workInfoData: any = {};
+                if (input.workInfo.companyName !== undefined)
+                  workInfoData.company_name = input.workInfo.companyName;
+                if (input.workInfo.companyNameKana !== undefined)
+                  workInfoData.company_name_kana = input.workInfo.companyNameKana;
+                if (input.workInfo.workPostalCode !== undefined)
+                  workInfoData.work_postal_code = input.workInfo.workPostalCode;
+                if (input.workInfo.workAddress !== undefined)
+                  workInfoData.work_address = input.workInfo.workAddress;
+                if (input.workInfo.workPhoneNumber !== undefined)
+                  workInfoData.work_phone_number = input.workInfo.workPhoneNumber;
+                if (input.workInfo.dmSetting !== undefined)
+                  workInfoData.dm_setting = input.workInfo.dmSetting;
+                if (input.workInfo.addressType !== undefined)
+                  workInfoData.address_type = input.workInfo.addressType;
+                if (input.workInfo.notes !== undefined) workInfoData.notes = input.workInfo.notes;
+
+                if (Object.keys(workInfoData).length > 0) {
+                  if (existingWorkInfo) {
+                    const updated = await tx.workInfo.update({
+                      where: { id: existingWorkInfo.id },
+                      data: workInfoData,
+                    });
+                    await recordEntityUpdated(tx, {
+                      entityType: 'WorkInfo',
+                      entityId: existingWorkInfo.id,
+                      physicalPlotId,
+                      contractPlotId: id as string,
+                      beforeRecord: {
+                        company_name: existingWorkInfo.company_name,
+                        company_name_kana: existingWorkInfo.company_name_kana,
+                        work_postal_code: existingWorkInfo.work_postal_code,
+                        work_address: existingWorkInfo.work_address,
+                        work_phone_number: existingWorkInfo.work_phone_number,
+                        dm_setting: existingWorkInfo.dm_setting,
+                        address_type: existingWorkInfo.address_type,
+                        notes: existingWorkInfo.notes,
+                      },
+                      afterRecord: {
+                        company_name: updated.company_name,
+                        company_name_kana: updated.company_name_kana,
+                        work_postal_code: updated.work_postal_code,
+                        work_address: updated.work_address,
+                        work_phone_number: updated.work_phone_number,
+                        dm_setting: updated.dm_setting,
+                        address_type: updated.address_type,
+                        notes: updated.notes,
+                      },
+                      req,
+                    });
+                  } else {
+                    const created = await tx.workInfo.create({
+                      data: {
+                        customer_id: customerId,
+                        ...workInfoData,
+                      },
+                    });
+                    await recordEntityCreated(tx, {
+                      entityType: 'WorkInfo',
+                      entityId: created.id,
+                      physicalPlotId,
+                      contractPlotId: id as string,
+                      afterRecord: {
+                        id: created.id,
+                        customer_id: customerId,
+                        ...workInfoData,
+                      },
+                      req,
+                    });
+                  }
+                }
               }
             }
-          }
 
-          // 6. BillingInfoの更新/作成/削除
-          if (input.billingInfo !== undefined) {
-            const existingBillingInfo = primaryRole?.customer.billingInfo;
+            // 6. BillingInfoの更新/作成/削除
+            if (input.billingInfo !== undefined) {
+              const existingBillingInfo = primaryRole?.customer.billingInfo;
 
-            if (input.billingInfo === null) {
-              // 削除
-              if (existingBillingInfo) {
-                await tx.billingInfo.delete({
-                  where: { id: existingBillingInfo.id },
-                });
-                await recordEntityDeleted(tx, {
-                  entityType: 'BillingInfo',
-                  entityId: existingBillingInfo.id,
-                  physicalPlotId,
-                  contractPlotId: id as string,
-                  beforeRecord: {
-                    id: existingBillingInfo.id,
-                    billing_type: existingBillingInfo.billing_type,
-                    bank_name: existingBillingInfo.bank_name,
-                    branch_name: existingBillingInfo.branch_name,
-                  },
-                  req,
-                });
-              }
-            } else {
-              // 更新または作成
-              const billingInfoData: any = {};
-              if (input.billingInfo.billingType !== undefined)
-                billingInfoData.billing_type = input.billingInfo.billingType;
-              if (input.billingInfo.bankName !== undefined)
-                billingInfoData.bank_name = input.billingInfo.bankName;
-              if (input.billingInfo.branchName !== undefined)
-                billingInfoData.branch_name = input.billingInfo.branchName;
-              if (input.billingInfo.accountType !== undefined)
-                billingInfoData.account_type = input.billingInfo.accountType;
-              if (input.billingInfo.accountNumber !== undefined)
-                billingInfoData.account_number = input.billingInfo.accountNumber;
-              if (input.billingInfo.accountHolder !== undefined)
-                billingInfoData.account_holder = input.billingInfo.accountHolder;
-
-              if (Object.keys(billingInfoData).length > 0) {
+              if (input.billingInfo === null) {
+                // 削除
                 if (existingBillingInfo) {
-                  const updated = await tx.billingInfo.update({
+                  await tx.billingInfo.delete({
                     where: { id: existingBillingInfo.id },
-                    data: billingInfoData,
                   });
-                  await recordEntityUpdated(tx, {
+                  await recordEntityDeleted(tx, {
                     entityType: 'BillingInfo',
                     entityId: existingBillingInfo.id,
                     physicalPlotId,
                     contractPlotId: id as string,
                     beforeRecord: {
+                      id: existingBillingInfo.id,
                       billing_type: existingBillingInfo.billing_type,
                       bank_name: existingBillingInfo.bank_name,
                       branch_name: existingBillingInfo.branch_name,
-                      account_type: existingBillingInfo.account_type,
-                      account_number: existingBillingInfo.account_number,
-                      account_holder: existingBillingInfo.account_holder,
-                    },
-                    afterRecord: {
-                      billing_type: updated.billing_type,
-                      bank_name: updated.bank_name,
-                      branch_name: updated.branch_name,
-                      account_type: updated.account_type,
-                      account_number: updated.account_number,
-                      account_holder: updated.account_holder,
                     },
                     req,
                   });
-                } else {
-                  const created = await tx.billingInfo.create({
-                    data: {
-                      customer_id: customerId,
-                      ...billingInfoData,
-                    },
-                  });
-                  await recordEntityCreated(tx, {
-                    entityType: 'BillingInfo',
-                    entityId: created.id,
-                    physicalPlotId,
-                    contractPlotId: id as string,
-                    afterRecord: {
-                      id: created.id,
-                      customer_id: customerId,
-                      ...billingInfoData,
-                    },
-                    req,
-                  });
+                }
+              } else {
+                // 更新または作成
+                const billingInfoData: any = {};
+                if (input.billingInfo.billingType !== undefined)
+                  billingInfoData.billing_type = input.billingInfo.billingType;
+                if (input.billingInfo.bankName !== undefined)
+                  billingInfoData.bank_name = input.billingInfo.bankName;
+                if (input.billingInfo.branchName !== undefined)
+                  billingInfoData.branch_name = input.billingInfo.branchName;
+                if (input.billingInfo.accountType !== undefined)
+                  billingInfoData.account_type = input.billingInfo.accountType;
+                if (input.billingInfo.accountNumber !== undefined)
+                  billingInfoData.account_number = input.billingInfo.accountNumber;
+                if (input.billingInfo.accountHolder !== undefined)
+                  billingInfoData.account_holder = input.billingInfo.accountHolder;
+
+                if (Object.keys(billingInfoData).length > 0) {
+                  if (existingBillingInfo) {
+                    const updated = await tx.billingInfo.update({
+                      where: { id: existingBillingInfo.id },
+                      data: billingInfoData,
+                    });
+                    await recordEntityUpdated(tx, {
+                      entityType: 'BillingInfo',
+                      entityId: existingBillingInfo.id,
+                      physicalPlotId,
+                      contractPlotId: id as string,
+                      beforeRecord: {
+                        billing_type: existingBillingInfo.billing_type,
+                        bank_name: existingBillingInfo.bank_name,
+                        branch_name: existingBillingInfo.branch_name,
+                        account_type: existingBillingInfo.account_type,
+                        account_number: existingBillingInfo.account_number,
+                        account_holder: existingBillingInfo.account_holder,
+                      },
+                      afterRecord: {
+                        billing_type: updated.billing_type,
+                        bank_name: updated.bank_name,
+                        branch_name: updated.branch_name,
+                        account_type: updated.account_type,
+                        account_number: updated.account_number,
+                        account_holder: updated.account_holder,
+                      },
+                      req,
+                    });
+                  } else {
+                    const created = await tx.billingInfo.create({
+                      data: {
+                        customer_id: customerId,
+                        ...billingInfoData,
+                      },
+                    });
+                    await recordEntityCreated(tx, {
+                      entityType: 'BillingInfo',
+                      entityId: created.id,
+                      physicalPlotId,
+                      contractPlotId: id as string,
+                      afterRecord: {
+                        id: created.id,
+                        customer_id: customerId,
+                        ...billingInfoData,
+                      },
+                      req,
+                    });
+                  }
                 }
               }
             }
           }
         }
-      }
 
-      // 7. UsageFeeの更新/作成/削除
-      if (input.usageFee !== undefined) {
-        if (input.usageFee === null) {
-          // 削除
-          if (existingContractPlot.usageFee) {
-            const before = existingContractPlot.usageFee;
-            await tx.usageFee.delete({
-              where: { id: before.id },
-            });
-            await recordEntityDeleted(tx, {
-              entityType: 'UsageFee',
-              entityId: before.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                id: before.id,
-                calculation_type: before.calculation_type,
-                tax_type: before.tax_type,
-                usage_fee: before.usage_fee,
-                area: before.area,
-                unit_price: before.unit_price,
-                payment_method: before.payment_method,
-              },
-              req,
-            });
-          }
-        } else {
-          // 更新または作成
-          const usageFeeData: any = {};
-          if (input.usageFee.calculationType !== undefined)
-            usageFeeData.calculation_type = input.usageFee.calculationType;
-          if (input.usageFee.taxType !== undefined) usageFeeData.tax_type = input.usageFee.taxType;
-          if (input.usageFee.usageFee !== undefined)
-            usageFeeData.usage_fee = String(input.usageFee.usageFee ?? '');
-          if (input.usageFee.area !== undefined)
-            usageFeeData.area = String(input.usageFee.area ?? '');
-          if (input.usageFee.unitPrice !== undefined)
-            usageFeeData.unit_price = String(input.usageFee.unitPrice ?? '');
-          if (input.usageFee.paymentMethod !== undefined)
-            usageFeeData.payment_method = input.usageFee.paymentMethod;
-
-          if (Object.keys(usageFeeData).length > 0) {
+        // 7. UsageFeeの更新/作成/削除
+        if (input.usageFee !== undefined) {
+          if (input.usageFee === null) {
+            // 削除
             if (existingContractPlot.usageFee) {
               const before = existingContractPlot.usageFee;
-              const updated = await tx.usageFee.update({
+              await tx.usageFee.delete({
                 where: { id: before.id },
-                data: usageFeeData,
               });
-              await recordEntityUpdated(tx, {
+              await recordEntityDeleted(tx, {
                 entityType: 'UsageFee',
                 entityId: before.id,
                 physicalPlotId,
                 contractPlotId: id as string,
                 beforeRecord: {
+                  id: before.id,
                   calculation_type: before.calculation_type,
                   tax_type: before.tax_type,
                   usage_fee: before.usage_fee,
@@ -570,626 +537,670 @@ export const updatePlot = async (
                   unit_price: before.unit_price,
                   payment_method: before.payment_method,
                 },
-                afterRecord: {
-                  calculation_type: updated.calculation_type,
-                  tax_type: updated.tax_type,
-                  usage_fee: updated.usage_fee,
-                  area: updated.area,
-                  unit_price: updated.unit_price,
-                  payment_method: updated.payment_method,
-                },
-                req,
-              });
-            } else {
-              const created = await tx.usageFee.create({
-                data: {
-                  contract_plot_id: id,
-                  billing_type: 'onetime',
-                  billing_years: '1',
-                  ...usageFeeData,
-                },
-              });
-              await recordEntityCreated(tx, {
-                entityType: 'UsageFee',
-                entityId: created.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                afterRecord: {
-                  id: created.id,
-                  calculation_type: created.calculation_type,
-                  tax_type: created.tax_type,
-                  usage_fee: created.usage_fee,
-                  area: created.area,
-                  unit_price: created.unit_price,
-                  payment_method: created.payment_method,
-                },
                 req,
               });
             }
+          } else {
+            // 更新または作成
+            const usageFeeData: any = {};
+            if (input.usageFee.calculationType !== undefined)
+              usageFeeData.calculation_type = input.usageFee.calculationType;
+            if (input.usageFee.taxType !== undefined)
+              usageFeeData.tax_type = input.usageFee.taxType;
+            if (input.usageFee.usageFee !== undefined)
+              usageFeeData.usage_fee = String(input.usageFee.usageFee ?? '');
+            if (input.usageFee.area !== undefined)
+              usageFeeData.area = String(input.usageFee.area ?? '');
+            if (input.usageFee.unitPrice !== undefined)
+              usageFeeData.unit_price = String(input.usageFee.unitPrice ?? '');
+            if (input.usageFee.paymentMethod !== undefined)
+              usageFeeData.payment_method = input.usageFee.paymentMethod;
+
+            if (Object.keys(usageFeeData).length > 0) {
+              if (existingContractPlot.usageFee) {
+                const before = existingContractPlot.usageFee;
+                const updated = await tx.usageFee.update({
+                  where: { id: before.id },
+                  data: usageFeeData,
+                });
+                await recordEntityUpdated(tx, {
+                  entityType: 'UsageFee',
+                  entityId: before.id,
+                  physicalPlotId,
+                  contractPlotId: id as string,
+                  beforeRecord: {
+                    calculation_type: before.calculation_type,
+                    tax_type: before.tax_type,
+                    usage_fee: before.usage_fee,
+                    area: before.area,
+                    unit_price: before.unit_price,
+                    payment_method: before.payment_method,
+                  },
+                  afterRecord: {
+                    calculation_type: updated.calculation_type,
+                    tax_type: updated.tax_type,
+                    usage_fee: updated.usage_fee,
+                    area: updated.area,
+                    unit_price: updated.unit_price,
+                    payment_method: updated.payment_method,
+                  },
+                  req,
+                });
+              } else {
+                const created = await tx.usageFee.create({
+                  data: {
+                    contract_plot_id: id,
+                    billing_type: 'onetime',
+                    billing_years: '1',
+                    ...usageFeeData,
+                  },
+                });
+                await recordEntityCreated(tx, {
+                  entityType: 'UsageFee',
+                  entityId: created.id,
+                  physicalPlotId,
+                  contractPlotId: id as string,
+                  afterRecord: {
+                    id: created.id,
+                    calculation_type: created.calculation_type,
+                    tax_type: created.tax_type,
+                    usage_fee: created.usage_fee,
+                    area: created.area,
+                    unit_price: created.unit_price,
+                    payment_method: created.payment_method,
+                  },
+                  req,
+                });
+              }
+            }
           }
         }
-      }
 
-      // 8. ManagementFeeの更新/作成/削除
-      if (input.managementFee !== undefined) {
-        if (input.managementFee === null) {
-          // 削除
-          if (existingContractPlot.managementFee) {
-            const before = existingContractPlot.managementFee;
-            await tx.managementFee.delete({
-              where: { id: before.id },
-            });
-            await recordEntityDeleted(tx, {
-              entityType: 'ManagementFee',
-              entityId: before.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                id: before.id,
-                management_fee: before.management_fee,
-                billing_type: before.billing_type,
-                billing_years: before.billing_years,
-              },
-              req,
-            });
-          }
-        } else {
-          // 更新または作成
-          const managementFeeData: any = {};
-          if (input.managementFee.calculationType !== undefined)
-            managementFeeData.calculation_type = input.managementFee.calculationType;
-          if (input.managementFee.taxType !== undefined)
-            managementFeeData.tax_type = input.managementFee.taxType;
-          if (input.managementFee.billingType !== undefined)
-            managementFeeData.billing_type = input.managementFee.billingType;
-          if (input.managementFee.billingYears !== undefined)
-            managementFeeData.billing_years = String(input.managementFee.billingYears ?? '');
-          if (input.managementFee.area !== undefined)
-            managementFeeData.area = String(input.managementFee.area ?? '');
-          if (input.managementFee.billingMonth !== undefined)
-            managementFeeData.billing_month = input.managementFee.billingMonth;
-          if (input.managementFee.managementFee !== undefined)
-            managementFeeData.management_fee = String(input.managementFee.managementFee ?? '');
-          if (input.managementFee.unitPrice !== undefined)
-            managementFeeData.unit_price = String(input.managementFee.unitPrice ?? '');
-          if (input.managementFee.lastBillingMonth !== undefined)
-            managementFeeData.last_billing_month = input.managementFee.lastBillingMonth;
-          if (input.managementFee.paymentMethod !== undefined)
-            managementFeeData.payment_method = input.managementFee.paymentMethod;
-
-          if (Object.keys(managementFeeData).length > 0) {
+        // 8. ManagementFeeの更新/作成/削除
+        if (input.managementFee !== undefined) {
+          if (input.managementFee === null) {
+            // 削除
             if (existingContractPlot.managementFee) {
               const before = existingContractPlot.managementFee;
-              const updated = await tx.managementFee.update({
+              await tx.managementFee.delete({
                 where: { id: before.id },
-                data: managementFeeData,
               });
-              await recordEntityUpdated(tx, {
+              await recordEntityDeleted(tx, {
                 entityType: 'ManagementFee',
                 entityId: before.id,
                 physicalPlotId,
                 contractPlotId: id as string,
                 beforeRecord: {
-                  calculation_type: before.calculation_type,
-                  tax_type: before.tax_type,
+                  id: before.id,
+                  management_fee: before.management_fee,
                   billing_type: before.billing_type,
                   billing_years: before.billing_years,
-                  area: before.area,
-                  billing_month: before.billing_month,
-                  management_fee: before.management_fee,
-                  unit_price: before.unit_price,
-                  last_billing_month: before.last_billing_month,
-                  payment_method: before.payment_method,
-                },
-                afterRecord: {
-                  calculation_type: updated.calculation_type,
-                  tax_type: updated.tax_type,
-                  billing_type: updated.billing_type,
-                  billing_years: updated.billing_years,
-                  area: updated.area,
-                  billing_month: updated.billing_month,
-                  management_fee: updated.management_fee,
-                  unit_price: updated.unit_price,
-                  last_billing_month: updated.last_billing_month,
-                  payment_method: updated.payment_method,
-                },
-                req,
-              });
-            } else {
-              const created = await tx.managementFee.create({
-                data: {
-                  contract_plot_id: id,
-                  ...managementFeeData,
-                },
-              });
-              await recordEntityCreated(tx, {
-                entityType: 'ManagementFee',
-                entityId: created.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                afterRecord: {
-                  id: created.id,
-                  ...managementFeeData,
                 },
                 req,
               });
             }
+          } else {
+            // 更新または作成
+            const managementFeeData: any = {};
+            if (input.managementFee.calculationType !== undefined)
+              managementFeeData.calculation_type = input.managementFee.calculationType;
+            if (input.managementFee.taxType !== undefined)
+              managementFeeData.tax_type = input.managementFee.taxType;
+            if (input.managementFee.billingType !== undefined)
+              managementFeeData.billing_type = input.managementFee.billingType;
+            if (input.managementFee.billingYears !== undefined)
+              managementFeeData.billing_years = String(input.managementFee.billingYears ?? '');
+            if (input.managementFee.area !== undefined)
+              managementFeeData.area = String(input.managementFee.area ?? '');
+            if (input.managementFee.billingMonth !== undefined)
+              managementFeeData.billing_month = input.managementFee.billingMonth;
+            if (input.managementFee.managementFee !== undefined)
+              managementFeeData.management_fee = String(input.managementFee.managementFee ?? '');
+            if (input.managementFee.unitPrice !== undefined)
+              managementFeeData.unit_price = String(input.managementFee.unitPrice ?? '');
+            if (input.managementFee.lastBillingMonth !== undefined)
+              managementFeeData.last_billing_month = input.managementFee.lastBillingMonth;
+            if (input.managementFee.paymentMethod !== undefined)
+              managementFeeData.payment_method = input.managementFee.paymentMethod;
+
+            if (Object.keys(managementFeeData).length > 0) {
+              if (existingContractPlot.managementFee) {
+                const before = existingContractPlot.managementFee;
+                const updated = await tx.managementFee.update({
+                  where: { id: before.id },
+                  data: managementFeeData,
+                });
+                await recordEntityUpdated(tx, {
+                  entityType: 'ManagementFee',
+                  entityId: before.id,
+                  physicalPlotId,
+                  contractPlotId: id as string,
+                  beforeRecord: {
+                    calculation_type: before.calculation_type,
+                    tax_type: before.tax_type,
+                    billing_type: before.billing_type,
+                    billing_years: before.billing_years,
+                    area: before.area,
+                    billing_month: before.billing_month,
+                    management_fee: before.management_fee,
+                    unit_price: before.unit_price,
+                    last_billing_month: before.last_billing_month,
+                    payment_method: before.payment_method,
+                  },
+                  afterRecord: {
+                    calculation_type: updated.calculation_type,
+                    tax_type: updated.tax_type,
+                    billing_type: updated.billing_type,
+                    billing_years: updated.billing_years,
+                    area: updated.area,
+                    billing_month: updated.billing_month,
+                    management_fee: updated.management_fee,
+                    unit_price: updated.unit_price,
+                    last_billing_month: updated.last_billing_month,
+                    payment_method: updated.payment_method,
+                  },
+                  req,
+                });
+              } else {
+                const created = await tx.managementFee.create({
+                  data: {
+                    contract_plot_id: id,
+                    ...managementFeeData,
+                  },
+                });
+                await recordEntityCreated(tx, {
+                  entityType: 'ManagementFee',
+                  entityId: created.id,
+                  physicalPlotId,
+                  contractPlotId: id as string,
+                  afterRecord: {
+                    id: created.id,
+                    ...managementFeeData,
+                  },
+                  req,
+                });
+              }
+            }
           }
         }
-      }
 
-      // 9. CollectiveBurialの更新/作成/削除
-      if (input.collectiveBurial !== undefined) {
-        const existingCB = existingContractPlot.collectiveBurial;
+        // 9. CollectiveBurialの更新/作成/削除
+        if (input.collectiveBurial !== undefined) {
+          const existingCB = existingContractPlot.collectiveBurial;
 
-        if (input.collectiveBurial === null) {
-          // 合祀設定を解除: ContractPlotのフィールドをnullに、CBレコードを論理削除
-          await tx.contractPlot.update({
-            where: { id },
-            data: {
-              burial_capacity: null,
-              validity_period_years: null,
-            },
-          });
-          if (existingCB && !existingCB.deleted_at) {
-            await tx.collectiveBurial.update({
-              where: { id: existingCB.id },
-              data: { deleted_at: new Date() },
-            });
-            await recordEntityDeleted(tx, {
-              entityType: 'CollectiveBurial',
-              entityId: existingCB.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                id: existingCB.id,
-                burial_capacity: existingCB.burial_capacity,
-                validity_period_years: existingCB.validity_period_years,
-                billing_amount: existingCB.billing_amount,
-                notes: existingCB.notes,
+          if (input.collectiveBurial === null) {
+            // 合祀設定を解除: ContractPlotのフィールドをnullに、CBレコードを論理削除
+            await tx.contractPlot.update({
+              where: { id },
+              data: {
+                burial_capacity: null,
+                validity_period_years: null,
               },
-              req,
             });
-          }
-        } else {
-          // 合祀設定を更新/作成: ContractPlotのフィールドを更新
-          await tx.contractPlot.update({
-            where: { id },
-            data: {
-              burial_capacity: input.collectiveBurial.burialCapacity,
-              validity_period_years: input.collectiveBurial.validityPeriodYears,
-            },
-          });
-
-          if (existingCB && !existingCB.deleted_at) {
-            // 既存CBを更新
-            const updated = await tx.collectiveBurial.update({
-              where: { id: existingCB.id },
+            if (existingCB && !existingCB.deleted_at) {
+              await tx.collectiveBurial.update({
+                where: { id: existingCB.id },
+                data: { deleted_at: new Date() },
+              });
+              await recordEntityDeleted(tx, {
+                entityType: 'CollectiveBurial',
+                entityId: existingCB.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                beforeRecord: {
+                  id: existingCB.id,
+                  burial_capacity: existingCB.burial_capacity,
+                  validity_period_years: existingCB.validity_period_years,
+                  billing_amount: existingCB.billing_amount,
+                  notes: existingCB.notes,
+                },
+                req,
+              });
+            }
+          } else {
+            // 合祀設定を更新/作成: ContractPlotのフィールドを更新
+            await tx.contractPlot.update({
+              where: { id },
               data: {
                 burial_capacity: input.collectiveBurial.burialCapacity,
                 validity_period_years: input.collectiveBurial.validityPeriodYears,
-                billing_amount: input.collectiveBurial.billingAmount ?? existingCB.billing_amount,
-                notes:
-                  input.collectiveBurial.notes !== undefined
-                    ? input.collectiveBurial.notes || null
-                    : existingCB.notes,
               },
             });
-            await recordEntityUpdated(tx, {
-              entityType: 'CollectiveBurial',
-              entityId: existingCB.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                burial_capacity: existingCB.burial_capacity,
-                validity_period_years: existingCB.validity_period_years,
-                billing_amount: existingCB.billing_amount,
-                notes: existingCB.notes,
-              },
-              afterRecord: {
-                burial_capacity: updated.burial_capacity,
-                validity_period_years: updated.validity_period_years,
-                billing_amount: updated.billing_amount,
-                notes: updated.notes,
-              },
-              req,
-            });
-          } else {
-            // 新規CB作成（論理削除済みの場合も復活）
-            const cbCapacity = input.collectiveBurial.burialCapacity;
-            const cbPeriod = input.collectiveBurial.validityPeriodYears;
-            if (!cbCapacity || !cbPeriod) {
-              throw new ValidationError(
-                '新規合祀設定には burialCapacity と validityPeriodYears が必須です'
-              );
-            }
 
-            let cbCreated: { id: string };
-            if (existingCB?.deleted_at) {
-              cbCreated = await tx.collectiveBurial.update({
+            if (existingCB && !existingCB.deleted_at) {
+              // 既存CBを更新
+              const updated = await tx.collectiveBurial.update({
                 where: { id: existingCB.id },
                 data: {
-                  burial_capacity: cbCapacity,
-                  validity_period_years: cbPeriod,
-                  billing_amount: input.collectiveBurial.billingAmount ?? null,
-                  notes: input.collectiveBurial.notes || null,
-                  deleted_at: null,
+                  burial_capacity: input.collectiveBurial.burialCapacity,
+                  validity_period_years: input.collectiveBurial.validityPeriodYears,
+                  billing_amount: input.collectiveBurial.billingAmount ?? existingCB.billing_amount,
+                  notes:
+                    input.collectiveBurial.notes !== undefined
+                      ? input.collectiveBurial.notes || null
+                      : existingCB.notes,
                 },
+              });
+              await recordEntityUpdated(tx, {
+                entityType: 'CollectiveBurial',
+                entityId: existingCB.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                beforeRecord: {
+                  burial_capacity: existingCB.burial_capacity,
+                  validity_period_years: existingCB.validity_period_years,
+                  billing_amount: existingCB.billing_amount,
+                  notes: existingCB.notes,
+                },
+                afterRecord: {
+                  burial_capacity: updated.burial_capacity,
+                  validity_period_years: updated.validity_period_years,
+                  billing_amount: updated.billing_amount,
+                  notes: updated.notes,
+                },
+                req,
               });
             } else {
-              cbCreated = await tx.collectiveBurial.create({
-                data: {
-                  contract_plot_id: id as string,
+              // 新規CB作成（論理削除済みの場合も復活）
+              const cbCapacity = input.collectiveBurial.burialCapacity;
+              const cbPeriod = input.collectiveBurial.validityPeriodYears;
+              if (!cbCapacity || !cbPeriod) {
+                throw new ValidationError(
+                  '新規合祀設定には burialCapacity と validityPeriodYears が必須です'
+                );
+              }
+
+              let cbCreated: { id: string };
+              if (existingCB?.deleted_at) {
+                cbCreated = await tx.collectiveBurial.update({
+                  where: { id: existingCB.id },
+                  data: {
+                    burial_capacity: cbCapacity,
+                    validity_period_years: cbPeriod,
+                    billing_amount: input.collectiveBurial.billingAmount ?? null,
+                    notes: input.collectiveBurial.notes || null,
+                    deleted_at: null,
+                  },
+                });
+              } else {
+                cbCreated = await tx.collectiveBurial.create({
+                  data: {
+                    contract_plot_id: id as string,
+                    burial_capacity: cbCapacity,
+                    validity_period_years: cbPeriod,
+                    billing_amount: input.collectiveBurial.billingAmount ?? null,
+                    notes: input.collectiveBurial.notes || null,
+                  },
+                });
+              }
+              await recordEntityCreated(tx, {
+                entityType: 'CollectiveBurial',
+                entityId: cbCreated.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                afterRecord: {
+                  id: cbCreated.id,
                   burial_capacity: cbCapacity,
                   validity_period_years: cbPeriod,
                   billing_amount: input.collectiveBurial.billingAmount ?? null,
                   notes: input.collectiveBurial.notes || null,
                 },
+                req,
               });
             }
-            await recordEntityCreated(tx, {
-              entityType: 'CollectiveBurial',
-              entityId: cbCreated.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              afterRecord: {
-                id: cbCreated.id,
-                burial_capacity: cbCapacity,
-                validity_period_years: cbPeriod,
-                billing_amount: input.collectiveBurial.billingAmount ?? null,
-                notes: input.collectiveBurial.notes || null,
-              },
-              req,
-            });
           }
         }
-      }
 
-      // 10. 埋葬者の全置換（送信された配列で既存を置き換え）
-      if (input.buriedPersons !== undefined) {
-        // 既存の埋葬者を取得
-        const existingBuriedPersons = await tx.buriedPerson.findMany({
-          where: { contract_plot_id: id, deleted_at: null },
-        });
-        const existingIds = existingBuriedPersons.map((bp) => bp.id);
-        const existingMap = new Map(existingBuriedPersons.map((bp) => [bp.id, bp]));
-        const inputIds = input.buriedPersons.filter((bp) => bp.id).map((bp) => bp.id as string);
-
-        // 送信されなかったIDは論理削除
-        const idsToDelete = existingIds.filter((eid) => !inputIds.includes(eid));
-        if (idsToDelete.length > 0) {
-          await tx.buriedPerson.updateMany({
-            where: { id: { in: idsToDelete } },
-            data: { deleted_at: new Date() },
+        // 10. 埋葬者の全置換（送信された配列で既存を置き換え）
+        if (input.buriedPersons !== undefined) {
+          // 既存の埋葬者を取得
+          const existingBuriedPersons = await tx.buriedPerson.findMany({
+            where: { contract_plot_id: id, deleted_at: null },
           });
-          for (const delId of idsToDelete) {
-            const before = existingMap.get(delId)!;
-            await recordEntityDeleted(tx, {
-              entityType: 'BuriedPerson',
-              entityId: delId,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                id: before.id,
-                name: before.name,
-                death_date: before.death_date?.toISOString() ?? null,
-                burial_date: before.burial_date?.toISOString() ?? null,
-              },
-              req,
+          const existingIds = existingBuriedPersons.map((bp) => bp.id);
+          const existingMap = new Map(existingBuriedPersons.map((bp) => [bp.id, bp]));
+          const inputIds = input.buriedPersons.filter((bp) => bp.id).map((bp) => bp.id as string);
+
+          // 送信されなかったIDは論理削除
+          const idsToDelete = existingIds.filter((eid) => !inputIds.includes(eid));
+          if (idsToDelete.length > 0) {
+            await tx.buriedPerson.updateMany({
+              where: { id: { in: idsToDelete } },
+              data: { deleted_at: new Date() },
             });
-          }
-        }
-
-        // 各レコードを作成/更新
-        for (const bp of input.buriedPersons) {
-          const bpData = {
-            name: bp.name,
-            name_kana: bp.nameKana || null,
-            relationship: bp.relationship || null,
-            birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
-            death_date: bp.deathDate ? new Date(bp.deathDate) : null,
-            age: bp.age ?? null,
-            gender: bp.gender || null,
-            burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
-            posthumous_name: bp.posthumousName || null,
-            report_date: bp.reportDate ? new Date(bp.reportDate) : null,
-            religion: bp.religion || null,
-            notes: bp.notes || null,
-          };
-
-          // 履歴用のシリアライズ可能な before/after
-          const serialize = (data: typeof bpData) => ({
-            name: data.name,
-            name_kana: data.name_kana,
-            relationship: data.relationship,
-            birth_date: data.birth_date?.toISOString() ?? null,
-            death_date: data.death_date?.toISOString() ?? null,
-            age: data.age,
-            gender: data.gender,
-            burial_date: data.burial_date?.toISOString() ?? null,
-            posthumous_name: data.posthumous_name,
-            report_date: data.report_date?.toISOString() ?? null,
-            religion: data.religion,
-            notes: data.notes,
-          });
-
-          if (bp.id && existingIds.includes(bp.id)) {
-            // 既存レコードを更新
-            const before = existingMap.get(bp.id)!;
-            await tx.buriedPerson.update({
-              where: { id: bp.id },
-              data: bpData,
-            });
-            await recordEntityUpdated(tx, {
-              entityType: 'BuriedPerson',
-              entityId: bp.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                name: before.name,
-                name_kana: before.name_kana,
-                relationship: before.relationship,
-                birth_date: before.birth_date?.toISOString() ?? null,
-                death_date: before.death_date?.toISOString() ?? null,
-                age: before.age,
-                gender: before.gender,
-                burial_date: before.burial_date?.toISOString() ?? null,
-                posthumous_name: before.posthumous_name,
-                report_date: before.report_date?.toISOString() ?? null,
-                religion: before.religion,
-                notes: before.notes,
-              },
-              afterRecord: serialize(bpData),
-              req,
-            });
-          } else {
-            // 新規作成
-            const created = await tx.buriedPerson.create({
-              data: {
-                contract_plot_id: id as string,
-                ...bpData,
-              },
-            });
-            await recordEntityCreated(tx, {
-              entityType: 'BuriedPerson',
-              entityId: created.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              afterRecord: { id: created.id, ...serialize(bpData) },
-              req,
-            });
-          }
-        }
-
-        // 合祀自動チェック: burial_capacityが設定されている場合、埋葬数を同期
-        const contractPlotForCB = await tx.contractPlot.findUnique({
-          where: { id },
-          select: { burial_capacity: true },
-        });
-        if (contractPlotForCB?.burial_capacity) {
-          await updateCollectiveBurialCount(tx, id as string);
-        }
-      }
-
-      // 11. 工事情報の全置換（送信された配列で既存を置き換え）
-      if (input.constructionInfos !== undefined) {
-        const existingConstructionInfos = await tx.constructionInfo.findMany({
-          where: { contract_plot_id: id, deleted_at: null },
-        });
-        const existingCiIds = existingConstructionInfos.map((ci) => ci.id);
-        const existingCiMap = new Map(existingConstructionInfos.map((ci) => [ci.id, ci]));
-        const inputCiIds = input.constructionInfos
-          .filter((ci) => ci.id)
-          .map((ci) => ci.id as string);
-
-        // 送信されなかったIDは論理削除
-        const ciIdsToDelete = existingCiIds.filter((eid) => !inputCiIds.includes(eid));
-        if (ciIdsToDelete.length > 0) {
-          await tx.constructionInfo.updateMany({
-            where: { id: { in: ciIdsToDelete } },
-            data: { deleted_at: new Date() },
-          });
-          for (const delId of ciIdsToDelete) {
-            const before = existingCiMap.get(delId)!;
-            await recordEntityDeleted(tx, {
-              entityType: 'ConstructionInfo',
-              entityId: delId,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                id: before.id,
-                construction_type: before.construction_type,
-                contractor: before.contractor,
-                start_date: before.start_date?.toISOString() ?? null,
-                completion_date: before.completion_date?.toISOString() ?? null,
-              },
-              req,
-            });
-          }
-        }
-
-        // 各レコードを作成/更新
-        for (const ci of input.constructionInfos) {
-          const ciData = {
-            construction_type: ci.constructionType || null,
-            start_date: ci.startDate ? new Date(ci.startDate) : null,
-            completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
-            contractor: ci.contractor || null,
-            supervisor: ci.supervisor || null,
-            progress: ci.progress || null,
-            work_item_1: ci.workItem1 || null,
-            work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
-            work_amount_1: ci.workAmount1 ?? null,
-            work_status_1: ci.workStatus1 || null,
-            work_item_2: ci.workItem2 || null,
-            work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
-            work_amount_2: ci.workAmount2 ?? null,
-            work_status_2: ci.workStatus2 || null,
-            permit_number: ci.permitNumber || null,
-            application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
-            permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
-            permit_status: ci.permitStatus || null,
-            payment_type_1: ci.paymentType1 || null,
-            payment_amount_1: ci.paymentAmount1 ?? null,
-            payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
-            payment_status_1: ci.paymentStatus1 || null,
-            payment_type_2: ci.paymentType2 || null,
-            payment_amount_2: ci.paymentAmount2 ?? null,
-            payment_date_2: ci.paymentScheduledDate2 ? new Date(ci.paymentScheduledDate2) : null,
-            payment_status_2: ci.paymentStatus2 || null,
-            scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
-            construction_content: ci.constructionContent || null,
-            notes: ci.notes || null,
-          };
-
-          // 履歴用にDate→ISOへシリアライズ
-          const serializeCi = (data: typeof ciData) => {
-            const result: Record<string, unknown> = {};
-            for (const [k, v] of Object.entries(data)) {
-              result[k] = v instanceof Date ? v.toISOString() : v;
+            for (const delId of idsToDelete) {
+              const before = existingMap.get(delId)!;
+              await recordEntityDeleted(tx, {
+                entityType: 'BuriedPerson',
+                entityId: delId,
+                physicalPlotId,
+                contractPlotId: id as string,
+                beforeRecord: {
+                  id: before.id,
+                  name: before.name,
+                  death_date: before.death_date?.toISOString() ?? null,
+                  burial_date: before.burial_date?.toISOString() ?? null,
+                },
+                req,
+              });
             }
-            return result;
-          };
+          }
 
-          if (ci.id && existingCiIds.includes(ci.id)) {
-            const before = existingCiMap.get(ci.id)!;
-            await tx.constructionInfo.update({
-              where: { id: ci.id },
-              data: ciData,
+          // 各レコードを作成/更新
+          for (const bp of input.buriedPersons) {
+            const bpData = {
+              name: bp.name,
+              name_kana: bp.nameKana || null,
+              relationship: bp.relationship || null,
+              birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
+              death_date: bp.deathDate ? new Date(bp.deathDate) : null,
+              age: bp.age ?? null,
+              gender: bp.gender || null,
+              burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
+              posthumous_name: bp.posthumousName || null,
+              report_date: bp.reportDate ? new Date(bp.reportDate) : null,
+              religion: bp.religion || null,
+              notes: bp.notes || null,
+            };
+
+            // 履歴用のシリアライズ可能な before/after
+            const serialize = (data: typeof bpData) => ({
+              name: data.name,
+              name_kana: data.name_kana,
+              relationship: data.relationship,
+              birth_date: data.birth_date?.toISOString() ?? null,
+              death_date: data.death_date?.toISOString() ?? null,
+              age: data.age,
+              gender: data.gender,
+              burial_date: data.burial_date?.toISOString() ?? null,
+              posthumous_name: data.posthumous_name,
+              report_date: data.report_date?.toISOString() ?? null,
+              religion: data.religion,
+              notes: data.notes,
             });
-            // beforeをciDataと同じ形にシリアライズ
-            const beforeSerialized: Record<string, unknown> = {};
-            for (const key of Object.keys(ciData)) {
-              const v = (before as any)[key];
-              beforeSerialized[key] = v instanceof Date ? v.toISOString() : v;
+
+            if (bp.id && existingIds.includes(bp.id)) {
+              // 既存レコードを更新
+              const before = existingMap.get(bp.id)!;
+              await tx.buriedPerson.update({
+                where: { id: bp.id },
+                data: bpData,
+              });
+              await recordEntityUpdated(tx, {
+                entityType: 'BuriedPerson',
+                entityId: bp.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                beforeRecord: {
+                  name: before.name,
+                  name_kana: before.name_kana,
+                  relationship: before.relationship,
+                  birth_date: before.birth_date?.toISOString() ?? null,
+                  death_date: before.death_date?.toISOString() ?? null,
+                  age: before.age,
+                  gender: before.gender,
+                  burial_date: before.burial_date?.toISOString() ?? null,
+                  posthumous_name: before.posthumous_name,
+                  report_date: before.report_date?.toISOString() ?? null,
+                  religion: before.religion,
+                  notes: before.notes,
+                },
+                afterRecord: serialize(bpData),
+                req,
+              });
+            } else {
+              // 新規作成
+              const created = await tx.buriedPerson.create({
+                data: {
+                  contract_plot_id: id as string,
+                  ...bpData,
+                },
+              });
+              await recordEntityCreated(tx, {
+                entityType: 'BuriedPerson',
+                entityId: created.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                afterRecord: { id: created.id, ...serialize(bpData) },
+                req,
+              });
             }
-            await recordEntityUpdated(tx, {
-              entityType: 'ConstructionInfo',
-              entityId: ci.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: beforeSerialized,
-              afterRecord: serializeCi(ciData),
-              req,
-            });
-          } else {
-            const created = await tx.constructionInfo.create({
-              data: {
-                contract_plot_id: id as string,
-                ...ciData,
-              },
-            });
-            await recordEntityCreated(tx, {
-              entityType: 'ConstructionInfo',
-              entityId: created.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              afterRecord: { id: created.id, ...serializeCi(ciData) },
-              req,
-            });
+          }
+
+          // 合祀自動チェック: burial_capacityが設定されている場合、埋葬数を同期
+          const contractPlotForCB = await tx.contractPlot.findUnique({
+            where: { id },
+            select: { burial_capacity: true },
+          });
+          if (contractPlotForCB?.burial_capacity) {
+            await updateCollectiveBurialCount(tx, id as string);
           }
         }
-      }
 
-      // 12. 契約面積が変更された場合、物理区画のステータス更新
-      if (
-        input.contractPlot?.contractAreaSqm !== undefined &&
-        input.contractPlot.contractAreaSqm !== oldContractArea
-      ) {
-        await updatePhysicalPlotStatus(tx as any, physicalPlotId);
-      }
-
-      // 10. 履歴の自動記録
-      // ContractPlotの更新履歴
-      if (Object.keys(updateData).length > 0) {
-        const beforeContractPlotData = {
-          contract_area_sqm: existingContractPlot.contract_area_sqm.toString(),
-          location_description: existingContractPlot.location_description,
-          contract_date: existingContractPlot.contract_date?.toISOString(),
-          price: existingContractPlot.price,
-          payment_status: existingContractPlot.payment_status,
-          reservation_date: existingContractPlot.reservation_date?.toISOString(),
-          acceptance_number: existingContractPlot.acceptance_number,
-          permit_date: existingContractPlot.permit_date?.toISOString(),
-          start_date: existingContractPlot.start_date?.toISOString(),
-          uncollected_amount: existingContractPlot.uncollected_amount,
-          notes: existingContractPlot.notes,
-        };
-
-        const updatedCp = await tx.contractPlot.findUnique({ where: { id } });
-        const afterContractPlotData = updatedCp
-          ? {
-              contract_area_sqm: updatedCp.contract_area_sqm.toString(),
-              location_description: updatedCp.location_description,
-              contract_date: updatedCp.contract_date?.toISOString(),
-              price: updatedCp.price,
-              payment_status: updatedCp.payment_status,
-              reservation_date: updatedCp.reservation_date?.toISOString(),
-              acceptance_number: updatedCp.acceptance_number,
-              permit_date: updatedCp.permit_date?.toISOString(),
-              start_date: updatedCp.start_date?.toISOString(),
-              uncollected_amount: updatedCp.uncollected_amount,
-              notes: updatedCp.notes,
-            }
-          : beforeContractPlotData;
-
-        await recordContractPlotUpdated(
-          tx,
-          beforeContractPlotData,
-          afterContractPlotData,
-          physicalPlotId,
-          id as string,
-          req
-        );
-      }
-
-      // Customerの更新履歴
-      if (input.customer) {
-        const primaryRole = existingContractPlot.saleContractRoles?.find(
-          (role: any) => role.role === 'contractor'
-        );
-        const existingCustomer = primaryRole?.customer;
-
-        if (existingCustomer) {
-          const beforeCustomerData = {
-            name: existingCustomer.name,
-            name_kana: existingCustomer.name_kana,
-            birth_date: existingCustomer.birth_date?.toISOString(),
-            gender: existingCustomer.gender,
-            postal_code: existingCustomer.postal_code,
-            address: existingCustomer.address,
-            phone_number: existingCustomer.phone_number,
-            email: existingCustomer.email,
-          };
-
-          const updatedCustomer = await tx.customer.findUnique({
-            where: { id: existingCustomer.id },
+        // 11. 工事情報の全置換（送信された配列で既存を置き換え）
+        if (input.constructionInfos !== undefined) {
+          const existingConstructionInfos = await tx.constructionInfo.findMany({
+            where: { contract_plot_id: id, deleted_at: null },
           });
-          const afterCustomerData = updatedCustomer
-            ? {
-                name: updatedCustomer.name,
-                name_kana: updatedCustomer.name_kana,
-                birth_date: updatedCustomer.birth_date?.toISOString(),
-                gender: updatedCustomer.gender,
-                postal_code: updatedCustomer.postal_code,
-                address: updatedCustomer.address,
-                phone_number: updatedCustomer.phone_number,
-                email: updatedCustomer.email,
+          const existingCiIds = existingConstructionInfos.map((ci) => ci.id);
+          const existingCiMap = new Map(existingConstructionInfos.map((ci) => [ci.id, ci]));
+          const inputCiIds = input.constructionInfos
+            .filter((ci) => ci.id)
+            .map((ci) => ci.id as string);
+
+          // 送信されなかったIDは論理削除
+          const ciIdsToDelete = existingCiIds.filter((eid) => !inputCiIds.includes(eid));
+          if (ciIdsToDelete.length > 0) {
+            await tx.constructionInfo.updateMany({
+              where: { id: { in: ciIdsToDelete } },
+              data: { deleted_at: new Date() },
+            });
+            for (const delId of ciIdsToDelete) {
+              const before = existingCiMap.get(delId)!;
+              await recordEntityDeleted(tx, {
+                entityType: 'ConstructionInfo',
+                entityId: delId,
+                physicalPlotId,
+                contractPlotId: id as string,
+                beforeRecord: {
+                  id: before.id,
+                  construction_type: before.construction_type,
+                  contractor: before.contractor,
+                  start_date: before.start_date?.toISOString() ?? null,
+                  completion_date: before.completion_date?.toISOString() ?? null,
+                },
+                req,
+              });
+            }
+          }
+
+          // 各レコードを作成/更新
+          for (const ci of input.constructionInfos) {
+            const ciData = {
+              construction_type: ci.constructionType || null,
+              start_date: ci.startDate ? new Date(ci.startDate) : null,
+              completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
+              contractor: ci.contractor || null,
+              supervisor: ci.supervisor || null,
+              progress: ci.progress || null,
+              work_item_1: ci.workItem1 || null,
+              work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
+              work_amount_1: ci.workAmount1 ?? null,
+              work_status_1: ci.workStatus1 || null,
+              work_item_2: ci.workItem2 || null,
+              work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
+              work_amount_2: ci.workAmount2 ?? null,
+              work_status_2: ci.workStatus2 || null,
+              permit_number: ci.permitNumber || null,
+              application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
+              permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
+              permit_status: ci.permitStatus || null,
+              payment_type_1: ci.paymentType1 || null,
+              payment_amount_1: ci.paymentAmount1 ?? null,
+              payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
+              payment_status_1: ci.paymentStatus1 || null,
+              payment_type_2: ci.paymentType2 || null,
+              payment_amount_2: ci.paymentAmount2 ?? null,
+              payment_date_2: ci.paymentScheduledDate2 ? new Date(ci.paymentScheduledDate2) : null,
+              payment_status_2: ci.paymentStatus2 || null,
+              scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
+              construction_content: ci.constructionContent || null,
+              notes: ci.notes || null,
+            };
+
+            // 履歴用にDate→ISOへシリアライズ
+            const serializeCi = (data: typeof ciData) => {
+              const result: Record<string, unknown> = {};
+              for (const [k, v] of Object.entries(data)) {
+                result[k] = v instanceof Date ? v.toISOString() : v;
               }
-            : beforeCustomerData;
+              return result;
+            };
 
-          await recordCustomerUpdated(
+            if (ci.id && existingCiIds.includes(ci.id)) {
+              const before = existingCiMap.get(ci.id)!;
+              await tx.constructionInfo.update({
+                where: { id: ci.id },
+                data: ciData,
+              });
+              // beforeをciDataと同じ形にシリアライズ
+              const beforeSerialized: Record<string, unknown> = {};
+              for (const key of Object.keys(ciData)) {
+                const v = (before as any)[key];
+                beforeSerialized[key] = v instanceof Date ? v.toISOString() : v;
+              }
+              await recordEntityUpdated(tx, {
+                entityType: 'ConstructionInfo',
+                entityId: ci.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                beforeRecord: beforeSerialized,
+                afterRecord: serializeCi(ciData),
+                req,
+              });
+            } else {
+              const created = await tx.constructionInfo.create({
+                data: {
+                  contract_plot_id: id as string,
+                  ...ciData,
+                },
+              });
+              await recordEntityCreated(tx, {
+                entityType: 'ConstructionInfo',
+                entityId: created.id,
+                physicalPlotId,
+                contractPlotId: id as string,
+                afterRecord: { id: created.id, ...serializeCi(ciData) },
+                req,
+              });
+            }
+          }
+        }
+
+        // 12. 契約面積が変更された場合、物理区画のステータス更新
+        if (
+          input.contractPlot?.contractAreaSqm !== undefined &&
+          input.contractPlot.contractAreaSqm !== oldContractArea
+        ) {
+          await updatePhysicalPlotStatus(tx as any, physicalPlotId);
+        }
+
+        // 10. 履歴の自動記録
+        // ContractPlotの更新履歴
+        if (Object.keys(updateData).length > 0) {
+          const beforeContractPlotData = {
+            contract_area_sqm: existingContractPlot.contract_area_sqm.toString(),
+            location_description: existingContractPlot.location_description,
+            contract_date: existingContractPlot.contract_date?.toISOString(),
+            price: existingContractPlot.price,
+            payment_status: existingContractPlot.payment_status,
+            reservation_date: existingContractPlot.reservation_date?.toISOString(),
+            acceptance_number: existingContractPlot.acceptance_number,
+            permit_date: existingContractPlot.permit_date?.toISOString(),
+            start_date: existingContractPlot.start_date?.toISOString(),
+            uncollected_amount: existingContractPlot.uncollected_amount,
+            notes: existingContractPlot.notes,
+          };
+
+          const updatedCp = await tx.contractPlot.findUnique({ where: { id } });
+          const afterContractPlotData = updatedCp
+            ? {
+                contract_area_sqm: updatedCp.contract_area_sqm.toString(),
+                location_description: updatedCp.location_description,
+                contract_date: updatedCp.contract_date?.toISOString(),
+                price: updatedCp.price,
+                payment_status: updatedCp.payment_status,
+                reservation_date: updatedCp.reservation_date?.toISOString(),
+                acceptance_number: updatedCp.acceptance_number,
+                permit_date: updatedCp.permit_date?.toISOString(),
+                start_date: updatedCp.start_date?.toISOString(),
+                uncollected_amount: updatedCp.uncollected_amount,
+                notes: updatedCp.notes,
+              }
+            : beforeContractPlotData;
+
+          await recordContractPlotUpdated(
             tx,
-            beforeCustomerData,
-            afterCustomerData,
-            existingCustomer.id,
-            id as string,
+            beforeContractPlotData,
+            afterContractPlotData,
             physicalPlotId,
+            id as string,
             req
           );
         }
+
+        // Customerの更新履歴
+        if (input.customer) {
+          const primaryRole = existingContractPlot.saleContractRoles?.find(
+            (role: any) => role.role === 'contractor'
+          );
+          const existingCustomer = primaryRole?.customer;
+
+          if (existingCustomer) {
+            const beforeCustomerData = {
+              name: existingCustomer.name,
+              name_kana: existingCustomer.name_kana,
+              birth_date: existingCustomer.birth_date?.toISOString(),
+              gender: existingCustomer.gender,
+              postal_code: existingCustomer.postal_code,
+              address: existingCustomer.address,
+              phone_number: existingCustomer.phone_number,
+              email: existingCustomer.email,
+            };
+
+            const updatedCustomer = await tx.customer.findUnique({
+              where: { id: existingCustomer.id },
+            });
+            const afterCustomerData = updatedCustomer
+              ? {
+                  name: updatedCustomer.name,
+                  name_kana: updatedCustomer.name_kana,
+                  birth_date: updatedCustomer.birth_date?.toISOString(),
+                  gender: updatedCustomer.gender,
+                  postal_code: updatedCustomer.postal_code,
+                  address: updatedCustomer.address,
+                  phone_number: updatedCustomer.phone_number,
+                  email: updatedCustomer.email,
+                }
+              : beforeCustomerData;
+
+            await recordCustomerUpdated(
+              tx,
+              beforeCustomerData,
+              afterCustomerData,
+              existingCustomer.id,
+              id as string,
+              physicalPlotId,
+              req
+            );
+          }
+        }
+      },
+      {
+        maxWait: 10000, // ロック取得待機の上限 10 秒
+        timeout: 30000, // トランザクション全体の上限 30 秒
       }
-    });
+    );
 
     // 更新後のデータを取得して返却
     const updatedContractPlot = await prisma.contractPlot.findUnique({

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -336,36 +336,38 @@ const contractPlotBillingInfoSchema = z
 
 /**
  * 使用料情報のバリデーションスキーマ（ContractPlot用）
+ * フロントが各フィールドを null として送信する場合があるため nullable
  */
 const contractPlotUsageFeeSchema = z
   .object({
-    calculationType: z.string().max(20).optional().or(z.literal('')),
-    taxType: z.string().max(20).optional().or(z.literal('')),
-    billingType: z.string().max(20).optional().or(z.literal('')),
-    billingYears: z.string().max(20).optional().or(z.literal('')),
-    area: z.string().max(50).optional().or(z.literal('')),
-    unitPrice: z.string().max(50).optional().or(z.literal('')),
-    usageFee: z.string().max(50).optional().or(z.literal('')),
-    paymentMethod: z.string().max(20).optional().or(z.literal('')),
+    calculationType: z.string().max(20).optional().nullable().or(z.literal('')),
+    taxType: z.string().max(20).optional().nullable().or(z.literal('')),
+    billingType: z.string().max(20).optional().nullable().or(z.literal('')),
+    billingYears: z.string().max(20).optional().nullable().or(z.literal('')),
+    area: z.string().max(50).optional().nullable().or(z.literal('')),
+    unitPrice: z.string().max(50).optional().nullable().or(z.literal('')),
+    usageFee: z.string().max(50).optional().nullable().or(z.literal('')),
+    paymentMethod: z.string().max(20).optional().nullable().or(z.literal('')),
   })
   .optional()
   .or(z.null());
 
 /**
  * 管理料情報のバリデーションスキーマ（ContractPlot用）
+ * フロントが各フィールドを null として送信する場合があるため nullable
  */
 const contractPlotManagementFeeSchema = z
   .object({
-    calculationType: z.string().max(20).optional().or(z.literal('')),
-    taxType: z.string().max(20).optional().or(z.literal('')),
-    billingType: z.string().max(20).optional().or(z.literal('')),
-    billingYears: z.string().max(20).optional().or(z.literal('')),
-    area: z.string().max(50).optional().or(z.literal('')),
-    billingMonth: z.string().max(20).optional().or(z.literal('')),
-    managementFee: z.string().max(50).optional().or(z.literal('')),
-    unitPrice: z.string().max(50).optional().or(z.literal('')),
-    lastBillingMonth: yearMonthSchema,
-    paymentMethod: z.string().max(20).optional().or(z.literal('')),
+    calculationType: z.string().max(20).optional().nullable().or(z.literal('')),
+    taxType: z.string().max(20).optional().nullable().or(z.literal('')),
+    billingType: z.string().max(20).optional().nullable().or(z.literal('')),
+    billingYears: z.string().max(20).optional().nullable().or(z.literal('')),
+    area: z.string().max(50).optional().nullable().or(z.literal('')),
+    billingMonth: z.string().max(20).optional().nullable().or(z.literal('')),
+    managementFee: z.string().max(50).optional().nullable().or(z.literal('')),
+    unitPrice: z.string().max(50).optional().nullable().or(z.literal('')),
+    lastBillingMonth: yearMonthSchema.nullable(),
+    paymentMethod: z.string().max(20).optional().nullable().or(z.literal('')),
   })
   .optional()
   .or(z.null());

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -57,6 +57,23 @@ const physicalPlotSchema = z.object({
 });
 
 /**
+ * 物理区画情報の更新バリデーションスキーマ
+ * PUT /plots/:id の input.physicalPlot で利用
+ * 全フィールドオプショナル（部分更新）
+ */
+const physicalPlotUpdateSchema = z.object({
+  plotNumber: z
+    .string()
+    .max(50, '区画番号は50文字以内で入力してください')
+    .regex(/^[A-Z0-9-]+$/, '区画番号は大文字英数字とハイフンのみ使用できます')
+    .optional(),
+  areaName: z.string().max(100, '区域名は100文字以内で入力してください').optional(),
+  areaSqm: z.number().positive('面積は正の数値で入力してください').optional(),
+  status: z.string().max(20).optional(),
+  notes: z.string().max(1000).optional().nullable().or(z.literal('')),
+});
+
+/**
  * 家族連絡先のバリデーションスキーマ
  * 将来的に家族連絡先管理エンドポイントで使用予定
  */
@@ -173,6 +190,45 @@ export const constructionInfoSchema = z
     constructionNotes: z.string().max(500).optional().or(z.literal('')),
   })
   .optional();
+
+/**
+ * 工事情報の更新バリデーションスキーマ
+ * PUT /plots/:id の input.constructionInfos[] で利用
+ * - id: 既存レコード識別用（無ければ新規作成）
+ * - notes: フロントから送られる備考フィールド（既存 constructionInfoSchema は constructionNotes だが、フロントは notes を使う）
+ */
+const constructionInfoUpdateSchema = z.object({
+  id: uuidSchema.optional(),
+  constructionType: z.string().max(100).optional().nullable().or(z.literal('')),
+  startDate: dateSchema.optional().nullable().or(z.literal('')),
+  completionDate: dateSchema.optional().nullable().or(z.literal('')),
+  contractor: z.string().max(100).optional().nullable().or(z.literal('')),
+  supervisor: z.string().max(100).optional().nullable().or(z.literal('')),
+  progress: z.string().max(100).optional().nullable().or(z.literal('')),
+  workItem1: z.string().max(100).optional().nullable().or(z.literal('')),
+  workDate1: dateSchema.optional().nullable().or(z.literal('')),
+  workAmount1: z.number().nonnegative().optional().nullable(),
+  workStatus1: z.string().max(50).optional().nullable().or(z.literal('')),
+  workItem2: z.string().max(100).optional().nullable().or(z.literal('')),
+  workDate2: dateSchema.optional().nullable().or(z.literal('')),
+  workAmount2: z.number().nonnegative().optional().nullable(),
+  workStatus2: z.string().max(50).optional().nullable().or(z.literal('')),
+  permitNumber: z.string().max(50).optional().nullable().or(z.literal('')),
+  applicationDate: dateSchema.optional().nullable().or(z.literal('')),
+  permitDate: dateSchema.optional().nullable().or(z.literal('')),
+  permitStatus: z.string().max(50).optional().nullable().or(z.literal('')),
+  paymentType1: z.string().max(50).optional().nullable().or(z.literal('')),
+  paymentAmount1: z.number().nonnegative().optional().nullable(),
+  paymentDate1: dateSchema.optional().nullable().or(z.literal('')),
+  paymentStatus1: z.string().max(50).optional().nullable().or(z.literal('')),
+  paymentType2: z.string().max(50).optional().nullable().or(z.literal('')),
+  paymentAmount2: z.number().nonnegative().optional().nullable(),
+  paymentScheduledDate2: dateSchema.optional().nullable().or(z.literal('')),
+  paymentStatus2: z.string().max(50).optional().nullable().or(z.literal('')),
+  scheduledEndDate: dateSchema.optional().nullable().or(z.literal('')),
+  constructionContent: z.string().max(2000).optional().nullable().or(z.literal('')),
+  notes: z.string().max(2000).optional().nullable().or(z.literal('')),
+});
 
 /**
  * 契約区画情報のバリデーションスキーマ
@@ -347,6 +403,7 @@ export const createPlotSchema = z.object({
  * すべてのフィールドがオプション
  */
 export const updatePlotSchema = z.object({
+  physicalPlot: physicalPlotUpdateSchema.optional(),
   contractPlot: contractPlotSchema.partial().optional(),
   saleContract: saleContractSchema.partial().optional(),
   customer: customerSchema.partial().optional(),
@@ -355,6 +412,7 @@ export const updatePlotSchema = z.object({
   usageFee: contractPlotUsageFeeSchema,
   managementFee: contractPlotManagementFeeSchema,
   buriedPersons: z.array(buriedPersonSchema).optional(),
+  constructionInfos: z.array(constructionInfoUpdateSchema).optional(),
   collectiveBurial: collectiveBurialSchema,
 });
 

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -493,6 +493,41 @@ describe('Plot Validation (ContractPlot Model)', () => {
       expect(() => updatePlotSchema.parse(validData)).not.toThrow();
     });
 
+    // フロントが各フィールドを null として送信するため null 許容が必須
+    it('UsageFee の各フィールドが null を受け入れること', () => {
+      const data = {
+        usageFee: {
+          calculationType: null,
+          taxType: null,
+          billingType: null,
+          billingYears: null,
+          area: null,
+          unitPrice: null,
+          usageFee: null,
+          paymentMethod: null,
+        },
+      };
+      expect(() => updatePlotSchema.parse(data)).not.toThrow();
+    });
+
+    it('ManagementFee の各フィールドが null を受け入れること', () => {
+      const data = {
+        managementFee: {
+          calculationType: null,
+          taxType: null,
+          billingType: null,
+          billingYears: null,
+          area: null,
+          billingMonth: null,
+          managementFee: null,
+          unitPrice: null,
+          lastBillingMonth: null,
+          paymentMethod: null,
+        },
+      };
+      expect(() => updatePlotSchema.parse(data)).not.toThrow();
+    });
+
     it('ManagementFee更新が可能であること', () => {
       const validData = {
         managementFee: {

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -502,6 +502,71 @@ describe('Plot Validation (ContractPlot Model)', () => {
 
       expect(() => updatePlotSchema.parse(validData)).not.toThrow();
     });
+
+    // issue #62: physicalPlot / constructionInfos が Zod により黙ってstripされていた問題の回帰テスト
+    describe('physicalPlot 更新（issue #62）', () => {
+      it('physicalPlot.notes のみ更新が可能であること', () => {
+        const data = { physicalPlot: { notes: '備考メモ' } };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.physicalPlot?.notes).toBe('備考メモ');
+      });
+
+      it('physicalPlot の全フィールド更新が可能であること', () => {
+        const data = {
+          physicalPlot: {
+            plotNumber: 'A-100',
+            areaName: '北区域',
+            areaSqm: 3.6,
+            status: 'available',
+            notes: 'メモ',
+          },
+        };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.physicalPlot).toEqual(data.physicalPlot);
+      });
+
+      it('physicalPlot.areaSqm に文字列を渡すとバリデーションエラーになること', () => {
+        const data = { physicalPlot: { areaSqm: 'invalid' as unknown as number } };
+        expect(() => updatePlotSchema.parse(data)).toThrow();
+      });
+
+      it('physicalPlot.notes に null を許容すること', () => {
+        const data = { physicalPlot: { notes: null } };
+        expect(() => updatePlotSchema.parse(data)).not.toThrow();
+      });
+    });
+
+    describe('constructionInfos 更新（issue #62）', () => {
+      it('constructionInfos の配列が parse 結果に保持されること', () => {
+        const data = {
+          constructionInfos: [
+            {
+              id: '550e8400-e29b-41d4-a716-446655440000',
+              constructionType: '建立',
+              contractor: '〇〇石材',
+              notes: '工事メモ',
+            },
+          ],
+        };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.constructionInfos).toHaveLength(1);
+        expect(parsed.constructionInfos?.[0].id).toBe('550e8400-e29b-41d4-a716-446655440000');
+        expect(parsed.constructionInfos?.[0].notes).toBe('工事メモ');
+      });
+
+      it('id 無しの新規工事情報も受け入れること', () => {
+        const data = {
+          constructionInfos: [{ contractor: '新規業者' }],
+        };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.constructionInfos?.[0].contractor).toBe('新規業者');
+      });
+
+      it('空配列も許容すること', () => {
+        const data = { constructionInfos: [] };
+        expect(() => updatePlotSchema.parse(data)).not.toThrow();
+      });
+    });
   });
 
   describe('createPlotContractSchema', () => {


### PR DESCRIPTION
## Summary
複数の関連修正を含む PR。

### 1. 履歴記録対象の拡大 (refs #51)
- 履歴ラベルの補完ロジックを追加（CREATE は after_record、DELETE は before_record からキー名を補完）
- これがないと CREATE/DELETE 時にフロントで物理カラム名が表示されていた

### 2. updatePlot の Zod スキーマ修正 (Closes #62)
- `updatePlotSchema` に `physicalPlot` / `constructionInfos` フィールドが定義されていなかった
- Zod のデフォルト挙動で未知キーは silently strip されるため、フロントから送られた物理区画情報・工事情報は **コントローラに到達する前に消失していた**
- これが issue #62「保存しても変更が反映されない」の根本原因
- `physicalPlotUpdateSchema` / `constructionInfoUpdateSchema` を新設して `updatePlotSchema` に追加
- 既存 `constructionInfoSchema` は `id` を持たず、フロントの `notes` に対し `constructionNotes` を期待していたためキー不一致していた問題も同時に解消

### 3. updatePlot コントローラの PhysicalPlot ハンドラ
- `input.physicalPlot` の更新処理を追加（前回コミットで追加済み、今回 cast を削除して型安全化）
- `recordEntityUpdated('PhysicalPlot', ...)` で履歴記録

## 関連
- Closes komine-crm-backend#62
- refs komine-crm-backend#51, #63
- 依存: komine-types#5（UpdatePlotRequest.physicalPlot の型拡張）
- フロント側修正: komine-crm-frontend `fix/plot-update-physical-fields-issue-62`

## Test plan
- [x] 全 693 テストパス
- [x] physicalPlot の全フィールドが Zod parse 結果に保持されることを回帰テスト
- [x] constructionInfos の id・notes が parse 結果に保持されることを回帰テスト
- [ ] 区画詳細編集 → 物理区画 notes 変更 → 保存 → 値が反映されること（手動）
- [ ] 区画詳細編集 → 工事情報 notes 変更 → 保存 → 値が反映されること（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)