### PR TITLE
fix: PERIODS定数を実DB/マスタの期名に合わせて修正

### DIFF
--- a/src/plots/services/inventoryService.ts
+++ b/src/plots/services/inventoryService.ts
@@ -11,10 +11,8 @@ import {
   SortOrder,
 } from '../../validations/inventoryValidation';
 
-// 期の定義
-// NOTE: これらはPhysicalPlot.area_nameの値に対応。区画名マスタ（SectionNameMaster）の
-// periodフィールド（"第1期"等）とは形式が異なる。将来的にマスタ参照への置換を検討。
-export const PERIODS: PlotPeriod[] = ['1期', '2期', '3期', '4期'];
+// 期の定義（区画名一覧.md / SectionNameMasterのperiodに準拠）
+export const PERIODS: PlotPeriod[] = ['第1期', '第2期', '第3期', '第3期樹林部', '第4期'];
 
 // Prisma Decimalまたは数値を数値に変換するヘルパー
 function toNumber(value: unknown): number {

--- a/src/validations/inventoryValidation.ts
+++ b/src/validations/inventoryValidation.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-// 期の定義
-export const PlotPeriodEnum = z.enum(['1期', '2期', '3期', '4期']);
+// 期の定義（区画名一覧.md / SectionNameMasterのperiodに準拠）
+export const PlotPeriodEnum = z.enum(['第1期', '第2期', '第3期', '第3期樹林部', '第4期']);
 export type PlotPeriod = z.infer<typeof PlotPeriodEnum>;
 
 // ステータスの定義

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -429,7 +429,7 @@ paths:
       tags:
         - Plots
       summary: 期別サマリー取得
-      description: 期別（1期〜4期）の在庫サマリーを取得。特定の期のみ取得も可能。
+      description: 期別（第1期〜第4期）の在庫サマリーを取得。特定の期のみ取得も可能。
       security:
         - bearerAuth: []
       parameters:
@@ -438,7 +438,7 @@ paths:
           description: 期（指定しない場合は全期）
           schema:
             type: string
-            enum: ["1期", "2期", "3期", "4期"]
+            enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
       responses:
         "200":
           description: 取得成功
@@ -476,7 +476,7 @@ paths:
           description: 期でフィルタ
           schema:
             type: string
-            enum: ["1期", "2期", "3期", "4期"]
+            enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
         - name: status
           in: query
           description: ステータスでフィルタ
@@ -493,7 +493,15 @@ paths:
           description: ソートキー
           schema:
             type: string
-            enum: ["period", "section", "totalCount", "usedCount", "remainingCount", "usageRate"]
+            enum:
+              [
+                "period",
+                "section",
+                "totalCount",
+                "usedCount",
+                "remainingCount",
+                "usageRate",
+              ]
             default: "period"
         - name: sortOrder
           in: query
@@ -556,7 +564,7 @@ paths:
           description: 期でフィルタ
           schema:
             type: string
-            enum: ["1期", "2期", "3期", "4期"]
+            enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
         - name: search
           in: query
           description: 面積・タイプで検索
@@ -567,7 +575,16 @@ paths:
           description: ソートキー
           schema:
             type: string
-            enum: ["period", "areaSqm", "totalCount", "usedCount", "remainingCount", "remainingAreaSqm", "plotType"]
+            enum:
+              [
+                "period",
+                "areaSqm",
+                "totalCount",
+                "usedCount",
+                "remainingCount",
+                "remainingAreaSqm",
+                "plotType",
+              ]
             default: "period"
         - name: sortOrder
           in: query
@@ -1944,7 +1961,7 @@ components:
         area_name:
           type: string
           description: 区域（期）
-          example: 1期
+          example: 第1期
         area_name_detail:
           type: string
           description: 区域（詳細）
@@ -2478,7 +2495,7 @@ components:
               type: string
               description: 区画（期）
               maxLength: 100
-              example: 2期
+              example: 第2期
             areaNameDetail:
               type: string
               description: 区画（詳細）
@@ -3483,9 +3500,9 @@ components:
       properties:
         period:
           type: string
-          description: 期（1期〜4期）
-          enum: ["1期", "2期", "3期", "4期"]
-          example: "1期"
+          description: 期（第1期〜第4期）
+          enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
+          example: "第1期"
         totalCount:
           type: integer
           description: 総区画数
@@ -3511,7 +3528,7 @@ components:
         period:
           type: string
           description: 期
-          example: "1期"
+          example: "第1期"
         section:
           type: string
           description: セクション（A, B, 吉相など）
@@ -3546,7 +3563,7 @@ components:
         period:
           type: string
           description: 期
-          example: "1期"
+          example: "第1期"
         areaSqm:
           type: number
           format: float

--- a/tests/plots/controllers/bulkCreatePlots.test.ts
+++ b/tests/plots/controllers/bulkCreatePlots.test.ts
@@ -142,7 +142,7 @@ describe('bulkCreatePlots', () => {
     });
 
     it('areaSqmが未指定の場合デフォルト値3.6が使用されること', async () => {
-      const items = [{ plotNumber: 'B-1', areaName: '2期' }];
+      const items = [{ plotNumber: 'B-1', areaName: '第2期' }];
       mockRequest = {
         body: { items },
       };
@@ -150,7 +150,7 @@ describe('bulkCreatePlots', () => {
       mockPhysicalPlotCreate.mockResolvedValueOnce({
         id: 'uuid-0',
         plot_number: 'B-1',
-        area_name: '2期',
+        area_name: '第2期',
         area_sqm: { toNumber: () => 3.6 },
         status: 'available',
         notes: null,
@@ -176,7 +176,7 @@ describe('bulkCreatePlots', () => {
       expect(mockPhysicalPlotCreate).toHaveBeenCalledWith({
         data: expect.objectContaining({
           plot_number: 'B-1',
-          area_name: '2期',
+          area_name: '第2期',
           status: 'available',
           notes: null,
         }),
@@ -184,7 +184,7 @@ describe('bulkCreatePlots', () => {
     });
 
     it('notesが未指定の場合nullが設定されること', async () => {
-      const items = [{ plotNumber: 'C-1', areaName: '3期', areaSqm: 1.8 }];
+      const items = [{ plotNumber: 'C-1', areaName: '第3期', areaSqm: 1.8 }];
       mockRequest = {
         body: { items },
       };
@@ -192,7 +192,7 @@ describe('bulkCreatePlots', () => {
       mockPhysicalPlotCreate.mockResolvedValueOnce({
         id: 'uuid-0',
         plot_number: 'C-1',
-        area_name: '3期',
+        area_name: '第3期',
         area_sqm: { toNumber: () => 1.8 },
         status: 'available',
         notes: null,
@@ -214,7 +214,7 @@ describe('bulkCreatePlots', () => {
 
   describe('バリデーションエラー', () => {
     it('plotNumberが欠けている場合エラーを返すこと', async () => {
-      const items = [{ areaName: '1期', areaSqm: 3.6 }];
+      const items = [{ areaName: '第1期', areaSqm: 3.6 }];
       mockRequest = {
         body: { items },
       };
@@ -307,9 +307,9 @@ describe('bulkCreatePlots', () => {
   describe('重複チェック', () => {
     it('バッチ内で区画番号が重複している場合エラーを返すこと', async () => {
       const items = [
-        { plotNumber: 'A-1', areaName: '1期', areaSqm: 3.6 },
-        { plotNumber: 'A-2', areaName: '1期', areaSqm: 3.6 },
-        { plotNumber: 'A-1', areaName: '1期', areaSqm: 3.6 }, // duplicate
+        { plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 },
+        { plotNumber: 'A-2', areaName: '第1期', areaSqm: 3.6 },
+        { plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 }, // duplicate
       ];
       mockRequest = {
         body: { items },
@@ -336,9 +336,9 @@ describe('bulkCreatePlots', () => {
 
     it('データベースに既存の区画番号がある場合エラーを返すこと', async () => {
       const items = [
-        { plotNumber: 'A-1', areaName: '1期', areaSqm: 3.6 },
-        { plotNumber: 'A-2', areaName: '1期', areaSqm: 3.6 },
-        { plotNumber: 'A-3', areaName: '1期', areaSqm: 3.6 },
+        { plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 },
+        { plotNumber: 'A-2', areaName: '第1期', areaSqm: 3.6 },
+        { plotNumber: 'A-3', areaName: '第1期', areaSqm: 3.6 },
       ];
       mockRequest = {
         body: { items },
@@ -379,7 +379,7 @@ describe('bulkCreatePlots', () => {
 
   describe('トランザクションエラー', () => {
     it('トランザクション中にエラーが発生した場合nextにエラーが渡されること', async () => {
-      const items = [{ plotNumber: 'A-1', areaName: '1期', areaSqm: 3.6 }];
+      const items = [{ plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 }];
       mockRequest = {
         body: { items },
       };

--- a/tests/plots/controllers/inventoryControllers.test.ts
+++ b/tests/plots/controllers/inventoryControllers.test.ts
@@ -106,8 +106,8 @@ describe('Inventory Controllers', () => {
       };
 
       const mockPeriods = [
-        { period: '1期', totalCount: 50, usedCount: 40, remainingCount: 10, usageRate: 80.0 },
-        { period: '2期', totalCount: 30, usedCount: 25, remainingCount: 5, usageRate: 83.3 },
+        { period: '第1期', totalCount: 50, usedCount: 40, remainingCount: 10, usageRate: 80.0 },
+        { period: '第2期', totalCount: 30, usedCount: 25, remainingCount: 5, usageRate: 83.3 },
       ];
 
       (inventoryService.getPeriodSummaries as jest.Mock).mockResolvedValue(mockPeriods);
@@ -125,18 +125,18 @@ describe('Inventory Controllers', () => {
 
     it('特定期のサマリーを返すこと', async () => {
       mockRequest = {
-        query: { period: '1期' },
+        query: { period: '第1期' },
       };
 
       const mockPeriods = [
-        { period: '1期', totalCount: 50, usedCount: 40, remainingCount: 10, usageRate: 80.0 },
+        { period: '第1期', totalCount: 50, usedCount: 40, remainingCount: 10, usageRate: 80.0 },
       ];
 
       (inventoryService.getPeriodSummaries as jest.Mock).mockResolvedValue(mockPeriods);
 
       await getInventoryPeriods(mockRequest as Request, mockResponse as Response);
 
-      expect(inventoryService.getPeriodSummaries).toHaveBeenCalledWith(expect.anything(), '1期');
+      expect(inventoryService.getPeriodSummaries).toHaveBeenCalledWith(expect.anything(), '第1期');
       expect(statusMock).toHaveBeenCalledWith(200);
     });
 
@@ -163,7 +163,7 @@ describe('Inventory Controllers', () => {
 
       const mockItems = [
         {
-          period: '1期',
+          period: '第1期',
           section: 'A',
           totalCount: 10,
           usedCount: 8,
@@ -197,7 +197,7 @@ describe('Inventory Controllers', () => {
     it('フィルタリングパラメータを正しく渡すこと', async () => {
       mockRequest = {
         query: {
-          period: '1期',
+          period: '第1期',
           status: 'available',
           search: 'A',
           sortBy: 'usageRate',
@@ -215,7 +215,7 @@ describe('Inventory Controllers', () => {
       await getInventorySections(mockRequest as Request, mockResponse as Response);
 
       expect(inventoryService.getSectionInventory).toHaveBeenCalledWith(expect.anything(), {
-        period: '1期',
+        period: '第1期',
         status: 'available',
         search: 'A',
         sortBy: 'usageRate',
@@ -277,7 +277,7 @@ describe('Inventory Controllers', () => {
 
       const mockItems = [
         {
-          period: '1期',
+          period: '第1期',
           areaSqm: 3.6,
           totalCount: 10,
           usedCount: 8,
@@ -312,7 +312,7 @@ describe('Inventory Controllers', () => {
     it('フィルタリングパラメータを正しく渡すこと', async () => {
       mockRequest = {
         query: {
-          period: '2期',
+          period: '第2期',
           search: '3.6',
           sortBy: 'areaSqm',
           sortOrder: 'asc',
@@ -329,7 +329,7 @@ describe('Inventory Controllers', () => {
       await getInventoryAreas(mockRequest as Request, mockResponse as Response);
 
       expect(inventoryService.getAreaInventory).toHaveBeenCalledWith(expect.anything(), {
-        period: '2期',
+        period: '第2期',
         search: '3.6',
         sortBy: 'areaSqm',
         sortOrder: 'asc',

--- a/tests/plots/services/inventoryService.test.ts
+++ b/tests/plots/services/inventoryService.test.ts
@@ -160,14 +160,14 @@ describe('inventoryService', () => {
       mockPrisma.physicalPlot.findMany.mockResolvedValue([
         {
           id: 'plot-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
         },
         {
           id: 'plot-2',
-          area_name: '2期',
+          area_name: '第2期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'sold_out',
           contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
@@ -176,11 +176,11 @@ describe('inventoryService', () => {
 
       const result = await getPeriodSummaries(mockPrisma);
 
-      expect(result).toHaveLength(4);
-      expect(result[0].period).toBe('1期');
+      expect(result).toHaveLength(5);
+      expect(result[0].period).toBe('第1期');
       expect(result[0].totalCount).toBe(1);
       expect(result[0].remainingCount).toBe(1);
-      expect(result[1].period).toBe('2期');
+      expect(result[1].period).toBe('第2期');
       expect(result[1].usedCount).toBe(1);
     });
 
@@ -188,24 +188,24 @@ describe('inventoryService', () => {
       mockPrisma.physicalPlot.findMany.mockResolvedValue([
         {
           id: 'plot-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'sold_out',
           contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
         },
         {
           id: 'plot-2',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
         },
       ]);
 
-      const result = await getPeriodSummaries(mockPrisma, '1期');
+      const result = await getPeriodSummaries(mockPrisma, '第1期');
 
       expect(result).toHaveLength(1);
-      expect(result[0].period).toBe('1期');
+      expect(result[0].period).toBe('第1期');
       expect(result[0].totalCount).toBe(2);
       expect(result[0].usedCount).toBe(1);
       expect(result[0].remainingCount).toBe(1);
@@ -233,7 +233,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -241,7 +241,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-2',
           plot_number: 'A-2',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'sold_out',
           contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
@@ -249,7 +249,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-3',
           plot_number: 'B-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -279,18 +279,18 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
         },
       ]);
 
-      await getSectionInventory(mockPrisma, { period: '1期' });
+      await getSectionInventory(mockPrisma, { period: '第1期' });
 
       expect(mockPrisma.physicalPlot.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ area_name: '1期' }),
+          where: expect.objectContaining({ area_name: '第1期' }),
         })
       );
     });
@@ -300,7 +300,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: '吉相-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -308,7 +308,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-2',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -326,7 +326,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -334,7 +334,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-2',
           plot_number: 'B-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'sold_out',
           contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
@@ -362,7 +362,7 @@ describe('inventoryService', () => {
       const plots = Array.from({ length: 30 }, (_, i) => ({
         id: `plot-${i}`,
         plot_number: `${String.fromCharCode(65 + (i % 26))}-${Math.floor(i / 26) + 1}`,
-        area_name: '1期',
+        area_name: '第1期',
         area_sqm: { toNumber: () => 3.6 },
         status: 'available',
         contractPlots: [],
@@ -397,7 +397,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -405,7 +405,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-2',
           plot_number: 'A-2',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 1.8 },
           status: 'sold_out',
           contractPlots: [{ contract_area_sqm: { toNumber: () => 1.8 } }],
@@ -431,11 +431,11 @@ describe('inventoryService', () => {
     it('期でフィルタリングできること', async () => {
       mockPrisma.physicalPlot.findMany.mockResolvedValue([]);
 
-      await getAreaInventory(mockPrisma, { period: '2期' });
+      await getAreaInventory(mockPrisma, { period: '第2期' });
 
       expect(mockPrisma.physicalPlot.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: expect.objectContaining({ area_name: '2期' }),
+          where: expect.objectContaining({ area_name: '第2期' }),
         })
       );
     });
@@ -445,7 +445,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -453,7 +453,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-2',
           plot_number: 'A-2',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'sold_out',
           contractPlots: [{ contract_area_sqm: { toNumber: () => 3.6 } }],
@@ -471,7 +471,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-1',
           plot_number: '吉相-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],
@@ -479,7 +479,7 @@ describe('inventoryService', () => {
         {
           id: 'plot-2',
           plot_number: 'A-1',
-          area_name: '1期',
+          area_name: '第1期',
           area_sqm: { toNumber: () => 3.6 },
           status: 'available',
           contractPlots: [],


### PR DESCRIPTION
## Summary
- `PERIODS` 定数・`PlotPeriodEnum` が `'1期','2期','3期','4期'` の4値だったが、実DB(`area_name`)およびSectionNameMasterの`period`値 `'第1期','第2期','第3期','第3期樹林部','第4期'` と完全不一致だった問題を修正
- 区画名一覧.md（komine-docs）を正として、バックエンド全箇所の期名を統一（4値→5値、「第」接頭辞追加、第3期樹林部を独立カテゴリ化）
- swagger.yaml の enum/example/description も合わせて更新

## 変更ファイル
- `src/validations/inventoryValidation.ts` — PlotPeriodEnum を5値に更新
- `src/plots/services/inventoryService.ts` — PERIODS定数を5値に更新
- `swagger.yaml` — 全4箇所のenum + example + description更新
- テスト3ファイル — 全テストデータの期名更新

## Test plan
- [x] 全705テスト通過確認済み
- [ ] フロントエンド側も同様の修正が必要（別PR予定）
- [ ] 実DBの `physical_plots.area_name` が新しい期名と一致することを確認

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)