### PR TITLE
fix(inventory): 按分計算の丸めズレで used+remaining≠total になる問題を修正

### DIFF
--- a/src/plots/services/inventoryService.ts
+++ b/src/plots/services/inventoryService.ts
@@ -117,14 +117,18 @@ export async function getOverallSummary(prisma: DbClient): Promise<InventorySumm
     }
   }
 
-  const remainingCount = totalCount - usedCount;
+  // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出する
+  // （別経路でMath.roundするとused + remaining ≠ totalになるケースがある）
+  const roundedTotalCount = Math.round(totalCount);
+  const roundedUsedCount = Math.round(usedCount);
+  const remainingCount = roundedTotalCount - roundedUsedCount;
   const remainingAreaSqm = totalAreaSqm - usedAreaSqm;
   const usageRate = totalCount > 0 ? (usedCount / totalCount) * 100 : 0;
 
   return {
-    totalCount: Math.round(totalCount),
-    usedCount: Math.round(usedCount),
-    remainingCount: Math.round(remainingCount),
+    totalCount: roundedTotalCount,
+    usedCount: roundedUsedCount,
+    remainingCount,
     usageRate: Math.round(usageRate * 10) / 10,
     totalAreaSqm: Math.round(totalAreaSqm * 100) / 100,
     remainingAreaSqm: Math.round(remainingAreaSqm * 100) / 100,
@@ -187,14 +191,17 @@ export async function getPeriodSummaries(
   // 結果を配列に変換
   const results: PeriodSummaryItem[] = periodsToQuery.map((p) => {
     const data = plotsByPeriod.get(p)!;
-    const remainingCount = data.totalCount - data.usedCount;
+    // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出
+    const roundedTotalCount = Math.round(data.totalCount);
+    const roundedUsedCount = Math.round(data.usedCount);
+    const remainingCount = roundedTotalCount - roundedUsedCount;
     const usageRate = data.totalCount > 0 ? (data.usedCount / data.totalCount) * 100 : 0;
 
     return {
       period: p,
-      totalCount: Math.round(data.totalCount),
-      usedCount: Math.round(data.usedCount),
-      remainingCount: Math.round(remainingCount),
+      totalCount: roundedTotalCount,
+      usedCount: roundedUsedCount,
+      remainingCount,
       usageRate: Math.round(usageRate * 10) / 10,
     };
   });
@@ -288,15 +295,18 @@ export async function getSectionInventory(
 
   // 結果を配列に変換
   let items: SectionInventoryItem[] = Array.from(sectionMap.values()).map((item) => {
-    const remainingCount = item.totalCount - item.usedCount;
+    // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出
+    const roundedTotalCount = Math.round(item.totalCount);
+    const roundedUsedCount = Math.round(item.usedCount);
+    const remainingCount = roundedTotalCount - roundedUsedCount;
     const usageRate = item.totalCount > 0 ? (item.usedCount / item.totalCount) * 100 : 0;
 
     return {
       period: item.period,
       section: item.section,
-      totalCount: Math.round(item.totalCount),
-      usedCount: Math.round(item.usedCount),
-      remainingCount: Math.round(remainingCount),
+      totalCount: roundedTotalCount,
+      usedCount: roundedUsedCount,
+      remainingCount,
       usageRate: Math.round(usageRate * 10) / 10,
       category: item.category,
     };
@@ -434,15 +444,18 @@ export async function getAreaInventory(
 
   // 結果を配列に変換
   let items: AreaInventoryItem[] = Array.from(areaMap.values()).map((item) => {
-    const remainingCount = item.totalCount - item.usedCount;
+    // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出
+    const roundedTotalCount = Math.round(item.totalCount);
+    const roundedUsedCount = Math.round(item.usedCount);
+    const remainingCount = roundedTotalCount - roundedUsedCount;
     const remainingAreaSqm = item.totalAreaSqm - item.usedAreaSqm;
 
     return {
       period: item.period,
       areaSqm: item.areaSqm,
-      totalCount: Math.round(item.totalCount),
-      usedCount: Math.round(item.usedCount),
-      remainingCount: Math.round(remainingCount),
+      totalCount: roundedTotalCount,
+      usedCount: roundedUsedCount,
+      remainingCount,
       remainingAreaSqm: Math.round(remainingAreaSqm * 100) / 100,
       plotType: item.plotType,
     };

--- a/tests/plots/services/inventoryService.test.ts
+++ b/tests/plots/services/inventoryService.test.ts
@@ -121,11 +121,51 @@ describe('inventoryService', () => {
       const result = await getOverallSummary(mockPrisma);
 
       expect(result.totalCount).toBe(3);
-      expect(result.usedCount).toBe(2); // 1 sold_out + 0.5 partially_sold → rounds to 2
-      expect(result.remainingCount).toBe(2); // 3 - 1.5 = 1.5 → rounds to 2
+      expect(result.usedCount).toBe(2); // 1 sold_out + 0.5 partially_sold = 1.5 → Math.round → 2
+      // 整合性を保つため、remainingCount は totalCount - roundedUsedCount で導出
+      expect(result.remainingCount).toBe(1); // 3 - 2 = 1
+      expect(result.usedCount + result.remainingCount).toBe(result.totalCount);
       expect(result.totalAreaSqm).toBe(10.8);
       expect(result.usageRate).toBeCloseTo(50, 0);
       expect(result.lastUpdated).toBeDefined();
+    });
+
+    it('按分による丸めが発生してもusedCount + remainingCount === totalCountを満たすこと', async () => {
+      // 100区画中、50区画がsold_outで、もう1区画がpartially_soldで0.5使用
+      // → usedCount = 50.5 → Math.round → 51
+      // → 修正前: remainingCount = Math.round(49.5) = 50, sum = 101 ≠ 100 ✗
+      // → 修正後: remainingCount = 100 - 51 = 49, sum = 100 ✓
+      const plots = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `sold-${i}`,
+          plot_number: `A-${i}`,
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'sold_out',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
+        })),
+        {
+          id: 'partial',
+          plot_number: 'A-50',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 1.8 } }],
+        },
+        ...Array.from({ length: 49 }, (_, i) => ({
+          id: `available-${i}`,
+          plot_number: `A-${100 + i}`,
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'available',
+          contractPlots: [],
+        })),
+      ];
+      mockPrisma.physicalPlot.findMany.mockResolvedValue(plots);
+
+      const result = await getOverallSummary(mockPrisma);
+
+      expect(result.totalCount).toBe(100);
+      expect(result.usedCount).toBe(51);
+      expect(result.remainingCount).toBe(49);
+      expect(result.usedCount + result.remainingCount).toBe(result.totalCount);
     });
 
     it('区画が存在しない場合、0を返すこと', async () => {
@@ -210,6 +250,40 @@ describe('inventoryService', () => {
       expect(result[0].usedCount).toBe(1);
       expect(result[0].remainingCount).toBe(1);
       expect(result[0].usageRate).toBe(50);
+    });
+
+    it('按分による丸めが発生してもusedCount + remainingCount === totalCountを満たすこと', async () => {
+      const plots = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `sold-${i}`,
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'sold_out',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
+        })),
+        {
+          id: 'partial',
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 1.8 } }],
+        },
+        ...Array.from({ length: 49 }, (_, i) => ({
+          id: `available-${i}`,
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'available',
+          contractPlots: [],
+        })),
+      ];
+      mockPrisma.physicalPlot.findMany.mockResolvedValue(plots);
+
+      const result = await getPeriodSummaries(mockPrisma, '1期');
+
+      expect(result[0].totalCount).toBe(100);
+      expect(result[0].usedCount).toBe(51);
+      expect(result[0].remainingCount).toBe(49);
+      expect(result[0].usedCount + result[0].remainingCount).toBe(result[0].totalCount);
     });
   });
 
@@ -375,6 +449,46 @@ describe('inventoryService', () => {
       expect(result.items.length).toBeLessThanOrEqual(10);
       expect(result.total).toBeGreaterThan(10);
     });
+
+    it('按分による丸めが発生してもusedCount + remainingCount === totalCountを満たすこと', async () => {
+      // セクションA, 1期, 100区画中50.5使用
+      const plots = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `sold-${i}`,
+          plot_number: `A-${i}`,
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'sold_out',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
+        })),
+        {
+          id: 'partial',
+          plot_number: 'A-50',
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 1.8 } }],
+        },
+        ...Array.from({ length: 49 }, (_, i) => ({
+          id: `available-${i}`,
+          plot_number: `A-${100 + i}`,
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'available',
+          contractPlots: [],
+        })),
+      ];
+      mockPrisma.physicalPlot.findMany.mockResolvedValue(plots);
+
+      const result = await getSectionInventory(mockPrisma);
+      const sectionA = result.items.find((i) => i.section === 'A');
+
+      expect(sectionA).toBeDefined();
+      expect(sectionA!.totalCount).toBe(100);
+      expect(sectionA!.usedCount).toBe(51);
+      expect(sectionA!.remainingCount).toBe(49);
+      expect(sectionA!.usedCount + sectionA!.remainingCount).toBe(sectionA!.totalCount);
+    });
   });
 
   describe('getAreaInventory', () => {
@@ -493,6 +607,46 @@ describe('inventoryService', () => {
 
       const jiyuu = result.items.find((i) => i.plotType === '自由');
       expect(jiyuu).toBeDefined();
+    });
+
+    it('按分による丸めが発生してもusedCount + remainingCount === totalCountを満たすこと', async () => {
+      // 1期, 3.6㎡, 自由タイプの100区画中50.5使用
+      const plots = [
+        ...Array.from({ length: 50 }, (_, i) => ({
+          id: `sold-${i}`,
+          plot_number: `A-${i}`,
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'sold_out',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
+        })),
+        {
+          id: 'partial',
+          plot_number: 'A-50',
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 1.8 } }],
+        },
+        ...Array.from({ length: 49 }, (_, i) => ({
+          id: `available-${i}`,
+          plot_number: `A-${100 + i}`,
+          area_name: '1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'available',
+          contractPlots: [],
+        })),
+      ];
+      mockPrisma.physicalPlot.findMany.mockResolvedValue(plots);
+
+      const result = await getAreaInventory(mockPrisma);
+      const item = result.items.find((i) => i.areaSqm === 3.6 && i.plotType === '自由');
+
+      expect(item).toBeDefined();
+      expect(item!.totalCount).toBe(100);
+      expect(item!.usedCount).toBe(51);
+      expect(item!.remainingCount).toBe(49);
+      expect(item!.usedCount + item!.remainingCount).toBe(item!.totalCount);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `partially_sold` の按分計算で `usedCount` と `remainingCount` を別経路で `Math.round` していたため、丸め境界で **`usedCount + remainingCount ≠ totalCount`** になるケースがあった
- 例: `totalCount=100, used=50.5` → `Math.round(50.5)=51` / `Math.round(49.5)=50` → 合計101 ✗
- `usedCount` を先に丸めて `remainingCount = roundedTotalCount - roundedUsedCount` で導出するように統一
- 影響範囲: `getOverallSummary` / `getPeriodSummaries` / `getSectionInventory` / `getAreaInventory` の4関数

## Test plan
- [x] 4関数それぞれに「100区画中50.5使用」シナリオの整合性テストを追加 (`usedCount + remainingCount === totalCount` をassert)
- [x] 既存テスト `getOverallSummary` の期待値を整合的な値に更新（旧テストは実は丸めバグを通過させていた）
- [x] `npm test -- tests/plots/services/inventoryService.test.ts` 全26件 pass
- [x] `npm run lint` errorなし

## 関連
Refs #64 (優先度高 #2)

このPRはissue #64の **#2 丸めズレ** だけをスコープとした小さな修正。
他の項目（#1 命名規則確認, #4 面積概算, #5 categorize範囲, #6 plotType妥当性）は実DB確認や業務確認が必要なため別PRで対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)