### PR TITLE
fix: 履歴情報タブの表示改善 (#69)

### DIFF
--- a/src/plots/services/historyLabels.ts
+++ b/src/plots/services/historyLabels.ts
@@ -5,9 +5,62 @@
  * UI表示用の日本語ラベルにマッピングする。
  *
  * issue #51 Phase 3: 履歴の表示改善
+ * issue #69: フィールド名・値の日本語化・整形
  */
 
 import { HistoryEntityType } from './historyService';
+
+/**
+ * UUID形式の正規表現
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * 値がUUID形式かどうか判定する
+ */
+export function isUuidValue(value: unknown): boolean {
+  return typeof value === 'string' && UUID_REGEX.test(value);
+}
+
+/**
+ * 表示対象から除外するフィールド名
+ *
+ * - 主キー（id）
+ * - タイムスタンプ系（created_at, updated_at, deleted_at）
+ * - 外部キー（*_id）
+ *
+ * issue #69: システムフィールド・FK・UUIDを非表示にする
+ */
+export const HIDDEN_FIELDS: ReadonlySet<string> = new Set([
+  // 主キー
+  'id',
+  // タイムスタンプ
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  // 外部キー
+  'physical_plot_id',
+  'contract_plot_id',
+  'sale_contract_id',
+  'customer_id',
+  'work_info_id',
+  'billing_info_id',
+  'usage_fee_id',
+  'management_fee_id',
+  'gravestone_info_id',
+  'construction_info_id',
+  'collective_burial_id',
+  'buried_person_id',
+  'family_contact_id',
+  'document_id',
+]);
+
+/**
+ * フィールドを表示対象から除外すべきか判定する
+ */
+export function isHiddenField(fieldName: string): boolean {
+  return HIDDEN_FIELDS.has(fieldName);
+}
 
 /**
  * エンティティ種別ごとのフィールド名→日本語ラベルマップ
@@ -245,26 +298,51 @@ export function formatHistoryWithLabels(history: {
   const entityType = history.entity_type;
   const entityLabel = getEntityLabel(entityType);
 
-  // 日本語ラベルマップを構築
+  // issue #69: 非表示フィールドを除外したレコードを構築
+  const filterRecord = (record: unknown): Record<string, unknown> | null => {
+    if (!record || typeof record !== 'object') return null;
+    const filtered: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(record as Record<string, unknown>)) {
+      if (isHiddenField(key)) continue;
+      filtered[key] = value;
+    }
+    return Object.keys(filtered).length > 0 ? filtered : null;
+  };
+
+  // changed_fields から非表示フィールドを除外
+  const filterChangedFields = (fields: unknown): Record<string, unknown> | null => {
+    if (!fields || typeof fields !== 'object') return null;
+    const filtered: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(fields as Record<string, unknown>)) {
+      if (isHiddenField(key)) continue;
+      filtered[key] = value;
+    }
+    return Object.keys(filtered).length > 0 ? filtered : null;
+  };
+
+  const filteredChangedFields = filterChangedFields(history.changed_fields);
+  const filteredBeforeRecord = filterRecord(history.before_record);
+  const filteredAfterRecord = filterRecord(history.after_record);
+
+  // 日本語ラベルマップを構築（フィルタ後のキーから）
   // - UPDATE: changed_fields のキーから
   // - CREATE: after_record のキーから
   // - DELETE: before_record のキーから
   const fieldLabels: Record<string, string> = {};
-  const collectLabels = (record: unknown): void => {
-    if (record && typeof record === 'object') {
-      for (const fieldName of Object.keys(record as Record<string, unknown>)) {
-        if (fieldName === 'id') continue;
+  const collectLabels = (record: Record<string, unknown> | null): void => {
+    if (record) {
+      for (const fieldName of Object.keys(record)) {
         fieldLabels[fieldName] = getFieldLabel(entityType, fieldName);
       }
     }
   };
-  if (history.changed_fields && typeof history.changed_fields === 'object') {
-    collectLabels(history.changed_fields);
+  if (filteredChangedFields) {
+    collectLabels(filteredChangedFields);
   }
   if (history.action_type === 'CREATE') {
-    collectLabels(history.after_record);
+    collectLabels(filteredAfterRecord);
   } else if (history.action_type === 'DELETE') {
-    collectLabels(history.before_record);
+    collectLabels(filteredBeforeRecord);
   }
 
   return {
@@ -273,10 +351,10 @@ export function formatHistoryWithLabels(history: {
     entityLabel,
     entityId: history.entity_id,
     actionType: history.action_type,
-    changedFields: history.changed_fields,
+    changedFields: filteredChangedFields,
     fieldLabels,
-    beforeRecord: history.before_record,
-    afterRecord: history.after_record,
+    beforeRecord: filteredBeforeRecord,
+    afterRecord: filteredAfterRecord,
     changedBy: history.changed_by,
     changeReason: history.change_reason,
     ipAddress: history.ip_address,

--- a/tests/plots/services/historyLabels.test.ts
+++ b/tests/plots/services/historyLabels.test.ts
@@ -6,6 +6,9 @@ import {
   getFieldLabel,
   getEntityLabel,
   formatHistoryWithLabels,
+  isHiddenField,
+  isUuidValue,
+  HIDDEN_FIELDS,
 } from '../../../src/plots/services/historyLabels';
 
 describe('historyLabels', () => {
@@ -35,6 +38,48 @@ describe('historyLabels', () => {
 
     it('未定義エンティティはそのまま返す', () => {
       expect(getEntityLabel('Unknown')).toBe('Unknown');
+    });
+  });
+
+  describe('isHiddenField', () => {
+    it('主キーは非表示', () => {
+      expect(isHiddenField('id')).toBe(true);
+    });
+
+    it('タイムスタンプ系は非表示', () => {
+      expect(isHiddenField('created_at')).toBe(true);
+      expect(isHiddenField('updated_at')).toBe(true);
+      expect(isHiddenField('deleted_at')).toBe(true);
+    });
+
+    it('FK系は非表示', () => {
+      expect(isHiddenField('physical_plot_id')).toBe(true);
+      expect(isHiddenField('contract_plot_id')).toBe(true);
+      expect(isHiddenField('sale_contract_id')).toBe(true);
+      expect(isHiddenField('customer_id')).toBe(true);
+      expect(isHiddenField('work_info_id')).toBe(true);
+      expect(isHiddenField('billing_info_id')).toBe(true);
+    });
+
+    it('通常のフィールドは表示対象', () => {
+      expect(isHiddenField('name')).toBe(false);
+      expect(isHiddenField('contract_area_sqm')).toBe(false);
+      expect(isHiddenField('notes')).toBe(false);
+    });
+  });
+
+  describe('isUuidValue', () => {
+    it('UUID形式を判定する', () => {
+      expect(isUuidValue('32295525-4309-477a-a524-30c0fa699795')).toBe(true);
+      expect(isUuidValue('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(true);
+    });
+
+    it('UUID以外はfalse', () => {
+      expect(isUuidValue('A-56')).toBe(false);
+      expect(isUuidValue('田中太郎')).toBe(false);
+      expect(isUuidValue(123)).toBe(false);
+      expect(isUuidValue(null)).toBe(false);
+      expect(isUuidValue(undefined)).toBe(false);
     });
   });
 
@@ -105,10 +150,14 @@ describe('historyLabels', () => {
       };
 
       const result = formatHistoryWithLabels(history);
+      // issue #69: idは非表示フィールドとして除外される
       expect(result['fieldLabels']).toEqual({
         name: '氏名',
         death_date: '死亡日',
       });
+      // afterRecordからもidが除外されている
+      const afterRecord = result['afterRecord'] as Record<string, unknown>;
+      expect(afterRecord).not.toHaveProperty('id');
     });
 
     it('DELETE時はbefore_recordのキーからfieldLabelsを補完する (issue #63)', () => {
@@ -130,6 +179,137 @@ describe('historyLabels', () => {
       expect(result['fieldLabels']).toEqual({
         company_name: '勤務先名称',
         work_address: '勤務先住所',
+      });
+      // beforeRecordからもidが除外されている
+      const beforeRecord = result['beforeRecord'] as Record<string, unknown>;
+      expect(beforeRecord).not.toHaveProperty('id');
+    });
+
+    // issue #69: 非表示フィールドの除外テスト
+    describe('issue #69: 非表示フィールドの除外', () => {
+      it('CREATE時にシステムフィールド・FKがafterRecordから除外される', () => {
+        const history = {
+          id: 'h-1',
+          entity_type: 'ContractPlot',
+          entity_id: 'cp-1',
+          action_type: 'CREATE',
+          changed_fields: null,
+          before_record: null,
+          after_record: {
+            id: 'cp-1',
+            physical_plot_id: '32295525-4309-477a-a524-30c0fa699795',
+            contract_area_sqm: '3.6',
+            contract_date: '2026-01-01',
+            price: 100000,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+          changed_by: 'テストユーザー',
+          change_reason: null,
+          ip_address: '127.0.0.1',
+          created_at: new Date(),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const afterRecord = result['afterRecord'] as Record<string, unknown>;
+        const fieldLabels = result['fieldLabels'] as Record<string, string>;
+
+        // 非表示フィールドが除外されている
+        expect(afterRecord).not.toHaveProperty('id');
+        expect(afterRecord).not.toHaveProperty('physical_plot_id');
+        expect(afterRecord).not.toHaveProperty('created_at');
+        expect(afterRecord).not.toHaveProperty('updated_at');
+
+        // 業務フィールドは残っている
+        expect(afterRecord).toHaveProperty('contract_area_sqm', '3.6');
+        expect(afterRecord).toHaveProperty('price', 100000);
+
+        // fieldLabelsにも非表示フィールドは含まれない
+        expect(fieldLabels).not.toHaveProperty('id');
+        expect(fieldLabels).not.toHaveProperty('physical_plot_id');
+        expect(fieldLabels).toHaveProperty('contract_area_sqm', '契約面積');
+      });
+
+      it('UPDATE時にchanged_fieldsからFKが除外される', () => {
+        const history = {
+          id: 'h-1',
+          entity_type: 'ContractPlot',
+          entity_id: 'cp-1',
+          action_type: 'UPDATE',
+          changed_fields: {
+            physical_plot_id: {
+              before: 'aaaa-bbbb-cccc',
+              after: 'dddd-eeee-ffff',
+            },
+            contract_area_sqm: { before: '3.6', after: '1.8' },
+          },
+          before_record: { physical_plot_id: 'aaaa', contract_area_sqm: '3.6' },
+          after_record: { physical_plot_id: 'dddd', contract_area_sqm: '1.8' },
+          changed_by: 'テストユーザー',
+          change_reason: null,
+          ip_address: '127.0.0.1',
+          created_at: new Date(),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const changedFields = result['changedFields'] as Record<string, unknown>;
+
+        expect(changedFields).not.toHaveProperty('physical_plot_id');
+        expect(changedFields).toHaveProperty('contract_area_sqm');
+      });
+
+      it('DELETE時にbefore_recordからシステムフィールドが除外される', () => {
+        const history = {
+          id: 'h-1',
+          entity_type: 'Customer',
+          entity_id: 'c-1',
+          action_type: 'DELETE',
+          changed_fields: null,
+          before_record: {
+            id: 'c-1',
+            name: '山田太郎',
+            phone_number: '090-1234-5678',
+            created_at: '2025-01-01T00:00:00Z',
+            deleted_at: '2026-04-01T00:00:00Z',
+          },
+          after_record: null,
+          changed_by: 'system',
+          change_reason: '退会',
+          ip_address: 'unknown',
+          created_at: new Date(),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const beforeRecord = result['beforeRecord'] as Record<string, unknown>;
+
+        expect(beforeRecord).not.toHaveProperty('id');
+        expect(beforeRecord).not.toHaveProperty('created_at');
+        expect(beforeRecord).not.toHaveProperty('deleted_at');
+        expect(beforeRecord).toHaveProperty('name', '山田太郎');
+        expect(beforeRecord).toHaveProperty('phone_number', '090-1234-5678');
+      });
+
+      it('全フィールドが非表示の場合はnullが返る', () => {
+        const history = {
+          id: 'h-1',
+          entity_type: 'ContractPlot',
+          entity_id: 'cp-1',
+          action_type: 'CREATE',
+          changed_fields: null,
+          before_record: null,
+          after_record: {
+            id: 'cp-1',
+            physical_plot_id: 'some-uuid',
+            created_at: '2026-01-01',
+          },
+          changed_by: 'system',
+          change_reason: null,
+          ip_address: 'unknown',
+          created_at: new Date(),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        expect(result['afterRecord']).toBeNull();
       });
     });
   });


### PR DESCRIPTION
## Summary
- `formatHistoryWithLabels`に非表示フィールドフィルタリング機能を追加
- `HIDDEN_FIELDS`セットで除外対象を定義（id, created_at, updated_at, deleted_at, 各種FK）
- `isHiddenField`/`isUuidValue`ユーティリティ関数をexport
- テスト19件追加（既存+新規issue #69対応分）

## 対応内容（issue #69）
- **A. 非表示フィールドリスト**: id, タイムスタンプ系, FK系フィールドを`HIDDEN_FIELDS`に定義し、`formatHistoryWithLabels`でフィルタ
- **B. レコードのフィルタリング**: `changedFields`, `beforeRecord`, `afterRecord`すべてから非表示フィールドを除外
- **C. フロントエンド対応**: 別PR（komine-crm-frontend）でUUID値の省略表示を実装

## Test plan
- [x] `historyLabels.test.ts` 19件全パス
- [x] `historyService.test.ts` 8件全パス（影響なし確認）
- [x] ESLint通過

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)