### PR TITLE
feat(plots): 一括登録フィールド拡充 + 一括編集エンドポイント新規実装 (#74)

### DIFF
--- a/src/plots/controllers/bulkCreatePlots.ts
+++ b/src/plots/controllers/bulkCreatePlots.ts
@@ -1,36 +1,39 @@
 /**
- * 物理区画一括登録エンドポイント
+ * 区画一括登録エンドポイント
  * POST /api/v1/plots/bulk
  *
- * 複数の物理区画（PhysicalPlot）を一括で登録します。
- * トランザクションによるall-or-nothing処理。
+ * 複数の区画を一件登録（createPlot）と同等のフィールド構成で一括登録します。
+ * familyContacts, buriedPersons, constructionInfos も合わせて作成可能。
+ * トランザクションによる all-or-nothing 処理。
  */
 
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
-import { Prisma } from '@prisma/client';
+import { AddressType, Gender } from '@prisma/client';
+import { CreatePlotRequest } from '@komine/types';
 import prisma from '../../db/prisma';
 import { ValidationError } from '../../middleware/errorHandler';
+import {
+  createPlotSchema,
+  buriedPersonSchema,
+  constructionInfoSchema,
+  familyContactSchema,
+  gravestoneInfoSchema,
+} from '../../validations/plotValidation';
+import { createPlotCore } from './createPlot';
+import { recordEntityCreated } from '../services/historyService';
 
 /**
  * 一括登録用の単一アイテムバリデーションスキーマ
+ * createPlotSchema に familyContacts / buriedPersons / constructionInfos / gravestoneInfo を追加
  */
-const bulkCreateItemSchema = z.object({
-  plotNumber: z
-    .string({ error: '区画番号は必須です' })
-    .min(1, '区画番号は必須です')
-    .max(50, '区画番号は50文字以内で入力してください'),
-  areaName: z
-    .string({ error: '区域名は必須です' })
-    .min(1, '区域名は必須です')
-    .max(100, '区域名は100文字以内で入力してください'),
-  areaSqm: z.number().positive('面積は正の数値で入力してください').optional().default(3.6),
-  notes: z.string().max(1000, '備考は1000文字以内で入力してください').optional(),
+const bulkCreateItemSchema = createPlotSchema.extend({
+  familyContacts: z.array(familyContactSchema).optional(),
+  buriedPersons: z.array(buriedPersonSchema).optional(),
+  constructionInfos: z.array(constructionInfoSchema.unwrap()).optional(),
+  gravestoneInfo: gravestoneInfoSchema,
 });
 
-/**
- * 一括登録リクエストボディのバリデーションスキーマ
- */
 const bulkCreateRequestSchema = z.object({
   items: z
     .array(bulkCreateItemSchema)
@@ -41,7 +44,7 @@ const bulkCreateRequestSchema = z.object({
 export type BulkCreateItem = z.infer<typeof bulkCreateItemSchema>;
 
 /**
- * 物理区画一括登録
+ * 区画一括登録
  * POST /api/v1/plots/bulk
  */
 export const bulkCreatePlots = async (
@@ -50,7 +53,7 @@ export const bulkCreatePlots = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    // 1. リクエストボディの基本バリデーション
+    // 1. リクエストボディのバリデーション
     const parseResult = bulkCreateRequestSchema.safeParse(req.body);
 
     if (!parseResult.success) {
@@ -59,8 +62,7 @@ export const bulkCreatePlots = async (
           issue.path[0] === 'items' && typeof issue.path[1] === 'number'
             ? issue.path[1]
             : undefined,
-        field:
-          issue.path.length > 2 ? String(issue.path[issue.path.length - 1]) : issue.path.join('.'),
+        field: issue.path.length > 2 ? issue.path.slice(2).join('.') : issue.path.join('.'),
         message: issue.message,
       }));
 
@@ -69,8 +71,11 @@ export const bulkCreatePlots = async (
 
     const { items } = parseResult.data;
 
-    // 2. バッチ内の重複チェック
-    const plotNumbers = items.map((item) => item.plotNumber);
+    // 2. バッチ内の plotNumber 重複チェック（新規物理区画のみ）
+    const plotNumbers = items
+      .filter((item) => !item.physicalPlot.id && item.physicalPlot.plotNumber)
+      .map((item) => item.physicalPlot.plotNumber as string);
+
     const duplicatesInBatch = plotNumbers.filter(
       (num, index) => plotNumbers.indexOf(num) !== index
     );
@@ -79,10 +84,10 @@ export const bulkCreatePlots = async (
       const uniqueDuplicates = [...new Set(duplicatesInBatch)];
       const details = uniqueDuplicates.map((plotNumber) => {
         const rows = items
-          .map((item, index) => (item.plotNumber === plotNumber ? index : -1))
+          .map((item, index) => (item.physicalPlot.plotNumber === plotNumber ? index : -1))
           .filter((index) => index !== -1);
         return {
-          row: rows[1], // 2番目の出現位置をエラー行として報告
+          row: rows[1],
           field: 'plotNumber',
           message: `区画番号「${plotNumber}」がバッチ内で重複しています（行 ${rows.join(', ')}）`,
         };
@@ -91,57 +96,192 @@ export const bulkCreatePlots = async (
       throw new ValidationError('一括登録でエラーが発生しました', details);
     }
 
-    // 3. データベース上の既存区画番号との重複チェック
-    const existingPlots = await prisma.physicalPlot.findMany({
-      where: {
-        plot_number: { in: plotNumbers },
-        deleted_at: null,
-      },
-      select: { plot_number: true },
-    });
-
-    if (existingPlots.length > 0) {
-      const existingNumbers = existingPlots.map((p) => p.plot_number);
-      const details = existingNumbers.map((plotNumber) => {
-        const row = items.findIndex((item) => item.plotNumber === plotNumber);
-        return {
-          row,
-          field: 'plotNumber',
-          message: `区画番号「${plotNumber}」は既にデータベースに存在します`,
-        };
+    // 3. DB上の既存区画番号との重複チェック
+    if (plotNumbers.length > 0) {
+      const existingPlots = await prisma.physicalPlot.findMany({
+        where: {
+          plot_number: { in: plotNumbers },
+          deleted_at: null,
+        },
+        select: { plot_number: true },
       });
 
-      throw new ValidationError('一括登録でエラーが発生しました', details);
+      if (existingPlots.length > 0) {
+        const existingNumbers = existingPlots.map((p) => p.plot_number);
+        const details = existingNumbers.map((plotNumber) => {
+          const row = items.findIndex((item) => item.physicalPlot.plotNumber === plotNumber);
+          return {
+            row,
+            field: 'plotNumber',
+            message: `区画番号「${plotNumber}」は既にデータベースに存在します`,
+          };
+        });
+
+        throw new ValidationError('一括登録でエラーが発生しました', details);
+      }
     }
 
     // 4. トランザクションで一括作成
-    const createdPlots = await prisma.$transaction(async (tx) => {
-      const results = [];
+    const createdPlots = await prisma.$transaction(
+      async (tx) => {
+        const results = [];
 
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i]!;
-        const plot = await tx.physicalPlot.create({
-          data: {
-            plot_number: item.plotNumber,
-            area_name: item.areaName,
-            area_sqm: new Prisma.Decimal(item.areaSqm),
-            status: 'available',
-            notes: item.notes || null,
-          },
-        });
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i]!;
 
-        results.push({
-          row: i,
-          id: plot.id,
-          plotNumber: plot.plot_number,
-          areaName: plot.area_name,
-        });
+          try {
+            const { contractPlotId, physicalPlotId } = await createPlotCore(
+              tx,
+              item as CreatePlotRequest,
+              req
+            );
+
+            // 4.1 family contacts（ContractPlot紐付け）
+            if (item.familyContacts && item.familyContacts.length > 0) {
+              for (const fc of item.familyContacts) {
+                // 必須フィールドが揃っていない行はスキップ（DB NOT NULL 制約回避）
+                if (!fc.name || !fc.phoneNumber || !fc.address || !fc.relationship) continue;
+                const created = await tx.familyContact.create({
+                  data: {
+                    contract_plot_id: contractPlotId,
+                    name: fc.name,
+                    name_kana: fc.nameKana || null,
+                    relationship: fc.relationship,
+                    address: fc.address,
+                    phone_number: fc.phoneNumber,
+                    phone_number_2: fc.phoneNumber2 || null,
+                    fax_number: fc.faxNumber || null,
+                    email: fc.email || null,
+                    registered_address: fc.registeredAddress || null,
+                    mailing_type: (fc.mailingType as AddressType) || null,
+                    work_company_name: fc.workCompanyName || null,
+                    work_company_name_kana: fc.workCompanyNameKana || null,
+                    work_address: fc.workAddress || null,
+                    work_phone_number: fc.workPhoneNumber || null,
+                    contact_method: fc.contactMethod || null,
+                    notes: fc.notes || null,
+                  },
+                });
+                await recordEntityCreated(tx, {
+                  entityType: 'FamilyContact',
+                  entityId: created.id,
+                  physicalPlotId,
+                  contractPlotId,
+                  afterRecord: { id: created.id, name: created.name },
+                  req,
+                });
+              }
+            }
+
+            // 4.2 buried persons（ContractPlot紐付け）
+            if (item.buriedPersons && item.buriedPersons.length > 0) {
+              for (const bp of item.buriedPersons) {
+                if (!bp.name) continue;
+                const created = await tx.buriedPerson.create({
+                  data: {
+                    contract_plot_id: contractPlotId,
+                    name: bp.name,
+                    name_kana: bp.nameKana || null,
+                    relationship: bp.relationship || null,
+                    birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
+                    death_date: bp.deathDate ? new Date(bp.deathDate) : null,
+                    age: bp.age ?? null,
+                    gender:
+                      bp.gender === 'male' || bp.gender === 'female' ? (bp.gender as Gender) : null,
+                    burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
+                    posthumous_name: bp.posthumousName || null,
+                    report_date: bp.reportDate ? new Date(bp.reportDate) : null,
+                    religion: bp.religion || null,
+                    notes: bp.notes || null,
+                  },
+                });
+                await recordEntityCreated(tx, {
+                  entityType: 'BuriedPerson',
+                  entityId: created.id,
+                  physicalPlotId,
+                  contractPlotId,
+                  afterRecord: { id: created.id, name: created.name },
+                  req,
+                });
+              }
+            }
+
+            // 4.3 construction infos（ContractPlot紐付け）
+            if (item.constructionInfos && item.constructionInfos.length > 0) {
+              for (const ci of item.constructionInfos) {
+                const created = await tx.constructionInfo.create({
+                  data: {
+                    contract_plot_id: contractPlotId,
+                    construction_type: ci.constructionType || null,
+                    start_date: ci.startDate ? new Date(ci.startDate) : null,
+                    completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
+                    contractor: ci.contractor || null,
+                    supervisor: ci.supervisor || null,
+                    progress: ci.progress || null,
+                    work_item_1: ci.workItem1 || null,
+                    work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
+                    work_amount_1: ci.workAmount1 ?? null,
+                    work_status_1: ci.workStatus1 || null,
+                    work_item_2: ci.workItem2 || null,
+                    work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
+                    work_amount_2: ci.workAmount2 ?? null,
+                    work_status_2: ci.workStatus2 || null,
+                    permit_number: ci.permitNumber || null,
+                    application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
+                    permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
+                    permit_status: ci.permitStatus || null,
+                    payment_type_1: ci.paymentType1 || null,
+                    payment_amount_1: ci.paymentAmount1 ?? null,
+                    payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
+                    payment_status_1: ci.paymentStatus1 || null,
+                    payment_type_2: ci.paymentType2 || null,
+                    payment_amount_2: ci.paymentAmount2 ?? null,
+                    payment_date_2: ci.paymentScheduledDate2
+                      ? new Date(ci.paymentScheduledDate2)
+                      : null,
+                    payment_status_2: ci.paymentStatus2 || null,
+                    scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
+                    construction_content: ci.constructionContent || null,
+                    notes: ci.constructionNotes || null,
+                  },
+                });
+                await recordEntityCreated(tx, {
+                  entityType: 'ConstructionInfo',
+                  entityId: created.id,
+                  physicalPlotId,
+                  contractPlotId,
+                  afterRecord: { id: created.id, construction_type: created.construction_type },
+                  req,
+                });
+              }
+            }
+
+            results.push({
+              row: i,
+              id: contractPlotId,
+              physicalPlotId,
+              plotNumber: item.physicalPlot.plotNumber || null,
+            });
+          } catch (error) {
+            // エラー詳細に行番号を付与して再スロー
+            if (error instanceof ValidationError) {
+              const details = error.details?.length
+                ? error.details.map((d) => ({ ...d, row: i }))
+                : [{ row: i, message: error.message }];
+              throw new ValidationError(`行 ${i} でエラー: ${error.message}`, details);
+            }
+            throw error;
+          }
+        }
+
+        return results;
+      },
+      {
+        maxWait: 10000,
+        timeout: 60000,
       }
+    );
 
-      return results;
-    });
-
-    // 5. 成功レスポンス
     res.status(201).json({
       success: true,
       data: {

--- a/src/plots/controllers/bulkUpdatePlots.ts
+++ b/src/plots/controllers/bulkUpdatePlots.ts
@@ -1,0 +1,192 @@
+/**
+ * 区画一括編集エンドポイント
+ * PUT /api/v1/plots/bulk
+ *
+ * 既存の ContractPlot を plotNumber でマッチングして一括更新します。
+ * 未指定フィールド = 変更しない、null 明示 = クリア（updatePlotCore 仕様）。
+ * トランザクションによる all-or-nothing 処理。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { UpdatePlotRequest } from '@komine/types';
+import prisma from '../../db/prisma';
+import { ValidationError } from '../../middleware/errorHandler';
+import { updatePlotSchema } from '../../validations/plotValidation';
+import { updatePlotCore } from './updatePlot';
+
+/**
+ * 一括編集用の単一アイテムバリデーションスキーマ
+ * plotNumber（マッチングキー）+ updatePlotSchema
+ */
+const bulkUpdateItemSchema = updatePlotSchema.extend({
+  plotNumber: z
+    .string({ error: 'plotNumber はマッチングキーとして必須です' })
+    .min(1, 'plotNumber は必須です')
+    .max(50, 'plotNumber は50文字以内で入力してください'),
+});
+
+const bulkUpdateRequestSchema = z.object({
+  items: z
+    .array(bulkUpdateItemSchema)
+    .min(1, '編集データが空です。1件以上のデータを指定してください')
+    .max(500, '一括編集は最大500件までです'),
+});
+
+export type BulkUpdateItem = z.infer<typeof bulkUpdateItemSchema>;
+
+/**
+ * 区画一括編集
+ * PUT /api/v1/plots/bulk
+ */
+export const bulkUpdatePlots = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    // 1. リクエストボディのバリデーション
+    const parseResult = bulkUpdateRequestSchema.safeParse(req.body);
+
+    if (!parseResult.success) {
+      const details = parseResult.error.issues.map((issue) => ({
+        row:
+          issue.path[0] === 'items' && typeof issue.path[1] === 'number'
+            ? issue.path[1]
+            : undefined,
+        field: issue.path.length > 2 ? issue.path.slice(2).join('.') : issue.path.join('.'),
+        message: issue.message,
+      }));
+
+      throw new ValidationError('一括編集でエラーが発生しました', details);
+    }
+
+    const { items } = parseResult.data;
+
+    // 2. バッチ内の plotNumber 重複チェック
+    const plotNumbers = items.map((item) => item.plotNumber);
+    const duplicatesInBatch = plotNumbers.filter(
+      (num, index) => plotNumbers.indexOf(num) !== index
+    );
+
+    if (duplicatesInBatch.length > 0) {
+      const uniqueDuplicates = [...new Set(duplicatesInBatch)];
+      const details = uniqueDuplicates.map((plotNumber) => {
+        const rows = items
+          .map((item, index) => (item.plotNumber === plotNumber ? index : -1))
+          .filter((index) => index !== -1);
+        return {
+          row: rows[1],
+          field: 'plotNumber',
+          message: `区画番号「${plotNumber}」がバッチ内で重複しています（行 ${rows.join(', ')}）`,
+        };
+      });
+
+      throw new ValidationError('一括編集でエラーが発生しました', details);
+    }
+
+    // 3. DB 上で plotNumber → 最新 ContractPlot.id をマッピング
+    //   1つの PhysicalPlot に複数契約がある場合は最新（created_at DESC）を選択
+    const existingPlots = await prisma.physicalPlot.findMany({
+      where: {
+        plot_number: { in: plotNumbers },
+        deleted_at: null,
+      },
+      include: {
+        contractPlots: {
+          where: { deleted_at: null },
+          orderBy: { created_at: 'desc' },
+          select: { id: true },
+          take: 1,
+        },
+      },
+    });
+
+    const plotNumberToContractId = new Map<string, string>();
+    const plotNumbersWithoutContract: string[] = [];
+    for (const pp of existingPlots) {
+      const contract = pp.contractPlots[0];
+      if (contract) {
+        plotNumberToContractId.set(pp.plot_number, contract.id);
+      } else {
+        plotNumbersWithoutContract.push(pp.plot_number);
+      }
+    }
+
+    const missingPlotNumbers = plotNumbers.filter(
+      (num) => !plotNumberToContractId.has(num) && !plotNumbersWithoutContract.includes(num)
+    );
+
+    if (missingPlotNumbers.length > 0 || plotNumbersWithoutContract.length > 0) {
+      const details: Array<{ row?: number; field: string; message: string }> = [];
+      for (const num of missingPlotNumbers) {
+        const row = items.findIndex((item) => item.plotNumber === num);
+        details.push({
+          row,
+          field: 'plotNumber',
+          message: `区画番号「${num}」はデータベースに存在しません`,
+        });
+      }
+      for (const num of plotNumbersWithoutContract) {
+        const row = items.findIndex((item) => item.plotNumber === num);
+        details.push({
+          row,
+          field: 'plotNumber',
+          message: `区画番号「${num}」に有効な契約区画が存在しません`,
+        });
+      }
+      throw new ValidationError('一括編集でエラーが発生しました', details);
+    }
+
+    // 4. トランザクションで一括更新
+    const updatedPlots = await prisma.$transaction(
+      async (tx) => {
+        const results: Array<{ row: number; id: string; plotNumber: string }> = [];
+
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i]!;
+          const contractPlotId = plotNumberToContractId.get(item.plotNumber)!;
+
+          // plotNumber を分離して updatePlotSchema 準拠の input にする
+          const { plotNumber, ...updateInput } = item;
+          void plotNumber;
+
+          try {
+            await updatePlotCore(tx, contractPlotId, updateInput as UpdatePlotRequest, req);
+
+            results.push({
+              row: i,
+              id: contractPlotId,
+              plotNumber: item.plotNumber,
+            });
+          } catch (error) {
+            if (error instanceof ValidationError) {
+              const details = error.details?.length
+                ? error.details.map((d) => ({ ...d, row: i }))
+                : [{ row: i, message: error.message }];
+              throw new ValidationError(`行 ${i} でエラー: ${error.message}`, details);
+            }
+            throw error;
+          }
+        }
+
+        return results;
+      },
+      {
+        maxWait: 10000,
+        timeout: 60000,
+      }
+    );
+
+    res.status(200).json({
+      success: true,
+      data: {
+        totalRequested: items.length,
+        updated: updatedPlots.length,
+        results: updatedPlots,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -18,6 +18,330 @@ import {
   recordEntityCreated,
 } from '../services/historyService';
 
+type Tx = Prisma.TransactionClient;
+
+/**
+ * 新規契約作成のトランザクション内処理
+ * bulkCreatePlots からも呼び出せるように外部化
+ */
+export async function createPlotCore(
+  tx: Tx,
+  input: CreatePlotRequest,
+  req: Request
+): Promise<{
+  contractPlotId: string;
+  physicalPlotId: string;
+  customerId: string;
+}> {
+  // 入力バリデーション
+  if (!input.contractPlot || !input.saleContract || !input.customer) {
+    throw new ValidationError('contractPlot, saleContract, customerは必須です');
+  }
+
+  if (!input.contractPlot.contractAreaSqm || input.contractPlot.contractAreaSqm <= 0) {
+    throw new ValidationError('契約面積は0より大きい値を指定してください');
+  }
+
+  // 1. PhysicalPlotの取得または作成
+  let physicalPlot;
+  if (input.physicalPlot.id) {
+    physicalPlot = await tx.physicalPlot.findUnique({
+      where: { id: input.physicalPlot.id, deleted_at: null },
+    });
+
+    if (!physicalPlot) {
+      throw new NotFoundError('指定された物理区画が見つかりません');
+    }
+  } else {
+    if (!input.physicalPlot.plotNumber || !input.physicalPlot.areaName) {
+      throw new ValidationError('新規物理区画作成時は plotNumber と areaName が必須です');
+    }
+
+    physicalPlot = await tx.physicalPlot.create({
+      data: {
+        plot_number: input.physicalPlot.plotNumber,
+        area_name: input.physicalPlot.areaName,
+        area_sqm: new Prisma.Decimal(input.physicalPlot.areaSqm || 3.6),
+        status: 'available',
+        notes: input.physicalPlot.notes || null,
+      },
+    });
+  }
+
+  // 2. 契約面積の妥当性検証
+  const validationResult = await validateContractArea(
+    tx as any,
+    physicalPlot.id,
+    input.contractPlot.contractAreaSqm
+  );
+
+  if (!validationResult.isValid) {
+    throw new ValidationError(validationResult.message || '契約面積の検証に失敗しました');
+  }
+
+  // 3. 顧客情報の作成
+  const customer = await tx.customer.create({
+    data: {
+      name: input.customer.name,
+      name_kana: input.customer.nameKana,
+      birth_date: input.customer.birthDate ? new Date(input.customer.birthDate) : null,
+      gender: input.customer.gender || null,
+      postal_code: input.customer.postalCode,
+      address: input.customer.address,
+      address_line_2: input.customer.addressLine2 || null,
+      registered_address: input.customer.registeredAddress || null,
+      phone_number: input.customer.phoneNumber,
+      fax_number: input.customer.faxNumber || null,
+      email: input.customer.email || null,
+      notes: input.customer.notes || null,
+    },
+  });
+
+  // 4. 勤務先情報の作成（オプション）
+  let workInfo: { id: string } | null = null;
+  if (input.workInfo) {
+    workInfo = await tx.workInfo.create({
+      data: {
+        customer_id: customer.id,
+        company_name: input.workInfo.companyName,
+        company_name_kana: input.workInfo.companyNameKana,
+        work_postal_code: input.workInfo.workPostalCode,
+        work_address: input.workInfo.workAddress,
+        work_phone_number: input.workInfo.workPhoneNumber,
+        dm_setting: input.workInfo.dmSetting as string as DmSetting,
+        address_type: input.workInfo.addressType as string as AddressType,
+        notes: input.workInfo.notes || null,
+      },
+    });
+  }
+
+  // 5. 請求情報の作成（オプション）
+  let billingInfo: { id: string } | null = null;
+  if (input.billingInfo) {
+    billingInfo = await tx.billingInfo.create({
+      data: {
+        customer_id: customer.id,
+        billing_type: input.billingInfo.billingType,
+        bank_name: input.billingInfo.bankName,
+        branch_name: input.billingInfo.branchName,
+        account_type: input.billingInfo.accountType,
+        account_number: input.billingInfo.accountNumber,
+        account_holder: input.billingInfo.accountHolder,
+      },
+    });
+  }
+
+  // 6. 契約区画の作成（販売契約情報を統合）
+  const contractPlot = await tx.contractPlot.create({
+    data: {
+      physical_plot_id: physicalPlot.id,
+      contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
+      location_description: input.contractPlot.locationDescription || null,
+      burial_capacity: input.collectiveBurial?.burialCapacity ?? null,
+      validity_period_years: input.collectiveBurial?.validityPeriodYears ?? null,
+      contract_date: new Date(input.saleContract.contractDate),
+      price: input.saleContract.price,
+      payment_status: input.saleContract.paymentStatus || PaymentStatus.unpaid,
+      reservation_date: input.saleContract.reservationDate
+        ? new Date(input.saleContract.reservationDate)
+        : null,
+      acceptance_number: input.saleContract.acceptanceNumber || null,
+      acceptance_date: input.saleContract.acceptanceDate
+        ? new Date(input.saleContract.acceptanceDate)
+        : null,
+      staff_in_charge: input.saleContract.staffInCharge || null,
+      agent_name: input.saleContract.agentName || null,
+      permit_number: input.saleContract.permitNumber || null,
+      permit_date: input.saleContract.permitDate ? new Date(input.saleContract.permitDate) : null,
+      start_date: input.saleContract.startDate ? new Date(input.saleContract.startDate) : null,
+      uncollected_amount: input.saleContract.uncollectedAmount ?? 0,
+      notes: input.saleContract.notes || null,
+    },
+  });
+
+  // 6.5. 合祀情報の作成
+  let collectiveBurial: { id: string } | null = null;
+  if (input.collectiveBurial) {
+    collectiveBurial = await tx.collectiveBurial.create({
+      data: {
+        contract_plot_id: contractPlot.id,
+        burial_capacity: input.collectiveBurial.burialCapacity,
+        validity_period_years: input.collectiveBurial.validityPeriodYears,
+        billing_amount: input.collectiveBurial.billingAmount ?? null,
+        notes: input.collectiveBurial.notes || null,
+      },
+    });
+  }
+
+  // 7. 顧客役割の作成
+  const createdRoles: { id: string; role: string; customer_id: string }[] = [];
+  if (input.saleContract.roles && input.saleContract.roles.length > 0) {
+    for (const roleData of input.saleContract.roles) {
+      const created = await tx.saleContractRole.create({
+        data: {
+          contract_plot_id: contractPlot.id,
+          customer_id: roleData.customerId || customer.id,
+          role: roleData.role,
+          role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
+          role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
+          notes: roleData.notes || null,
+        },
+      });
+      createdRoles.push({
+        id: created.id,
+        role: created.role,
+        customer_id: created.customer_id,
+      });
+    }
+  } else {
+    const created = await tx.saleContractRole.create({
+      data: {
+        contract_plot_id: contractPlot.id,
+        customer_id: customer.id,
+        role: (input.saleContract.customerRole as ContractRole) || ContractRole.contractor,
+      },
+    });
+    createdRoles.push({ id: created.id, role: created.role, customer_id: created.customer_id });
+  }
+
+  // 8. 使用料情報の作成
+  let usageFee: { id: string } | null = null;
+  if (input.usageFee) {
+    usageFee = await tx.usageFee.create({
+      data: {
+        contract_plot_id: contractPlot.id,
+        calculation_type: input.usageFee.calculationType || '',
+        tax_type: input.usageFee.taxType || '',
+        billing_type: input.usageFee.billingType || 'onetime',
+        billing_years: input.usageFee.billingYears || '1',
+        usage_fee: String(input.usageFee.usageFee ?? ''),
+        area: String(input.usageFee.area ?? ''),
+        unit_price: String(input.usageFee.unitPrice ?? ''),
+        payment_method: input.usageFee.paymentMethod || '',
+      },
+    });
+  }
+
+  // 9. 管理料情報の作成
+  let managementFee: { id: string } | null = null;
+  if (input.managementFee) {
+    managementFee = await tx.managementFee.create({
+      data: {
+        contract_plot_id: contractPlot.id,
+        calculation_type: input.managementFee.calculationType || '',
+        tax_type: input.managementFee.taxType || '',
+        billing_type: input.managementFee.billingType || '',
+        billing_years: String(input.managementFee.billingYears ?? ''),
+        area: String(input.managementFee.area ?? ''),
+        billing_month: input.managementFee.billingMonth || '',
+        management_fee: String(input.managementFee.managementFee ?? ''),
+        unit_price: String(input.managementFee.unitPrice ?? ''),
+        last_billing_month: input.managementFee.lastBillingMonth || '',
+        payment_method: input.managementFee.paymentMethod || '',
+      },
+    });
+  }
+
+  // 10. 物理区画のステータス更新
+  await updatePhysicalPlotStatus(tx as any, physicalPlot.id);
+
+  // 11. 履歴の自動記録
+  if (!input.physicalPlot.id) {
+    await recordEntityCreated(tx, {
+      entityType: 'PhysicalPlot',
+      entityId: physicalPlot.id,
+      physicalPlotId: physicalPlot.id,
+      afterRecord: {
+        id: physicalPlot.id,
+        plot_number: physicalPlot.plot_number,
+        area_name: physicalPlot.area_name,
+        area_sqm: physicalPlot.area_sqm.toString(),
+        status: physicalPlot.status,
+        notes: physicalPlot.notes,
+      },
+      req,
+    });
+  }
+  await recordContractPlotCreated(tx, contractPlot, req);
+  await recordCustomerCreated(tx, customer, contractPlot.id, physicalPlot.id, req);
+  if (workInfo) {
+    await recordEntityCreated(tx, {
+      entityType: 'WorkInfo',
+      entityId: workInfo.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: { id: workInfo.id, customer_id: customer.id, ...input.workInfo! },
+      req,
+    });
+  }
+  if (billingInfo) {
+    await recordEntityCreated(tx, {
+      entityType: 'BillingInfo',
+      entityId: billingInfo.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: { id: billingInfo.id, customer_id: customer.id, ...input.billingInfo! },
+      req,
+    });
+  }
+  if (usageFee) {
+    await recordEntityCreated(tx, {
+      entityType: 'UsageFee',
+      entityId: usageFee.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: { id: usageFee.id, ...input.usageFee! },
+      req,
+    });
+  }
+  if (managementFee) {
+    await recordEntityCreated(tx, {
+      entityType: 'ManagementFee',
+      entityId: managementFee.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: { id: managementFee.id, ...input.managementFee! },
+      req,
+    });
+  }
+  if (collectiveBurial) {
+    await recordEntityCreated(tx, {
+      entityType: 'CollectiveBurial',
+      entityId: collectiveBurial.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: {
+        id: collectiveBurial.id,
+        burial_capacity: input.collectiveBurial!.burialCapacity,
+        validity_period_years: input.collectiveBurial!.validityPeriodYears,
+        billing_amount: input.collectiveBurial!.billingAmount ?? null,
+        notes: input.collectiveBurial!.notes || null,
+      },
+      req,
+    });
+  }
+  for (const role of createdRoles) {
+    await recordEntityCreated(tx, {
+      entityType: 'SaleContractRole',
+      entityId: role.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: {
+        id: role.id,
+        role: role.role,
+        customer_id: role.customer_id,
+      },
+      req,
+    });
+  }
+
+  return {
+    contractPlotId: contractPlot.id,
+    physicalPlotId: physicalPlot.id,
+    customerId: customer.id,
+  };
+}
+
 /**
  * 新規契約作成（ContractPlot + SaleContract + Customer）
  * POST /api/v1/plots
@@ -30,330 +354,13 @@ export const createPlot = async (
   try {
     const input: CreatePlotRequest = req.body;
 
-    // 入力バリデーション
-    if (!input.contractPlot || !input.saleContract || !input.customer) {
-      throw new ValidationError('contractPlot, saleContract, customerは必須です');
-    }
-
-    // 契約面積のバリデーション
-    if (!input.contractPlot.contractAreaSqm || input.contractPlot.contractAreaSqm <= 0) {
-      throw new ValidationError('契約面積は0より大きい値を指定してください');
-    }
-
-    // トランザクション処理
     const result = await prisma.$transaction(async (tx) => {
-      // 1. PhysicalPlotの取得または作成
-      let physicalPlot;
-      if (input.physicalPlot.id) {
-        // 既存の物理区画を取得
-        physicalPlot = await tx.physicalPlot.findUnique({
-          where: { id: input.physicalPlot.id, deleted_at: null },
-        });
-
-        if (!physicalPlot) {
-          throw new NotFoundError('指定された物理区画が見つかりません');
-        }
-      } else {
-        // 新規物理区画を作成
-        if (!input.physicalPlot.plotNumber || !input.physicalPlot.areaName) {
-          throw new ValidationError('新規物理区画作成時は plotNumber と areaName が必須です');
-        }
-
-        physicalPlot = await tx.physicalPlot.create({
-          data: {
-            plot_number: input.physicalPlot.plotNumber,
-            area_name: input.physicalPlot.areaName,
-            area_sqm: new Prisma.Decimal(input.physicalPlot.areaSqm || 3.6),
-            status: 'available', // 初期ステータス
-            notes: input.physicalPlot.notes || null,
-          },
-        });
-      }
-
-      // 2. 契約面積の妥当性検証
-      const validationResult = await validateContractArea(
-        tx as any,
-        physicalPlot.id,
-        input.contractPlot.contractAreaSqm
-      );
-
-      if (!validationResult.isValid) {
-        throw new ValidationError(validationResult.message || '契約面積の検証に失敗しました');
-      }
-
-      // 3. 顧客情報の作成
-      const customer = await tx.customer.create({
-        data: {
-          name: input.customer.name,
-          name_kana: input.customer.nameKana,
-          birth_date: input.customer.birthDate ? new Date(input.customer.birthDate) : null,
-          gender: input.customer.gender || null,
-          postal_code: input.customer.postalCode,
-          address: input.customer.address,
-          address_line_2: input.customer.addressLine2 || null,
-          registered_address: input.customer.registeredAddress || null,
-          phone_number: input.customer.phoneNumber,
-          fax_number: input.customer.faxNumber || null,
-          email: input.customer.email || null,
-          notes: input.customer.notes || null,
-        },
-      });
-
-      // 4. 勤務先情報の作成（オプション）
-      let workInfo: { id: string } | null = null;
-      if (input.workInfo) {
-        workInfo = await tx.workInfo.create({
-          data: {
-            customer_id: customer.id,
-            company_name: input.workInfo.companyName,
-            company_name_kana: input.workInfo.companyNameKana,
-            work_postal_code: input.workInfo.workPostalCode,
-            work_address: input.workInfo.workAddress,
-            work_phone_number: input.workInfo.workPhoneNumber,
-            dm_setting: input.workInfo.dmSetting as string as DmSetting,
-            address_type: input.workInfo.addressType as string as AddressType,
-            notes: input.workInfo.notes || null,
-          },
-        });
-      }
-
-      // 5. 請求情報の作成（オプション）
-      let billingInfo: { id: string } | null = null;
-      if (input.billingInfo) {
-        billingInfo = await tx.billingInfo.create({
-          data: {
-            customer_id: customer.id,
-            billing_type: input.billingInfo.billingType,
-            bank_name: input.billingInfo.bankName,
-            branch_name: input.billingInfo.branchName,
-            account_type: input.billingInfo.accountType,
-            account_number: input.billingInfo.accountNumber,
-            account_holder: input.billingInfo.accountHolder,
-          },
-        });
-      }
-
-      // 6. 契約区画の作成（販売契約情報を統合）
-      const contractPlot = await tx.contractPlot.create({
-        data: {
-          physical_plot_id: physicalPlot.id,
-          contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
-          location_description: input.contractPlot.locationDescription || null,
-          // 合祀設定
-          burial_capacity: input.collectiveBurial?.burialCapacity ?? null,
-          validity_period_years: input.collectiveBurial?.validityPeriodYears ?? null,
-          // 販売契約情報（ContractPlotに統合済み）
-          contract_date: new Date(input.saleContract.contractDate),
-          price: input.saleContract.price,
-          payment_status: input.saleContract.paymentStatus || PaymentStatus.unpaid,
-          reservation_date: input.saleContract.reservationDate
-            ? new Date(input.saleContract.reservationDate)
-            : null,
-          acceptance_number: input.saleContract.acceptanceNumber || null,
-          acceptance_date: input.saleContract.acceptanceDate
-            ? new Date(input.saleContract.acceptanceDate)
-            : null,
-          staff_in_charge: input.saleContract.staffInCharge || null,
-          agent_name: input.saleContract.agentName || null,
-          permit_number: input.saleContract.permitNumber || null,
-          permit_date: input.saleContract.permitDate
-            ? new Date(input.saleContract.permitDate)
-            : null,
-          start_date: input.saleContract.startDate ? new Date(input.saleContract.startDate) : null,
-          uncollected_amount: input.saleContract.uncollectedAmount ?? 0,
-          notes: input.saleContract.notes || null,
-        },
-      });
-
-      // 6.5. 合祀情報の作成（合祀設定がある場合）
-      let collectiveBurial: { id: string } | null = null;
-      if (input.collectiveBurial) {
-        collectiveBurial = await tx.collectiveBurial.create({
-          data: {
-            contract_plot_id: contractPlot.id,
-            burial_capacity: input.collectiveBurial.burialCapacity,
-            validity_period_years: input.collectiveBurial.validityPeriodYears,
-            billing_amount: input.collectiveBurial.billingAmount ?? null,
-            notes: input.collectiveBurial.notes || null,
-          },
-        });
-      }
-
-      // 7. 契約における顧客役割の作成
-      // 新方式: roles配列が指定されている場合
-      const createdRoles: { id: string; role: string; customer_id: string }[] = [];
-      if (input.saleContract.roles && input.saleContract.roles.length > 0) {
-        for (const roleData of input.saleContract.roles) {
-          const created = await tx.saleContractRole.create({
-            data: {
-              contract_plot_id: contractPlot.id, // sale_contract_id → contract_plot_idに変更
-              customer_id: roleData.customerId || customer.id, // 指定がなければ作成した顧客を使用
-              role: roleData.role,
-              role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
-              role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
-              notes: roleData.notes || null,
-            },
-          });
-          createdRoles.push({
-            id: created.id,
-            role: created.role,
-            customer_id: created.customer_id,
-          });
-        }
-      } else {
-        // 旧方式（後方互換性）: customerとcustomerRoleから1つの役割を作成
-        const created = await tx.saleContractRole.create({
-          data: {
-            contract_plot_id: contractPlot.id, // sale_contract_id → contract_plot_idに変更
-            customer_id: customer.id,
-            role: (input.saleContract.customerRole as ContractRole) || ContractRole.contractor,
-          },
-        });
-        createdRoles.push({ id: created.id, role: created.role, customer_id: created.customer_id });
-      }
-
-      // 8. 使用料情報の作成（オプション）
-      let usageFee: { id: string } | null = null;
-      if (input.usageFee) {
-        usageFee = await tx.usageFee.create({
-          data: {
-            contract_plot_id: contractPlot.id,
-            calculation_type: input.usageFee.calculationType || '',
-            tax_type: input.usageFee.taxType || '',
-            billing_type: input.usageFee.billingType || 'onetime',
-            billing_years: input.usageFee.billingYears || '1',
-            usage_fee: String(input.usageFee.usageFee ?? ''),
-            area: String(input.usageFee.area ?? ''),
-            unit_price: String(input.usageFee.unitPrice ?? ''),
-            payment_method: input.usageFee.paymentMethod || '',
-          },
-        });
-      }
-
-      // 9. 管理料情報の作成（オプション）
-      let managementFee: { id: string } | null = null;
-      if (input.managementFee) {
-        managementFee = await tx.managementFee.create({
-          data: {
-            contract_plot_id: contractPlot.id,
-            calculation_type: input.managementFee.calculationType || '',
-            tax_type: input.managementFee.taxType || '',
-            billing_type: input.managementFee.billingType || '',
-            billing_years: String(input.managementFee.billingYears ?? ''),
-            area: String(input.managementFee.area ?? ''),
-            billing_month: input.managementFee.billingMonth || '',
-            management_fee: String(input.managementFee.managementFee ?? ''),
-            unit_price: String(input.managementFee.unitPrice ?? ''),
-            last_billing_month: input.managementFee.lastBillingMonth || '',
-            payment_method: input.managementFee.paymentMethod || '',
-          },
-        });
-      }
-
-      // 9. 物理区画のステータス更新
-      await updatePhysicalPlotStatus(tx as any, physicalPlot.id);
-
-      // 10. 履歴の自動記録
-      // 新規物理区画を作成した場合のみ PhysicalPlot の CREATE 履歴を残す
-      if (!input.physicalPlot.id) {
-        await recordEntityCreated(tx, {
-          entityType: 'PhysicalPlot',
-          entityId: physicalPlot.id,
-          physicalPlotId: physicalPlot.id,
-          afterRecord: {
-            id: physicalPlot.id,
-            plot_number: physicalPlot.plot_number,
-            area_name: physicalPlot.area_name,
-            area_sqm: physicalPlot.area_sqm.toString(),
-            status: physicalPlot.status,
-            notes: physicalPlot.notes,
-          },
-          req,
-        });
-      }
-      await recordContractPlotCreated(tx, contractPlot, req);
-      await recordCustomerCreated(tx, customer, contractPlot.id, physicalPlot.id, req);
-      if (workInfo) {
-        await recordEntityCreated(tx, {
-          entityType: 'WorkInfo',
-          entityId: workInfo.id,
-          physicalPlotId: physicalPlot.id,
-          contractPlotId: contractPlot.id,
-          afterRecord: { id: workInfo.id, customer_id: customer.id, ...input.workInfo! },
-          req,
-        });
-      }
-      if (billingInfo) {
-        await recordEntityCreated(tx, {
-          entityType: 'BillingInfo',
-          entityId: billingInfo.id,
-          physicalPlotId: physicalPlot.id,
-          contractPlotId: contractPlot.id,
-          afterRecord: { id: billingInfo.id, customer_id: customer.id, ...input.billingInfo! },
-          req,
-        });
-      }
-      if (usageFee) {
-        await recordEntityCreated(tx, {
-          entityType: 'UsageFee',
-          entityId: usageFee.id,
-          physicalPlotId: physicalPlot.id,
-          contractPlotId: contractPlot.id,
-          afterRecord: { id: usageFee.id, ...input.usageFee! },
-          req,
-        });
-      }
-      if (managementFee) {
-        await recordEntityCreated(tx, {
-          entityType: 'ManagementFee',
-          entityId: managementFee.id,
-          physicalPlotId: physicalPlot.id,
-          contractPlotId: contractPlot.id,
-          afterRecord: { id: managementFee.id, ...input.managementFee! },
-          req,
-        });
-      }
-      if (collectiveBurial) {
-        await recordEntityCreated(tx, {
-          entityType: 'CollectiveBurial',
-          entityId: collectiveBurial.id,
-          physicalPlotId: physicalPlot.id,
-          contractPlotId: contractPlot.id,
-          afterRecord: {
-            id: collectiveBurial.id,
-            burial_capacity: input.collectiveBurial!.burialCapacity,
-            validity_period_years: input.collectiveBurial!.validityPeriodYears,
-            billing_amount: input.collectiveBurial!.billingAmount ?? null,
-            notes: input.collectiveBurial!.notes || null,
-          },
-          req,
-        });
-      }
-      for (const role of createdRoles) {
-        await recordEntityCreated(tx, {
-          entityType: 'SaleContractRole',
-          entityId: role.id,
-          physicalPlotId: physicalPlot.id,
-          contractPlotId: contractPlot.id,
-          afterRecord: {
-            id: role.id,
-            role: role.role,
-            customer_id: role.customer_id,
-          },
-          req,
-        });
-      }
-
-      return {
-        contractPlot,
-        customer,
-        physicalPlot,
-      };
+      return createPlotCore(tx, input, req);
     });
 
     // 作成完了後、詳細情報を取得して返却
     const createdContractPlot = await prisma.contractPlot.findUnique({
-      where: { id: result.contractPlot.id },
+      where: { id: result.contractPlotId },
       include: {
         physicalPlot: true,
         saleContractRoles: {
@@ -373,7 +380,6 @@ export const createPlot = async (
       },
     });
 
-    // 最初の役割を取得（後方互換性のため）
     const firstRole = createdContractPlot?.saleContractRoles?.[0];
     const firstCustomer = firstRole?.customer;
 
@@ -384,7 +390,6 @@ export const createPlot = async (
         contractAreaSqm: createdContractPlot?.contract_area_sqm.toNumber(),
         locationDescription: createdContractPlot?.location_description,
 
-        // 販売契約情報（ContractPlotに統合済み）
         contractDate: createdContractPlot?.contract_date,
         price: createdContractPlot?.price,
         paymentStatus: createdContractPlot?.payment_status,
@@ -405,7 +410,6 @@ export const createPlot = async (
           status: createdContractPlot?.physicalPlot.status,
         },
 
-        // 後方互換性: 最初の顧客の情報
         primaryCustomer: firstCustomer
           ? {
               id: firstCustomer.id,
@@ -417,7 +421,6 @@ export const createPlot = async (
             }
           : null,
 
-        // 全ての役割と顧客情報
         roles: createdContractPlot?.saleContractRoles?.map((role) => ({
           id: role.id,
           role: role.role,

--- a/src/plots/controllers/index.ts
+++ b/src/plots/controllers/index.ts
@@ -7,6 +7,7 @@ export { getPlots } from './getPlots';
 export { getPlotById } from './getPlotById';
 export { createPlot } from './createPlot';
 export { bulkCreatePlots } from './bulkCreatePlots';
+export { bulkUpdatePlots } from './bulkUpdatePlots';
 export { updatePlot } from './updatePlot';
 export { deletePlot } from './deletePlot';
 export { getPlotContracts } from './getPlotContracts';

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -20,6 +20,1135 @@ import {
 } from '../services/historyService';
 import { updateCollectiveBurialCount } from '../../collective-burials/utils';
 
+type Tx = Prisma.TransactionClient;
+
+/**
+ * 契約区画更新のトランザクション内処理
+ * bulkUpdatePlots からも呼び出せるように外部化
+ */
+export async function updatePlotCore(
+  tx: Tx,
+  id: string,
+  input: UpdatePlotRequest,
+  req: Request
+): Promise<void> {
+  // 1. 既存のContractPlotを取得
+  const existingContractPlot = await tx.contractPlot.findUnique({
+    where: { id, deleted_at: null },
+    include: {
+      physicalPlot: true,
+      saleContractRoles: {
+        where: { deleted_at: null },
+        include: {
+          customer: {
+            include: {
+              workInfo: true,
+              billingInfo: true,
+            },
+          },
+        },
+      },
+      usageFee: true,
+      managementFee: true,
+      collectiveBurial: true,
+    },
+  });
+
+  if (!existingContractPlot) {
+    throw new NotFoundError('指定された契約区画が見つかりません');
+  }
+
+  const physicalPlotId = existingContractPlot.physical_plot_id;
+  const oldContractArea = existingContractPlot.contract_area_sqm.toNumber();
+
+  // 1.5. 物理区画情報の更新
+  const physicalPlotInput = input.physicalPlot;
+  if (physicalPlotInput) {
+    const ppUpdateData: Record<string, unknown> = {};
+    if (physicalPlotInput.plotNumber !== undefined)
+      ppUpdateData['plot_number'] = physicalPlotInput.plotNumber;
+    if (physicalPlotInput.areaName !== undefined)
+      ppUpdateData['area_name'] = physicalPlotInput.areaName;
+    if (physicalPlotInput.areaSqm !== undefined)
+      ppUpdateData['area_sqm'] = new Prisma.Decimal(physicalPlotInput.areaSqm);
+    if (physicalPlotInput.status !== undefined) ppUpdateData['status'] = physicalPlotInput.status;
+    if (physicalPlotInput.notes !== undefined) ppUpdateData['notes'] = physicalPlotInput.notes;
+
+    if (Object.keys(ppUpdateData).length > 0) {
+      const beforePp = existingContractPlot.physicalPlot;
+      const updatedPp = await tx.physicalPlot.update({
+        where: { id: physicalPlotId },
+        data: ppUpdateData,
+      });
+      await recordEntityUpdated(tx, {
+        entityType: 'PhysicalPlot',
+        entityId: physicalPlotId,
+        physicalPlotId,
+        beforeRecord: {
+          plot_number: beforePp.plot_number,
+          area_name: beforePp.area_name,
+          area_sqm: beforePp.area_sqm.toString(),
+          status: beforePp.status,
+          notes: beforePp.notes,
+        },
+        afterRecord: {
+          plot_number: updatedPp.plot_number,
+          area_name: updatedPp.area_name,
+          area_sqm: updatedPp.area_sqm.toString(),
+          status: updatedPp.status,
+          notes: updatedPp.notes,
+        },
+        req,
+      });
+    }
+  }
+
+  // 2. ContractPlotの更新
+  const updateData: any = {};
+
+  if (input.contractPlot) {
+    if (input.contractPlot.contractAreaSqm !== undefined) {
+      const newAreaSqm = input.contractPlot.contractAreaSqm;
+
+      const otherContracts = await tx.contractPlot.findMany({
+        where: {
+          physical_plot_id: physicalPlotId,
+          id: { not: id },
+          deleted_at: null,
+        },
+      });
+
+      const otherContractsTotal = otherContracts.reduce(
+        (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
+        0
+      );
+
+      const totalAfterUpdate = otherContractsTotal + newAreaSqm;
+      const physicalPlotArea = existingContractPlot.physicalPlot.area_sqm.toNumber();
+
+      if (totalAfterUpdate > physicalPlotArea) {
+        throw new ValidationError(
+          `契約面積の合計が物理区画の面積を超えています（物理区画: ${physicalPlotArea}㎡、合計: ${totalAfterUpdate}㎡）`
+        );
+      }
+
+      updateData.contract_area_sqm = new Prisma.Decimal(newAreaSqm);
+    }
+
+    if (input.contractPlot.locationDescription !== undefined) {
+      updateData.location_description = input.contractPlot.locationDescription;
+    }
+  }
+
+  if (input.saleContract) {
+    if (input.saleContract.contractDate !== undefined) {
+      updateData.contract_date = new Date(input.saleContract.contractDate);
+    }
+    if (input.saleContract.price !== undefined) {
+      updateData.price = new Prisma.Decimal(input.saleContract.price);
+    }
+    if (input.saleContract.paymentStatus !== undefined) {
+      updateData.payment_status = input.saleContract.paymentStatus;
+    }
+    if (input.saleContract.reservationDate !== undefined) {
+      updateData.reservation_date = input.saleContract.reservationDate
+        ? new Date(input.saleContract.reservationDate)
+        : null;
+    }
+    if (input.saleContract.acceptanceNumber !== undefined) {
+      updateData.acceptance_number = input.saleContract.acceptanceNumber;
+    }
+    if (input.saleContract.acceptanceDate !== undefined) {
+      updateData.acceptance_date = input.saleContract.acceptanceDate
+        ? new Date(input.saleContract.acceptanceDate)
+        : null;
+    }
+    if (input.saleContract.staffInCharge !== undefined) {
+      updateData.staff_in_charge = input.saleContract.staffInCharge;
+    }
+    if (input.saleContract.agentName !== undefined) {
+      updateData.agent_name = input.saleContract.agentName;
+    }
+    if (input.saleContract.permitNumber !== undefined) {
+      updateData.permit_number = input.saleContract.permitNumber || null;
+    }
+    if (input.saleContract.permitDate !== undefined) {
+      updateData.permit_date = input.saleContract.permitDate
+        ? new Date(input.saleContract.permitDate)
+        : null;
+    }
+    if (input.saleContract.startDate !== undefined) {
+      updateData.start_date = input.saleContract.startDate
+        ? new Date(input.saleContract.startDate)
+        : null;
+    }
+    if (input.saleContract.uncollectedAmount !== undefined) {
+      updateData.uncollected_amount = input.saleContract.uncollectedAmount;
+    }
+    if (input.saleContract.notes !== undefined) {
+      updateData.notes = input.saleContract.notes;
+    }
+  }
+
+  if (Object.keys(updateData).length > 0) {
+    await tx.contractPlot.update({
+      where: { id },
+      data: updateData,
+    });
+  }
+
+  // 3. 顧客役割の更新
+  if (input.saleContract?.roles !== undefined) {
+    const existingRoles = await tx.saleContractRole.findMany({
+      where: {
+        contract_plot_id: id,
+        deleted_at: null,
+      },
+    });
+
+    await tx.saleContractRole.updateMany({
+      where: {
+        contract_plot_id: id,
+        deleted_at: null,
+      },
+      data: {
+        deleted_at: new Date(),
+      },
+    });
+    for (const oldRole of existingRoles) {
+      await recordEntityDeleted(tx, {
+        entityType: 'SaleContractRole',
+        entityId: oldRole.id,
+        physicalPlotId,
+        contractPlotId: id,
+        beforeRecord: {
+          id: oldRole.id,
+          role: oldRole.role,
+          customer_id: oldRole.customer_id,
+        },
+        req,
+      });
+    }
+
+    for (const roleData of input.saleContract.roles) {
+      if (!roleData.customerId) {
+        throw new ValidationError('役割更新時は customerId が必須です');
+      }
+
+      const created = await tx.saleContractRole.create({
+        data: {
+          contract_plot_id: existingContractPlot.id,
+          customer_id: roleData.customerId,
+          role: roleData.role,
+          role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
+          role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
+          notes: roleData.notes || null,
+        },
+      });
+      await recordEntityCreated(tx, {
+        entityType: 'SaleContractRole',
+        entityId: created.id,
+        physicalPlotId,
+        contractPlotId: id,
+        afterRecord: {
+          id: created.id,
+          role: created.role,
+          customer_id: created.customer_id,
+        },
+        req,
+      });
+    }
+  }
+
+  // 4. Customerの更新
+  if (input.customer) {
+    const primaryRole = existingContractPlot.saleContractRoles?.find(
+      (role: any) => role.role === 'contractor'
+    );
+    const customerId = primaryRole?.customer.id;
+
+    if (customerId) {
+      const customerUpdateData: any = {};
+
+      if (input.customer.name !== undefined) customerUpdateData.name = input.customer.name;
+      if (input.customer.nameKana !== undefined)
+        customerUpdateData.name_kana = input.customer.nameKana;
+      if (input.customer.birthDate !== undefined) {
+        customerUpdateData.birth_date = input.customer.birthDate
+          ? new Date(input.customer.birthDate)
+          : null;
+      }
+      if (input.customer.gender !== undefined) customerUpdateData.gender = input.customer.gender;
+      if (input.customer.postalCode !== undefined)
+        customerUpdateData.postal_code = input.customer.postalCode;
+      if (input.customer.address !== undefined) customerUpdateData.address = input.customer.address;
+      if (input.customer.addressLine2 !== undefined)
+        customerUpdateData.address_line_2 = input.customer.addressLine2;
+      if (input.customer.registeredAddress !== undefined)
+        customerUpdateData.registered_address = input.customer.registeredAddress;
+      if (input.customer.phoneNumber !== undefined)
+        customerUpdateData.phone_number = input.customer.phoneNumber;
+      if (input.customer.faxNumber !== undefined)
+        customerUpdateData.fax_number = input.customer.faxNumber;
+      if (input.customer.email !== undefined) customerUpdateData.email = input.customer.email;
+      if (input.customer.notes !== undefined) customerUpdateData.notes = input.customer.notes;
+
+      if (Object.keys(customerUpdateData).length > 0) {
+        await tx.customer.update({
+          where: { id: customerId },
+          data: customerUpdateData,
+        });
+      }
+
+      // 5. WorkInfoの更新/作成/削除
+      if (input.workInfo !== undefined) {
+        const existingWorkInfo = primaryRole?.customer.workInfo;
+
+        if (input.workInfo === null) {
+          if (existingWorkInfo) {
+            await tx.workInfo.delete({
+              where: { id: existingWorkInfo.id },
+            });
+            await recordEntityDeleted(tx, {
+              entityType: 'WorkInfo',
+              entityId: existingWorkInfo.id,
+              physicalPlotId,
+              contractPlotId: id,
+              beforeRecord: {
+                id: existingWorkInfo.id,
+                company_name: existingWorkInfo.company_name,
+                work_address: existingWorkInfo.work_address,
+                work_phone_number: existingWorkInfo.work_phone_number,
+              },
+              req,
+            });
+          }
+        } else {
+          const workInfoData: any = {};
+          if (input.workInfo.companyName !== undefined)
+            workInfoData.company_name = input.workInfo.companyName;
+          if (input.workInfo.companyNameKana !== undefined)
+            workInfoData.company_name_kana = input.workInfo.companyNameKana;
+          if (input.workInfo.workPostalCode !== undefined)
+            workInfoData.work_postal_code = input.workInfo.workPostalCode;
+          if (input.workInfo.workAddress !== undefined)
+            workInfoData.work_address = input.workInfo.workAddress;
+          if (input.workInfo.workPhoneNumber !== undefined)
+            workInfoData.work_phone_number = input.workInfo.workPhoneNumber;
+          if (input.workInfo.dmSetting !== undefined)
+            workInfoData.dm_setting = input.workInfo.dmSetting;
+          if (input.workInfo.addressType !== undefined)
+            workInfoData.address_type = input.workInfo.addressType;
+          if (input.workInfo.notes !== undefined) workInfoData.notes = input.workInfo.notes;
+
+          if (Object.keys(workInfoData).length > 0) {
+            if (existingWorkInfo) {
+              const updated = await tx.workInfo.update({
+                where: { id: existingWorkInfo.id },
+                data: workInfoData,
+              });
+              await recordEntityUpdated(tx, {
+                entityType: 'WorkInfo',
+                entityId: existingWorkInfo.id,
+                physicalPlotId,
+                contractPlotId: id,
+                beforeRecord: {
+                  company_name: existingWorkInfo.company_name,
+                  company_name_kana: existingWorkInfo.company_name_kana,
+                  work_postal_code: existingWorkInfo.work_postal_code,
+                  work_address: existingWorkInfo.work_address,
+                  work_phone_number: existingWorkInfo.work_phone_number,
+                  dm_setting: existingWorkInfo.dm_setting,
+                  address_type: existingWorkInfo.address_type,
+                  notes: existingWorkInfo.notes,
+                },
+                afterRecord: {
+                  company_name: updated.company_name,
+                  company_name_kana: updated.company_name_kana,
+                  work_postal_code: updated.work_postal_code,
+                  work_address: updated.work_address,
+                  work_phone_number: updated.work_phone_number,
+                  dm_setting: updated.dm_setting,
+                  address_type: updated.address_type,
+                  notes: updated.notes,
+                },
+                req,
+              });
+            } else {
+              const created = await tx.workInfo.create({
+                data: {
+                  customer_id: customerId,
+                  ...workInfoData,
+                },
+              });
+              await recordEntityCreated(tx, {
+                entityType: 'WorkInfo',
+                entityId: created.id,
+                physicalPlotId,
+                contractPlotId: id,
+                afterRecord: {
+                  id: created.id,
+                  customer_id: customerId,
+                  ...workInfoData,
+                },
+                req,
+              });
+            }
+          }
+        }
+      }
+
+      // 6. BillingInfoの更新/作成/削除
+      if (input.billingInfo !== undefined) {
+        const existingBillingInfo = primaryRole?.customer.billingInfo;
+
+        if (input.billingInfo === null) {
+          if (existingBillingInfo) {
+            await tx.billingInfo.delete({
+              where: { id: existingBillingInfo.id },
+            });
+            await recordEntityDeleted(tx, {
+              entityType: 'BillingInfo',
+              entityId: existingBillingInfo.id,
+              physicalPlotId,
+              contractPlotId: id,
+              beforeRecord: {
+                id: existingBillingInfo.id,
+                billing_type: existingBillingInfo.billing_type,
+                bank_name: existingBillingInfo.bank_name,
+                branch_name: existingBillingInfo.branch_name,
+              },
+              req,
+            });
+          }
+        } else {
+          const billingInfoData: any = {};
+          if (input.billingInfo.billingType !== undefined)
+            billingInfoData.billing_type = input.billingInfo.billingType;
+          if (input.billingInfo.bankName !== undefined)
+            billingInfoData.bank_name = input.billingInfo.bankName;
+          if (input.billingInfo.branchName !== undefined)
+            billingInfoData.branch_name = input.billingInfo.branchName;
+          if (input.billingInfo.accountType !== undefined)
+            billingInfoData.account_type = input.billingInfo.accountType;
+          if (input.billingInfo.accountNumber !== undefined)
+            billingInfoData.account_number = input.billingInfo.accountNumber;
+          if (input.billingInfo.accountHolder !== undefined)
+            billingInfoData.account_holder = input.billingInfo.accountHolder;
+
+          if (Object.keys(billingInfoData).length > 0) {
+            if (existingBillingInfo) {
+              const updated = await tx.billingInfo.update({
+                where: { id: existingBillingInfo.id },
+                data: billingInfoData,
+              });
+              await recordEntityUpdated(tx, {
+                entityType: 'BillingInfo',
+                entityId: existingBillingInfo.id,
+                physicalPlotId,
+                contractPlotId: id,
+                beforeRecord: {
+                  billing_type: existingBillingInfo.billing_type,
+                  bank_name: existingBillingInfo.bank_name,
+                  branch_name: existingBillingInfo.branch_name,
+                  account_type: existingBillingInfo.account_type,
+                  account_number: existingBillingInfo.account_number,
+                  account_holder: existingBillingInfo.account_holder,
+                },
+                afterRecord: {
+                  billing_type: updated.billing_type,
+                  bank_name: updated.bank_name,
+                  branch_name: updated.branch_name,
+                  account_type: updated.account_type,
+                  account_number: updated.account_number,
+                  account_holder: updated.account_holder,
+                },
+                req,
+              });
+            } else {
+              const created = await tx.billingInfo.create({
+                data: {
+                  customer_id: customerId,
+                  ...billingInfoData,
+                },
+              });
+              await recordEntityCreated(tx, {
+                entityType: 'BillingInfo',
+                entityId: created.id,
+                physicalPlotId,
+                contractPlotId: id,
+                afterRecord: {
+                  id: created.id,
+                  customer_id: customerId,
+                  ...billingInfoData,
+                },
+                req,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 7. UsageFee
+  if (input.usageFee !== undefined) {
+    if (input.usageFee === null) {
+      if (existingContractPlot.usageFee) {
+        const before = existingContractPlot.usageFee;
+        await tx.usageFee.delete({
+          where: { id: before.id },
+        });
+        await recordEntityDeleted(tx, {
+          entityType: 'UsageFee',
+          entityId: before.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: before.id,
+            calculation_type: before.calculation_type,
+            tax_type: before.tax_type,
+            usage_fee: before.usage_fee,
+            area: before.area,
+            unit_price: before.unit_price,
+            payment_method: before.payment_method,
+          },
+          req,
+        });
+      }
+    } else {
+      const usageFeeData: any = {};
+      if (input.usageFee.calculationType !== undefined)
+        usageFeeData.calculation_type = input.usageFee.calculationType;
+      if (input.usageFee.taxType !== undefined) usageFeeData.tax_type = input.usageFee.taxType;
+      if (input.usageFee.usageFee !== undefined)
+        usageFeeData.usage_fee = String(input.usageFee.usageFee ?? '');
+      if (input.usageFee.area !== undefined) usageFeeData.area = String(input.usageFee.area ?? '');
+      if (input.usageFee.unitPrice !== undefined)
+        usageFeeData.unit_price = String(input.usageFee.unitPrice ?? '');
+      if (input.usageFee.paymentMethod !== undefined)
+        usageFeeData.payment_method = input.usageFee.paymentMethod;
+
+      if (Object.keys(usageFeeData).length > 0) {
+        if (existingContractPlot.usageFee) {
+          const before = existingContractPlot.usageFee;
+          const updated = await tx.usageFee.update({
+            where: { id: before.id },
+            data: usageFeeData,
+          });
+          await recordEntityUpdated(tx, {
+            entityType: 'UsageFee',
+            entityId: before.id,
+            physicalPlotId,
+            contractPlotId: id,
+            beforeRecord: {
+              calculation_type: before.calculation_type,
+              tax_type: before.tax_type,
+              usage_fee: before.usage_fee,
+              area: before.area,
+              unit_price: before.unit_price,
+              payment_method: before.payment_method,
+            },
+            afterRecord: {
+              calculation_type: updated.calculation_type,
+              tax_type: updated.tax_type,
+              usage_fee: updated.usage_fee,
+              area: updated.area,
+              unit_price: updated.unit_price,
+              payment_method: updated.payment_method,
+            },
+            req,
+          });
+        } else {
+          const created = await tx.usageFee.create({
+            data: {
+              contract_plot_id: id,
+              billing_type: 'onetime',
+              billing_years: '1',
+              ...usageFeeData,
+            },
+          });
+          await recordEntityCreated(tx, {
+            entityType: 'UsageFee',
+            entityId: created.id,
+            physicalPlotId,
+            contractPlotId: id,
+            afterRecord: {
+              id: created.id,
+              calculation_type: created.calculation_type,
+              tax_type: created.tax_type,
+              usage_fee: created.usage_fee,
+              area: created.area,
+              unit_price: created.unit_price,
+              payment_method: created.payment_method,
+            },
+            req,
+          });
+        }
+      }
+    }
+  }
+
+  // 8. ManagementFee
+  if (input.managementFee !== undefined) {
+    if (input.managementFee === null) {
+      if (existingContractPlot.managementFee) {
+        const before = existingContractPlot.managementFee;
+        await tx.managementFee.delete({
+          where: { id: before.id },
+        });
+        await recordEntityDeleted(tx, {
+          entityType: 'ManagementFee',
+          entityId: before.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: before.id,
+            management_fee: before.management_fee,
+            billing_type: before.billing_type,
+            billing_years: before.billing_years,
+          },
+          req,
+        });
+      }
+    } else {
+      const managementFeeData: any = {};
+      if (input.managementFee.calculationType !== undefined)
+        managementFeeData.calculation_type = input.managementFee.calculationType;
+      if (input.managementFee.taxType !== undefined)
+        managementFeeData.tax_type = input.managementFee.taxType;
+      if (input.managementFee.billingType !== undefined)
+        managementFeeData.billing_type = input.managementFee.billingType;
+      if (input.managementFee.billingYears !== undefined)
+        managementFeeData.billing_years = String(input.managementFee.billingYears ?? '');
+      if (input.managementFee.area !== undefined)
+        managementFeeData.area = String(input.managementFee.area ?? '');
+      if (input.managementFee.billingMonth !== undefined)
+        managementFeeData.billing_month = input.managementFee.billingMonth;
+      if (input.managementFee.managementFee !== undefined)
+        managementFeeData.management_fee = String(input.managementFee.managementFee ?? '');
+      if (input.managementFee.unitPrice !== undefined)
+        managementFeeData.unit_price = String(input.managementFee.unitPrice ?? '');
+      if (input.managementFee.lastBillingMonth !== undefined)
+        managementFeeData.last_billing_month = input.managementFee.lastBillingMonth;
+      if (input.managementFee.paymentMethod !== undefined)
+        managementFeeData.payment_method = input.managementFee.paymentMethod;
+
+      if (Object.keys(managementFeeData).length > 0) {
+        if (existingContractPlot.managementFee) {
+          const before = existingContractPlot.managementFee;
+          const updated = await tx.managementFee.update({
+            where: { id: before.id },
+            data: managementFeeData,
+          });
+          await recordEntityUpdated(tx, {
+            entityType: 'ManagementFee',
+            entityId: before.id,
+            physicalPlotId,
+            contractPlotId: id,
+            beforeRecord: {
+              calculation_type: before.calculation_type,
+              tax_type: before.tax_type,
+              billing_type: before.billing_type,
+              billing_years: before.billing_years,
+              area: before.area,
+              billing_month: before.billing_month,
+              management_fee: before.management_fee,
+              unit_price: before.unit_price,
+              last_billing_month: before.last_billing_month,
+              payment_method: before.payment_method,
+            },
+            afterRecord: {
+              calculation_type: updated.calculation_type,
+              tax_type: updated.tax_type,
+              billing_type: updated.billing_type,
+              billing_years: updated.billing_years,
+              area: updated.area,
+              billing_month: updated.billing_month,
+              management_fee: updated.management_fee,
+              unit_price: updated.unit_price,
+              last_billing_month: updated.last_billing_month,
+              payment_method: updated.payment_method,
+            },
+            req,
+          });
+        } else {
+          const created = await tx.managementFee.create({
+            data: {
+              contract_plot_id: id,
+              ...managementFeeData,
+            },
+          });
+          await recordEntityCreated(tx, {
+            entityType: 'ManagementFee',
+            entityId: created.id,
+            physicalPlotId,
+            contractPlotId: id,
+            afterRecord: {
+              id: created.id,
+              ...managementFeeData,
+            },
+            req,
+          });
+        }
+      }
+    }
+  }
+
+  // 9. CollectiveBurial
+  if (input.collectiveBurial !== undefined) {
+    const existingCB = existingContractPlot.collectiveBurial;
+
+    if (input.collectiveBurial === null) {
+      await tx.contractPlot.update({
+        where: { id },
+        data: {
+          burial_capacity: null,
+          validity_period_years: null,
+        },
+      });
+      if (existingCB && !existingCB.deleted_at) {
+        await tx.collectiveBurial.update({
+          where: { id: existingCB.id },
+          data: { deleted_at: new Date() },
+        });
+        await recordEntityDeleted(tx, {
+          entityType: 'CollectiveBurial',
+          entityId: existingCB.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: existingCB.id,
+            burial_capacity: existingCB.burial_capacity,
+            validity_period_years: existingCB.validity_period_years,
+            billing_amount: existingCB.billing_amount,
+            notes: existingCB.notes,
+          },
+          req,
+        });
+      }
+    } else {
+      await tx.contractPlot.update({
+        where: { id },
+        data: {
+          burial_capacity: input.collectiveBurial.burialCapacity,
+          validity_period_years: input.collectiveBurial.validityPeriodYears,
+        },
+      });
+
+      if (existingCB && !existingCB.deleted_at) {
+        const updated = await tx.collectiveBurial.update({
+          where: { id: existingCB.id },
+          data: {
+            burial_capacity: input.collectiveBurial.burialCapacity,
+            validity_period_years: input.collectiveBurial.validityPeriodYears,
+            billing_amount: input.collectiveBurial.billingAmount ?? existingCB.billing_amount,
+            notes:
+              input.collectiveBurial.notes !== undefined
+                ? input.collectiveBurial.notes || null
+                : existingCB.notes,
+          },
+        });
+        await recordEntityUpdated(tx, {
+          entityType: 'CollectiveBurial',
+          entityId: existingCB.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            burial_capacity: existingCB.burial_capacity,
+            validity_period_years: existingCB.validity_period_years,
+            billing_amount: existingCB.billing_amount,
+            notes: existingCB.notes,
+          },
+          afterRecord: {
+            burial_capacity: updated.burial_capacity,
+            validity_period_years: updated.validity_period_years,
+            billing_amount: updated.billing_amount,
+            notes: updated.notes,
+          },
+          req,
+        });
+      } else {
+        const cbCapacity = input.collectiveBurial.burialCapacity;
+        const cbPeriod = input.collectiveBurial.validityPeriodYears;
+        if (!cbCapacity || !cbPeriod) {
+          throw new ValidationError(
+            '新規合祀設定には burialCapacity と validityPeriodYears が必須です'
+          );
+        }
+
+        let cbCreated: { id: string };
+        if (existingCB?.deleted_at) {
+          cbCreated = await tx.collectiveBurial.update({
+            where: { id: existingCB.id },
+            data: {
+              burial_capacity: cbCapacity,
+              validity_period_years: cbPeriod,
+              billing_amount: input.collectiveBurial.billingAmount ?? null,
+              notes: input.collectiveBurial.notes || null,
+              deleted_at: null,
+            },
+          });
+        } else {
+          cbCreated = await tx.collectiveBurial.create({
+            data: {
+              contract_plot_id: id,
+              burial_capacity: cbCapacity,
+              validity_period_years: cbPeriod,
+              billing_amount: input.collectiveBurial.billingAmount ?? null,
+              notes: input.collectiveBurial.notes || null,
+            },
+          });
+        }
+        await recordEntityCreated(tx, {
+          entityType: 'CollectiveBurial',
+          entityId: cbCreated.id,
+          physicalPlotId,
+          contractPlotId: id,
+          afterRecord: {
+            id: cbCreated.id,
+            burial_capacity: cbCapacity,
+            validity_period_years: cbPeriod,
+            billing_amount: input.collectiveBurial.billingAmount ?? null,
+            notes: input.collectiveBurial.notes || null,
+          },
+          req,
+        });
+      }
+    }
+  }
+
+  // 10. 埋葬者の全置換
+  if (input.buriedPersons !== undefined) {
+    const existingBuriedPersons = await tx.buriedPerson.findMany({
+      where: { contract_plot_id: id, deleted_at: null },
+    });
+    const existingIds = existingBuriedPersons.map((bp) => bp.id);
+    const existingMap = new Map(existingBuriedPersons.map((bp) => [bp.id, bp]));
+    const inputIds = input.buriedPersons.filter((bp) => bp.id).map((bp) => bp.id as string);
+
+    const idsToDelete = existingIds.filter((eid) => !inputIds.includes(eid));
+    if (idsToDelete.length > 0) {
+      await tx.buriedPerson.updateMany({
+        where: { id: { in: idsToDelete } },
+        data: { deleted_at: new Date() },
+      });
+      for (const delId of idsToDelete) {
+        const before = existingMap.get(delId)!;
+        await recordEntityDeleted(tx, {
+          entityType: 'BuriedPerson',
+          entityId: delId,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: before.id,
+            name: before.name,
+            death_date: before.death_date?.toISOString() ?? null,
+            burial_date: before.burial_date?.toISOString() ?? null,
+          },
+          req,
+        });
+      }
+    }
+
+    for (const bp of input.buriedPersons) {
+      const bpData = {
+        name: bp.name,
+        name_kana: bp.nameKana || null,
+        relationship: bp.relationship || null,
+        birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
+        death_date: bp.deathDate ? new Date(bp.deathDate) : null,
+        age: bp.age ?? null,
+        gender: bp.gender || null,
+        burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
+        posthumous_name: bp.posthumousName || null,
+        report_date: bp.reportDate ? new Date(bp.reportDate) : null,
+        religion: bp.religion || null,
+        notes: bp.notes || null,
+      };
+
+      const serialize = (data: typeof bpData) => ({
+        name: data.name,
+        name_kana: data.name_kana,
+        relationship: data.relationship,
+        birth_date: data.birth_date?.toISOString() ?? null,
+        death_date: data.death_date?.toISOString() ?? null,
+        age: data.age,
+        gender: data.gender,
+        burial_date: data.burial_date?.toISOString() ?? null,
+        posthumous_name: data.posthumous_name,
+        report_date: data.report_date?.toISOString() ?? null,
+        religion: data.religion,
+        notes: data.notes,
+      });
+
+      if (bp.id && existingIds.includes(bp.id)) {
+        const before = existingMap.get(bp.id)!;
+        await tx.buriedPerson.update({
+          where: { id: bp.id },
+          data: bpData,
+        });
+        await recordEntityUpdated(tx, {
+          entityType: 'BuriedPerson',
+          entityId: bp.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            name: before.name,
+            name_kana: before.name_kana,
+            relationship: before.relationship,
+            birth_date: before.birth_date?.toISOString() ?? null,
+            death_date: before.death_date?.toISOString() ?? null,
+            age: before.age,
+            gender: before.gender,
+            burial_date: before.burial_date?.toISOString() ?? null,
+            posthumous_name: before.posthumous_name,
+            report_date: before.report_date?.toISOString() ?? null,
+            religion: before.religion,
+            notes: before.notes,
+          },
+          afterRecord: serialize(bpData),
+          req,
+        });
+      } else {
+        const created = await tx.buriedPerson.create({
+          data: {
+            contract_plot_id: id,
+            ...bpData,
+          },
+        });
+        await recordEntityCreated(tx, {
+          entityType: 'BuriedPerson',
+          entityId: created.id,
+          physicalPlotId,
+          contractPlotId: id,
+          afterRecord: { id: created.id, ...serialize(bpData) },
+          req,
+        });
+      }
+    }
+
+    const contractPlotForCB = await tx.contractPlot.findUnique({
+      where: { id },
+      select: { burial_capacity: true },
+    });
+    if (contractPlotForCB?.burial_capacity) {
+      await updateCollectiveBurialCount(tx, id);
+    }
+  }
+
+  // 11. 工事情報の全置換
+  if (input.constructionInfos !== undefined) {
+    const existingConstructionInfos = await tx.constructionInfo.findMany({
+      where: { contract_plot_id: id, deleted_at: null },
+    });
+    const existingCiIds = existingConstructionInfos.map((ci) => ci.id);
+    const existingCiMap = new Map(existingConstructionInfos.map((ci) => [ci.id, ci]));
+    const inputCiIds = input.constructionInfos.filter((ci) => ci.id).map((ci) => ci.id as string);
+
+    const ciIdsToDelete = existingCiIds.filter((eid) => !inputCiIds.includes(eid));
+    if (ciIdsToDelete.length > 0) {
+      await tx.constructionInfo.updateMany({
+        where: { id: { in: ciIdsToDelete } },
+        data: { deleted_at: new Date() },
+      });
+      for (const delId of ciIdsToDelete) {
+        const before = existingCiMap.get(delId)!;
+        await recordEntityDeleted(tx, {
+          entityType: 'ConstructionInfo',
+          entityId: delId,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: before.id,
+            construction_type: before.construction_type,
+            contractor: before.contractor,
+            start_date: before.start_date?.toISOString() ?? null,
+            completion_date: before.completion_date?.toISOString() ?? null,
+          },
+          req,
+        });
+      }
+    }
+
+    for (const ci of input.constructionInfos) {
+      const ciData = {
+        construction_type: ci.constructionType || null,
+        start_date: ci.startDate ? new Date(ci.startDate) : null,
+        completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
+        contractor: ci.contractor || null,
+        supervisor: ci.supervisor || null,
+        progress: ci.progress || null,
+        work_item_1: ci.workItem1 || null,
+        work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
+        work_amount_1: ci.workAmount1 ?? null,
+        work_status_1: ci.workStatus1 || null,
+        work_item_2: ci.workItem2 || null,
+        work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
+        work_amount_2: ci.workAmount2 ?? null,
+        work_status_2: ci.workStatus2 || null,
+        permit_number: ci.permitNumber || null,
+        application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
+        permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
+        permit_status: ci.permitStatus || null,
+        payment_type_1: ci.paymentType1 || null,
+        payment_amount_1: ci.paymentAmount1 ?? null,
+        payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
+        payment_status_1: ci.paymentStatus1 || null,
+        payment_type_2: ci.paymentType2 || null,
+        payment_amount_2: ci.paymentAmount2 ?? null,
+        payment_date_2: ci.paymentScheduledDate2 ? new Date(ci.paymentScheduledDate2) : null,
+        payment_status_2: ci.paymentStatus2 || null,
+        scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
+        construction_content: ci.constructionContent || null,
+        notes: ci.notes || null,
+      };
+
+      const serializeCi = (data: typeof ciData) => {
+        const result: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(data)) {
+          result[k] = v instanceof Date ? v.toISOString() : v;
+        }
+        return result;
+      };
+
+      if (ci.id && existingCiIds.includes(ci.id)) {
+        const before = existingCiMap.get(ci.id)!;
+        await tx.constructionInfo.update({
+          where: { id: ci.id },
+          data: ciData,
+        });
+        const beforeSerialized: Record<string, unknown> = {};
+        for (const key of Object.keys(ciData)) {
+          const v = (before as any)[key];
+          beforeSerialized[key] = v instanceof Date ? v.toISOString() : v;
+        }
+        await recordEntityUpdated(tx, {
+          entityType: 'ConstructionInfo',
+          entityId: ci.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: beforeSerialized,
+          afterRecord: serializeCi(ciData),
+          req,
+        });
+      } else {
+        const created = await tx.constructionInfo.create({
+          data: {
+            contract_plot_id: id,
+            ...ciData,
+          },
+        });
+        await recordEntityCreated(tx, {
+          entityType: 'ConstructionInfo',
+          entityId: created.id,
+          physicalPlotId,
+          contractPlotId: id,
+          afterRecord: { id: created.id, ...serializeCi(ciData) },
+          req,
+        });
+      }
+    }
+  }
+
+  // 12. 契約面積が変更された場合、物理区画のステータス更新
+  if (
+    input.contractPlot?.contractAreaSqm !== undefined &&
+    input.contractPlot.contractAreaSqm !== oldContractArea
+  ) {
+    await updatePhysicalPlotStatus(tx as any, physicalPlotId);
+  }
+
+  // 13. 履歴の自動記録（ContractPlot、Customer）
+  if (Object.keys(updateData).length > 0) {
+    const beforeContractPlotData = {
+      contract_area_sqm: existingContractPlot.contract_area_sqm.toString(),
+      location_description: existingContractPlot.location_description,
+      contract_date: existingContractPlot.contract_date?.toISOString(),
+      price: existingContractPlot.price,
+      payment_status: existingContractPlot.payment_status,
+      reservation_date: existingContractPlot.reservation_date?.toISOString(),
+      acceptance_number: existingContractPlot.acceptance_number,
+      permit_date: existingContractPlot.permit_date?.toISOString(),
+      start_date: existingContractPlot.start_date?.toISOString(),
+      uncollected_amount: existingContractPlot.uncollected_amount,
+      notes: existingContractPlot.notes,
+    };
+
+    const updatedCp = await tx.contractPlot.findUnique({ where: { id } });
+    const afterContractPlotData = updatedCp
+      ? {
+          contract_area_sqm: updatedCp.contract_area_sqm.toString(),
+          location_description: updatedCp.location_description,
+          contract_date: updatedCp.contract_date?.toISOString(),
+          price: updatedCp.price,
+          payment_status: updatedCp.payment_status,
+          reservation_date: updatedCp.reservation_date?.toISOString(),
+          acceptance_number: updatedCp.acceptance_number,
+          permit_date: updatedCp.permit_date?.toISOString(),
+          start_date: updatedCp.start_date?.toISOString(),
+          uncollected_amount: updatedCp.uncollected_amount,
+          notes: updatedCp.notes,
+        }
+      : beforeContractPlotData;
+
+    await recordContractPlotUpdated(
+      tx,
+      beforeContractPlotData,
+      afterContractPlotData,
+      physicalPlotId,
+      id,
+      req
+    );
+  }
+
+  if (input.customer) {
+    const primaryRole = existingContractPlot.saleContractRoles?.find(
+      (role: any) => role.role === 'contractor'
+    );
+    const existingCustomer = primaryRole?.customer;
+
+    if (existingCustomer) {
+      const beforeCustomerData = {
+        name: existingCustomer.name,
+        name_kana: existingCustomer.name_kana,
+        birth_date: existingCustomer.birth_date?.toISOString(),
+        gender: existingCustomer.gender,
+        postal_code: existingCustomer.postal_code,
+        address: existingCustomer.address,
+        phone_number: existingCustomer.phone_number,
+        email: existingCustomer.email,
+      };
+
+      const updatedCustomer = await tx.customer.findUnique({
+        where: { id: existingCustomer.id },
+      });
+      const afterCustomerData = updatedCustomer
+        ? {
+            name: updatedCustomer.name,
+            name_kana: updatedCustomer.name_kana,
+            birth_date: updatedCustomer.birth_date?.toISOString(),
+            gender: updatedCustomer.gender,
+            postal_code: updatedCustomer.postal_code,
+            address: updatedCustomer.address,
+            phone_number: updatedCustomer.phone_number,
+            email: updatedCustomer.email,
+          }
+        : beforeCustomerData;
+
+      await recordCustomerUpdated(
+        tx,
+        beforeCustomerData,
+        afterCustomerData,
+        existingCustomer.id,
+        id,
+        physicalPlotId,
+        req
+      );
+    }
+  }
+}
+
 /**
  * 契約区画更新
  * PUT /api/v1/plots/:id
@@ -33,1172 +1162,15 @@ export const updatePlot = async (
     const { id } = req.params as Record<string, string>;
     const input: UpdatePlotRequest = req.body;
 
-    // トランザクション処理
     // updatePlot は履歴記録を含む多数の sequential query を 1 トランザクションで実行するため
     // デフォルトの 5 秒タイムアウトでは P2028 が発生する。30 秒に延長。
     await prisma.$transaction(
       async (tx) => {
-        // 1. 既存のContractPlotを取得
-        const existingContractPlot = await tx.contractPlot.findUnique({
-          where: { id, deleted_at: null },
-          include: {
-            physicalPlot: true,
-            saleContractRoles: {
-              where: { deleted_at: null },
-              include: {
-                customer: {
-                  include: {
-                    workInfo: true,
-                    billingInfo: true,
-                  },
-                },
-              },
-            },
-            usageFee: true,
-            managementFee: true,
-            collectiveBurial: true,
-          },
-        });
-
-        if (!existingContractPlot) {
-          throw new NotFoundError('指定された契約区画が見つかりません');
-        }
-
-        const physicalPlotId = existingContractPlot.physical_plot_id;
-        const oldContractArea = existingContractPlot.contract_area_sqm.toNumber();
-
-        // 1.5. 物理区画情報の更新（issue #62）
-        // フロントから input.physicalPlot が送られてきた場合のみ更新
-        const physicalPlotInput = input.physicalPlot;
-        if (physicalPlotInput) {
-          const ppUpdateData: Record<string, unknown> = {};
-          if (physicalPlotInput.plotNumber !== undefined)
-            ppUpdateData['plot_number'] = physicalPlotInput.plotNumber;
-          if (physicalPlotInput.areaName !== undefined)
-            ppUpdateData['area_name'] = physicalPlotInput.areaName;
-          if (physicalPlotInput.areaSqm !== undefined)
-            ppUpdateData['area_sqm'] = new Prisma.Decimal(physicalPlotInput.areaSqm);
-          if (physicalPlotInput.status !== undefined)
-            ppUpdateData['status'] = physicalPlotInput.status;
-          if (physicalPlotInput.notes !== undefined)
-            ppUpdateData['notes'] = physicalPlotInput.notes;
-
-          if (Object.keys(ppUpdateData).length > 0) {
-            const beforePp = existingContractPlot.physicalPlot;
-            const updatedPp = await tx.physicalPlot.update({
-              where: { id: physicalPlotId },
-              data: ppUpdateData,
-            });
-            await recordEntityUpdated(tx, {
-              entityType: 'PhysicalPlot',
-              entityId: physicalPlotId,
-              physicalPlotId,
-              beforeRecord: {
-                plot_number: beforePp.plot_number,
-                area_name: beforePp.area_name,
-                area_sqm: beforePp.area_sqm.toString(),
-                status: beforePp.status,
-                notes: beforePp.notes,
-              },
-              afterRecord: {
-                plot_number: updatedPp.plot_number,
-                area_name: updatedPp.area_name,
-                area_sqm: updatedPp.area_sqm.toString(),
-                status: updatedPp.status,
-                notes: updatedPp.notes,
-              },
-              req,
-            });
-          }
-        }
-
-        // 2. ContractPlot（販売契約情報統合済み）の更新
-        const updateData: any = {};
-
-        // 契約区画情報の更新
-        if (input.contractPlot) {
-          if (input.contractPlot.contractAreaSqm !== undefined) {
-            // 契約面積が変更された場合は妥当性検証
-            const newAreaSqm = input.contractPlot.contractAreaSqm;
-
-            // 他の契約の合計面積を計算（現在の契約を除く）
-            const otherContracts = await tx.contractPlot.findMany({
-              where: {
-                physical_plot_id: physicalPlotId,
-                id: { not: id },
-                deleted_at: null,
-              },
-            });
-
-            const otherContractsTotal = otherContracts.reduce(
-              (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
-              0
-            );
-
-            const totalAfterUpdate = otherContractsTotal + newAreaSqm;
-            const physicalPlotArea = existingContractPlot.physicalPlot.area_sqm.toNumber();
-
-            if (totalAfterUpdate > physicalPlotArea) {
-              throw new ValidationError(
-                `契約面積の合計が物理区画の面積を超えています（物理区画: ${physicalPlotArea}㎡、合計: ${totalAfterUpdate}㎡）`
-              );
-            }
-
-            updateData.contract_area_sqm = new Prisma.Decimal(newAreaSqm);
-          }
-
-          if (input.contractPlot.locationDescription !== undefined) {
-            updateData.location_description = input.contractPlot.locationDescription;
-          }
-        }
-
-        // 販売契約情報の更新（ContractPlotに統合済み）
-        if (input.saleContract) {
-          if (input.saleContract.contractDate !== undefined) {
-            updateData.contract_date = new Date(input.saleContract.contractDate);
-          }
-          if (input.saleContract.price !== undefined) {
-            updateData.price = new Prisma.Decimal(input.saleContract.price);
-          }
-          if (input.saleContract.paymentStatus !== undefined) {
-            updateData.payment_status = input.saleContract.paymentStatus;
-          }
-          if (input.saleContract.reservationDate !== undefined) {
-            updateData.reservation_date = input.saleContract.reservationDate
-              ? new Date(input.saleContract.reservationDate)
-              : null;
-          }
-          if (input.saleContract.acceptanceNumber !== undefined) {
-            updateData.acceptance_number = input.saleContract.acceptanceNumber;
-          }
-          if (input.saleContract.acceptanceDate !== undefined) {
-            updateData.acceptance_date = input.saleContract.acceptanceDate
-              ? new Date(input.saleContract.acceptanceDate)
-              : null;
-          }
-          if (input.saleContract.staffInCharge !== undefined) {
-            updateData.staff_in_charge = input.saleContract.staffInCharge;
-          }
-          if (input.saleContract.agentName !== undefined) {
-            updateData.agent_name = input.saleContract.agentName;
-          }
-          if (input.saleContract.permitNumber !== undefined) {
-            updateData.permit_number = input.saleContract.permitNumber || null;
-          }
-          if (input.saleContract.permitDate !== undefined) {
-            updateData.permit_date = input.saleContract.permitDate
-              ? new Date(input.saleContract.permitDate)
-              : null;
-          }
-          if (input.saleContract.startDate !== undefined) {
-            updateData.start_date = input.saleContract.startDate
-              ? new Date(input.saleContract.startDate)
-              : null;
-          }
-          if (input.saleContract.uncollectedAmount !== undefined) {
-            updateData.uncollected_amount = input.saleContract.uncollectedAmount;
-          }
-          if (input.saleContract.notes !== undefined) {
-            updateData.notes = input.saleContract.notes;
-          }
-        }
-
-        // ContractPlotの更新を実行
-        if (Object.keys(updateData).length > 0) {
-          await tx.contractPlot.update({
-            where: { id },
-            data: updateData,
-          });
-        }
-
-        // 3. 顧客役割の更新
-        if (input.saleContract?.roles !== undefined) {
-          // 既存役割を退避
-          const existingRoles = await tx.saleContractRole.findMany({
-            where: {
-              contract_plot_id: id,
-              deleted_at: null,
-            },
-          });
-
-          // 既存の役割を論理削除
-          await tx.saleContractRole.updateMany({
-            where: {
-              contract_plot_id: id, // sale_contract_id → contract_plot_idに変更
-              deleted_at: null,
-            },
-            data: {
-              deleted_at: new Date(),
-            },
-          });
-          for (const oldRole of existingRoles) {
-            await recordEntityDeleted(tx, {
-              entityType: 'SaleContractRole',
-              entityId: oldRole.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              beforeRecord: {
-                id: oldRole.id,
-                role: oldRole.role,
-                customer_id: oldRole.customer_id,
-              },
-              req,
-            });
-          }
-
-          // 新しい役割を作成
-          for (const roleData of input.saleContract.roles) {
-            // customerId が指定されていない場合はエラー
-            if (!roleData.customerId) {
-              throw new ValidationError('役割更新時は customerId が必須です');
-            }
-
-            const created = await tx.saleContractRole.create({
-              data: {
-                contract_plot_id: existingContractPlot.id, // sale_contract_id → contract_plot_idに変更
-                customer_id: roleData.customerId,
-                role: roleData.role,
-                role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
-                role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
-                notes: roleData.notes || null,
-              },
-            });
-            await recordEntityCreated(tx, {
-              entityType: 'SaleContractRole',
-              entityId: created.id,
-              physicalPlotId,
-              contractPlotId: id as string,
-              afterRecord: {
-                id: created.id,
-                role: created.role,
-                customer_id: created.customer_id,
-              },
-              req,
-            });
-          }
-        }
-
-        // 4. Customerの更新（主契約者を対象）
-        if (input.customer) {
-          // 主契約者を取得
-          const primaryRole = existingContractPlot.saleContractRoles?.find(
-            (role: any) => role.role === 'contractor'
-          );
-          const customerId = primaryRole?.customer.id;
-
-          if (customerId) {
-            const updateData: any = {};
-
-            if (input.customer.name !== undefined) updateData.name = input.customer.name;
-            if (input.customer.nameKana !== undefined)
-              updateData.name_kana = input.customer.nameKana;
-            if (input.customer.birthDate !== undefined) {
-              updateData.birth_date = input.customer.birthDate
-                ? new Date(input.customer.birthDate)
-                : null;
-            }
-            if (input.customer.gender !== undefined) updateData.gender = input.customer.gender;
-            if (input.customer.postalCode !== undefined)
-              updateData.postal_code = input.customer.postalCode;
-            if (input.customer.address !== undefined) updateData.address = input.customer.address;
-            if (input.customer.addressLine2 !== undefined)
-              updateData.address_line_2 = input.customer.addressLine2;
-            if (input.customer.registeredAddress !== undefined)
-              updateData.registered_address = input.customer.registeredAddress;
-            if (input.customer.phoneNumber !== undefined)
-              updateData.phone_number = input.customer.phoneNumber;
-            if (input.customer.faxNumber !== undefined)
-              updateData.fax_number = input.customer.faxNumber;
-            if (input.customer.email !== undefined) updateData.email = input.customer.email;
-            if (input.customer.notes !== undefined) updateData.notes = input.customer.notes;
-
-            if (Object.keys(updateData).length > 0) {
-              await tx.customer.update({
-                where: { id: customerId },
-                data: updateData,
-              });
-            }
-
-            // 5. WorkInfoの更新/作成/削除
-            if (input.workInfo !== undefined) {
-              const existingWorkInfo = primaryRole?.customer.workInfo;
-
-              if (input.workInfo === null) {
-                // 削除
-                if (existingWorkInfo) {
-                  await tx.workInfo.delete({
-                    where: { id: existingWorkInfo.id },
-                  });
-                  await recordEntityDeleted(tx, {
-                    entityType: 'WorkInfo',
-                    entityId: existingWorkInfo.id,
-                    physicalPlotId,
-                    contractPlotId: id as string,
-                    beforeRecord: {
-                      id: existingWorkInfo.id,
-                      company_name: existingWorkInfo.company_name,
-                      work_address: existingWorkInfo.work_address,
-                      work_phone_number: existingWorkInfo.work_phone_number,
-                    },
-                    req,
-                  });
-                }
-              } else {
-                // 更新または作成
-                const workInfoData: any = {};
-                if (input.workInfo.companyName !== undefined)
-                  workInfoData.company_name = input.workInfo.companyName;
-                if (input.workInfo.companyNameKana !== undefined)
-                  workInfoData.company_name_kana = input.workInfo.companyNameKana;
-                if (input.workInfo.workPostalCode !== undefined)
-                  workInfoData.work_postal_code = input.workInfo.workPostalCode;
-                if (input.workInfo.workAddress !== undefined)
-                  workInfoData.work_address = input.workInfo.workAddress;
-                if (input.workInfo.workPhoneNumber !== undefined)
-                  workInfoData.work_phone_number = input.workInfo.workPhoneNumber;
-                if (input.workInfo.dmSetting !== undefined)
-                  workInfoData.dm_setting = input.workInfo.dmSetting;
-                if (input.workInfo.addressType !== undefined)
-                  workInfoData.address_type = input.workInfo.addressType;
-                if (input.workInfo.notes !== undefined) workInfoData.notes = input.workInfo.notes;
-
-                if (Object.keys(workInfoData).length > 0) {
-                  if (existingWorkInfo) {
-                    const updated = await tx.workInfo.update({
-                      where: { id: existingWorkInfo.id },
-                      data: workInfoData,
-                    });
-                    await recordEntityUpdated(tx, {
-                      entityType: 'WorkInfo',
-                      entityId: existingWorkInfo.id,
-                      physicalPlotId,
-                      contractPlotId: id as string,
-                      beforeRecord: {
-                        company_name: existingWorkInfo.company_name,
-                        company_name_kana: existingWorkInfo.company_name_kana,
-                        work_postal_code: existingWorkInfo.work_postal_code,
-                        work_address: existingWorkInfo.work_address,
-                        work_phone_number: existingWorkInfo.work_phone_number,
-                        dm_setting: existingWorkInfo.dm_setting,
-                        address_type: existingWorkInfo.address_type,
-                        notes: existingWorkInfo.notes,
-                      },
-                      afterRecord: {
-                        company_name: updated.company_name,
-                        company_name_kana: updated.company_name_kana,
-                        work_postal_code: updated.work_postal_code,
-                        work_address: updated.work_address,
-                        work_phone_number: updated.work_phone_number,
-                        dm_setting: updated.dm_setting,
-                        address_type: updated.address_type,
-                        notes: updated.notes,
-                      },
-                      req,
-                    });
-                  } else {
-                    const created = await tx.workInfo.create({
-                      data: {
-                        customer_id: customerId,
-                        ...workInfoData,
-                      },
-                    });
-                    await recordEntityCreated(tx, {
-                      entityType: 'WorkInfo',
-                      entityId: created.id,
-                      physicalPlotId,
-                      contractPlotId: id as string,
-                      afterRecord: {
-                        id: created.id,
-                        customer_id: customerId,
-                        ...workInfoData,
-                      },
-                      req,
-                    });
-                  }
-                }
-              }
-            }
-
-            // 6. BillingInfoの更新/作成/削除
-            if (input.billingInfo !== undefined) {
-              const existingBillingInfo = primaryRole?.customer.billingInfo;
-
-              if (input.billingInfo === null) {
-                // 削除
-                if (existingBillingInfo) {
-                  await tx.billingInfo.delete({
-                    where: { id: existingBillingInfo.id },
-                  });
-                  await recordEntityDeleted(tx, {
-                    entityType: 'BillingInfo',
-                    entityId: existingBillingInfo.id,
-                    physicalPlotId,
-                    contractPlotId: id as string,
-                    beforeRecord: {
-                      id: existingBillingInfo.id,
-                      billing_type: existingBillingInfo.billing_type,
-                      bank_name: existingBillingInfo.bank_name,
-                      branch_name: existingBillingInfo.branch_name,
-                    },
-                    req,
-                  });
-                }
-              } else {
-                // 更新または作成
-                const billingInfoData: any = {};
-                if (input.billingInfo.billingType !== undefined)
-                  billingInfoData.billing_type = input.billingInfo.billingType;
-                if (input.billingInfo.bankName !== undefined)
-                  billingInfoData.bank_name = input.billingInfo.bankName;
-                if (input.billingInfo.branchName !== undefined)
-                  billingInfoData.branch_name = input.billingInfo.branchName;
-                if (input.billingInfo.accountType !== undefined)
-                  billingInfoData.account_type = input.billingInfo.accountType;
-                if (input.billingInfo.accountNumber !== undefined)
-                  billingInfoData.account_number = input.billingInfo.accountNumber;
-                if (input.billingInfo.accountHolder !== undefined)
-                  billingInfoData.account_holder = input.billingInfo.accountHolder;
-
-                if (Object.keys(billingInfoData).length > 0) {
-                  if (existingBillingInfo) {
-                    const updated = await tx.billingInfo.update({
-                      where: { id: existingBillingInfo.id },
-                      data: billingInfoData,
-                    });
-                    await recordEntityUpdated(tx, {
-                      entityType: 'BillingInfo',
-                      entityId: existingBillingInfo.id,
-                      physicalPlotId,
-                      contractPlotId: id as string,
-                      beforeRecord: {
-                        billing_type: existingBillingInfo.billing_type,
-                        bank_name: existingBillingInfo.bank_name,
-                        branch_name: existingBillingInfo.branch_name,
-                        account_type: existingBillingInfo.account_type,
-                        account_number: existingBillingInfo.account_number,
-                        account_holder: existingBillingInfo.account_holder,
-                      },
-                      afterRecord: {
-                        billing_type: updated.billing_type,
-                        bank_name: updated.bank_name,
-                        branch_name: updated.branch_name,
-                        account_type: updated.account_type,
-                        account_number: updated.account_number,
-                        account_holder: updated.account_holder,
-                      },
-                      req,
-                    });
-                  } else {
-                    const created = await tx.billingInfo.create({
-                      data: {
-                        customer_id: customerId,
-                        ...billingInfoData,
-                      },
-                    });
-                    await recordEntityCreated(tx, {
-                      entityType: 'BillingInfo',
-                      entityId: created.id,
-                      physicalPlotId,
-                      contractPlotId: id as string,
-                      afterRecord: {
-                        id: created.id,
-                        customer_id: customerId,
-                        ...billingInfoData,
-                      },
-                      req,
-                    });
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // 7. UsageFeeの更新/作成/削除
-        if (input.usageFee !== undefined) {
-          if (input.usageFee === null) {
-            // 削除
-            if (existingContractPlot.usageFee) {
-              const before = existingContractPlot.usageFee;
-              await tx.usageFee.delete({
-                where: { id: before.id },
-              });
-              await recordEntityDeleted(tx, {
-                entityType: 'UsageFee',
-                entityId: before.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  id: before.id,
-                  calculation_type: before.calculation_type,
-                  tax_type: before.tax_type,
-                  usage_fee: before.usage_fee,
-                  area: before.area,
-                  unit_price: before.unit_price,
-                  payment_method: before.payment_method,
-                },
-                req,
-              });
-            }
-          } else {
-            // 更新または作成
-            const usageFeeData: any = {};
-            if (input.usageFee.calculationType !== undefined)
-              usageFeeData.calculation_type = input.usageFee.calculationType;
-            if (input.usageFee.taxType !== undefined)
-              usageFeeData.tax_type = input.usageFee.taxType;
-            if (input.usageFee.usageFee !== undefined)
-              usageFeeData.usage_fee = String(input.usageFee.usageFee ?? '');
-            if (input.usageFee.area !== undefined)
-              usageFeeData.area = String(input.usageFee.area ?? '');
-            if (input.usageFee.unitPrice !== undefined)
-              usageFeeData.unit_price = String(input.usageFee.unitPrice ?? '');
-            if (input.usageFee.paymentMethod !== undefined)
-              usageFeeData.payment_method = input.usageFee.paymentMethod;
-
-            if (Object.keys(usageFeeData).length > 0) {
-              if (existingContractPlot.usageFee) {
-                const before = existingContractPlot.usageFee;
-                const updated = await tx.usageFee.update({
-                  where: { id: before.id },
-                  data: usageFeeData,
-                });
-                await recordEntityUpdated(tx, {
-                  entityType: 'UsageFee',
-                  entityId: before.id,
-                  physicalPlotId,
-                  contractPlotId: id as string,
-                  beforeRecord: {
-                    calculation_type: before.calculation_type,
-                    tax_type: before.tax_type,
-                    usage_fee: before.usage_fee,
-                    area: before.area,
-                    unit_price: before.unit_price,
-                    payment_method: before.payment_method,
-                  },
-                  afterRecord: {
-                    calculation_type: updated.calculation_type,
-                    tax_type: updated.tax_type,
-                    usage_fee: updated.usage_fee,
-                    area: updated.area,
-                    unit_price: updated.unit_price,
-                    payment_method: updated.payment_method,
-                  },
-                  req,
-                });
-              } else {
-                const created = await tx.usageFee.create({
-                  data: {
-                    contract_plot_id: id,
-                    billing_type: 'onetime',
-                    billing_years: '1',
-                    ...usageFeeData,
-                  },
-                });
-                await recordEntityCreated(tx, {
-                  entityType: 'UsageFee',
-                  entityId: created.id,
-                  physicalPlotId,
-                  contractPlotId: id as string,
-                  afterRecord: {
-                    id: created.id,
-                    calculation_type: created.calculation_type,
-                    tax_type: created.tax_type,
-                    usage_fee: created.usage_fee,
-                    area: created.area,
-                    unit_price: created.unit_price,
-                    payment_method: created.payment_method,
-                  },
-                  req,
-                });
-              }
-            }
-          }
-        }
-
-        // 8. ManagementFeeの更新/作成/削除
-        if (input.managementFee !== undefined) {
-          if (input.managementFee === null) {
-            // 削除
-            if (existingContractPlot.managementFee) {
-              const before = existingContractPlot.managementFee;
-              await tx.managementFee.delete({
-                where: { id: before.id },
-              });
-              await recordEntityDeleted(tx, {
-                entityType: 'ManagementFee',
-                entityId: before.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  id: before.id,
-                  management_fee: before.management_fee,
-                  billing_type: before.billing_type,
-                  billing_years: before.billing_years,
-                },
-                req,
-              });
-            }
-          } else {
-            // 更新または作成
-            const managementFeeData: any = {};
-            if (input.managementFee.calculationType !== undefined)
-              managementFeeData.calculation_type = input.managementFee.calculationType;
-            if (input.managementFee.taxType !== undefined)
-              managementFeeData.tax_type = input.managementFee.taxType;
-            if (input.managementFee.billingType !== undefined)
-              managementFeeData.billing_type = input.managementFee.billingType;
-            if (input.managementFee.billingYears !== undefined)
-              managementFeeData.billing_years = String(input.managementFee.billingYears ?? '');
-            if (input.managementFee.area !== undefined)
-              managementFeeData.area = String(input.managementFee.area ?? '');
-            if (input.managementFee.billingMonth !== undefined)
-              managementFeeData.billing_month = input.managementFee.billingMonth;
-            if (input.managementFee.managementFee !== undefined)
-              managementFeeData.management_fee = String(input.managementFee.managementFee ?? '');
-            if (input.managementFee.unitPrice !== undefined)
-              managementFeeData.unit_price = String(input.managementFee.unitPrice ?? '');
-            if (input.managementFee.lastBillingMonth !== undefined)
-              managementFeeData.last_billing_month = input.managementFee.lastBillingMonth;
-            if (input.managementFee.paymentMethod !== undefined)
-              managementFeeData.payment_method = input.managementFee.paymentMethod;
-
-            if (Object.keys(managementFeeData).length > 0) {
-              if (existingContractPlot.managementFee) {
-                const before = existingContractPlot.managementFee;
-                const updated = await tx.managementFee.update({
-                  where: { id: before.id },
-                  data: managementFeeData,
-                });
-                await recordEntityUpdated(tx, {
-                  entityType: 'ManagementFee',
-                  entityId: before.id,
-                  physicalPlotId,
-                  contractPlotId: id as string,
-                  beforeRecord: {
-                    calculation_type: before.calculation_type,
-                    tax_type: before.tax_type,
-                    billing_type: before.billing_type,
-                    billing_years: before.billing_years,
-                    area: before.area,
-                    billing_month: before.billing_month,
-                    management_fee: before.management_fee,
-                    unit_price: before.unit_price,
-                    last_billing_month: before.last_billing_month,
-                    payment_method: before.payment_method,
-                  },
-                  afterRecord: {
-                    calculation_type: updated.calculation_type,
-                    tax_type: updated.tax_type,
-                    billing_type: updated.billing_type,
-                    billing_years: updated.billing_years,
-                    area: updated.area,
-                    billing_month: updated.billing_month,
-                    management_fee: updated.management_fee,
-                    unit_price: updated.unit_price,
-                    last_billing_month: updated.last_billing_month,
-                    payment_method: updated.payment_method,
-                  },
-                  req,
-                });
-              } else {
-                const created = await tx.managementFee.create({
-                  data: {
-                    contract_plot_id: id,
-                    ...managementFeeData,
-                  },
-                });
-                await recordEntityCreated(tx, {
-                  entityType: 'ManagementFee',
-                  entityId: created.id,
-                  physicalPlotId,
-                  contractPlotId: id as string,
-                  afterRecord: {
-                    id: created.id,
-                    ...managementFeeData,
-                  },
-                  req,
-                });
-              }
-            }
-          }
-        }
-
-        // 9. CollectiveBurialの更新/作成/削除
-        if (input.collectiveBurial !== undefined) {
-          const existingCB = existingContractPlot.collectiveBurial;
-
-          if (input.collectiveBurial === null) {
-            // 合祀設定を解除: ContractPlotのフィールドをnullに、CBレコードを論理削除
-            await tx.contractPlot.update({
-              where: { id },
-              data: {
-                burial_capacity: null,
-                validity_period_years: null,
-              },
-            });
-            if (existingCB && !existingCB.deleted_at) {
-              await tx.collectiveBurial.update({
-                where: { id: existingCB.id },
-                data: { deleted_at: new Date() },
-              });
-              await recordEntityDeleted(tx, {
-                entityType: 'CollectiveBurial',
-                entityId: existingCB.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  id: existingCB.id,
-                  burial_capacity: existingCB.burial_capacity,
-                  validity_period_years: existingCB.validity_period_years,
-                  billing_amount: existingCB.billing_amount,
-                  notes: existingCB.notes,
-                },
-                req,
-              });
-            }
-          } else {
-            // 合祀設定を更新/作成: ContractPlotのフィールドを更新
-            await tx.contractPlot.update({
-              where: { id },
-              data: {
-                burial_capacity: input.collectiveBurial.burialCapacity,
-                validity_period_years: input.collectiveBurial.validityPeriodYears,
-              },
-            });
-
-            if (existingCB && !existingCB.deleted_at) {
-              // 既存CBを更新
-              const updated = await tx.collectiveBurial.update({
-                where: { id: existingCB.id },
-                data: {
-                  burial_capacity: input.collectiveBurial.burialCapacity,
-                  validity_period_years: input.collectiveBurial.validityPeriodYears,
-                  billing_amount: input.collectiveBurial.billingAmount ?? existingCB.billing_amount,
-                  notes:
-                    input.collectiveBurial.notes !== undefined
-                      ? input.collectiveBurial.notes || null
-                      : existingCB.notes,
-                },
-              });
-              await recordEntityUpdated(tx, {
-                entityType: 'CollectiveBurial',
-                entityId: existingCB.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  burial_capacity: existingCB.burial_capacity,
-                  validity_period_years: existingCB.validity_period_years,
-                  billing_amount: existingCB.billing_amount,
-                  notes: existingCB.notes,
-                },
-                afterRecord: {
-                  burial_capacity: updated.burial_capacity,
-                  validity_period_years: updated.validity_period_years,
-                  billing_amount: updated.billing_amount,
-                  notes: updated.notes,
-                },
-                req,
-              });
-            } else {
-              // 新規CB作成（論理削除済みの場合も復活）
-              const cbCapacity = input.collectiveBurial.burialCapacity;
-              const cbPeriod = input.collectiveBurial.validityPeriodYears;
-              if (!cbCapacity || !cbPeriod) {
-                throw new ValidationError(
-                  '新規合祀設定には burialCapacity と validityPeriodYears が必須です'
-                );
-              }
-
-              let cbCreated: { id: string };
-              if (existingCB?.deleted_at) {
-                cbCreated = await tx.collectiveBurial.update({
-                  where: { id: existingCB.id },
-                  data: {
-                    burial_capacity: cbCapacity,
-                    validity_period_years: cbPeriod,
-                    billing_amount: input.collectiveBurial.billingAmount ?? null,
-                    notes: input.collectiveBurial.notes || null,
-                    deleted_at: null,
-                  },
-                });
-              } else {
-                cbCreated = await tx.collectiveBurial.create({
-                  data: {
-                    contract_plot_id: id as string,
-                    burial_capacity: cbCapacity,
-                    validity_period_years: cbPeriod,
-                    billing_amount: input.collectiveBurial.billingAmount ?? null,
-                    notes: input.collectiveBurial.notes || null,
-                  },
-                });
-              }
-              await recordEntityCreated(tx, {
-                entityType: 'CollectiveBurial',
-                entityId: cbCreated.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                afterRecord: {
-                  id: cbCreated.id,
-                  burial_capacity: cbCapacity,
-                  validity_period_years: cbPeriod,
-                  billing_amount: input.collectiveBurial.billingAmount ?? null,
-                  notes: input.collectiveBurial.notes || null,
-                },
-                req,
-              });
-            }
-          }
-        }
-
-        // 10. 埋葬者の全置換（送信された配列で既存を置き換え）
-        if (input.buriedPersons !== undefined) {
-          // 既存の埋葬者を取得
-          const existingBuriedPersons = await tx.buriedPerson.findMany({
-            where: { contract_plot_id: id, deleted_at: null },
-          });
-          const existingIds = existingBuriedPersons.map((bp) => bp.id);
-          const existingMap = new Map(existingBuriedPersons.map((bp) => [bp.id, bp]));
-          const inputIds = input.buriedPersons.filter((bp) => bp.id).map((bp) => bp.id as string);
-
-          // 送信されなかったIDは論理削除
-          const idsToDelete = existingIds.filter((eid) => !inputIds.includes(eid));
-          if (idsToDelete.length > 0) {
-            await tx.buriedPerson.updateMany({
-              where: { id: { in: idsToDelete } },
-              data: { deleted_at: new Date() },
-            });
-            for (const delId of idsToDelete) {
-              const before = existingMap.get(delId)!;
-              await recordEntityDeleted(tx, {
-                entityType: 'BuriedPerson',
-                entityId: delId,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  id: before.id,
-                  name: before.name,
-                  death_date: before.death_date?.toISOString() ?? null,
-                  burial_date: before.burial_date?.toISOString() ?? null,
-                },
-                req,
-              });
-            }
-          }
-
-          // 各レコードを作成/更新
-          for (const bp of input.buriedPersons) {
-            const bpData = {
-              name: bp.name,
-              name_kana: bp.nameKana || null,
-              relationship: bp.relationship || null,
-              birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
-              death_date: bp.deathDate ? new Date(bp.deathDate) : null,
-              age: bp.age ?? null,
-              gender: bp.gender || null,
-              burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
-              posthumous_name: bp.posthumousName || null,
-              report_date: bp.reportDate ? new Date(bp.reportDate) : null,
-              religion: bp.religion || null,
-              notes: bp.notes || null,
-            };
-
-            // 履歴用のシリアライズ可能な before/after
-            const serialize = (data: typeof bpData) => ({
-              name: data.name,
-              name_kana: data.name_kana,
-              relationship: data.relationship,
-              birth_date: data.birth_date?.toISOString() ?? null,
-              death_date: data.death_date?.toISOString() ?? null,
-              age: data.age,
-              gender: data.gender,
-              burial_date: data.burial_date?.toISOString() ?? null,
-              posthumous_name: data.posthumous_name,
-              report_date: data.report_date?.toISOString() ?? null,
-              religion: data.religion,
-              notes: data.notes,
-            });
-
-            if (bp.id && existingIds.includes(bp.id)) {
-              // 既存レコードを更新
-              const before = existingMap.get(bp.id)!;
-              await tx.buriedPerson.update({
-                where: { id: bp.id },
-                data: bpData,
-              });
-              await recordEntityUpdated(tx, {
-                entityType: 'BuriedPerson',
-                entityId: bp.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  name: before.name,
-                  name_kana: before.name_kana,
-                  relationship: before.relationship,
-                  birth_date: before.birth_date?.toISOString() ?? null,
-                  death_date: before.death_date?.toISOString() ?? null,
-                  age: before.age,
-                  gender: before.gender,
-                  burial_date: before.burial_date?.toISOString() ?? null,
-                  posthumous_name: before.posthumous_name,
-                  report_date: before.report_date?.toISOString() ?? null,
-                  religion: before.religion,
-                  notes: before.notes,
-                },
-                afterRecord: serialize(bpData),
-                req,
-              });
-            } else {
-              // 新規作成
-              const created = await tx.buriedPerson.create({
-                data: {
-                  contract_plot_id: id as string,
-                  ...bpData,
-                },
-              });
-              await recordEntityCreated(tx, {
-                entityType: 'BuriedPerson',
-                entityId: created.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                afterRecord: { id: created.id, ...serialize(bpData) },
-                req,
-              });
-            }
-          }
-
-          // 合祀自動チェック: burial_capacityが設定されている場合、埋葬数を同期
-          const contractPlotForCB = await tx.contractPlot.findUnique({
-            where: { id },
-            select: { burial_capacity: true },
-          });
-          if (contractPlotForCB?.burial_capacity) {
-            await updateCollectiveBurialCount(tx, id as string);
-          }
-        }
-
-        // 11. 工事情報の全置換（送信された配列で既存を置き換え）
-        if (input.constructionInfos !== undefined) {
-          const existingConstructionInfos = await tx.constructionInfo.findMany({
-            where: { contract_plot_id: id, deleted_at: null },
-          });
-          const existingCiIds = existingConstructionInfos.map((ci) => ci.id);
-          const existingCiMap = new Map(existingConstructionInfos.map((ci) => [ci.id, ci]));
-          const inputCiIds = input.constructionInfos
-            .filter((ci) => ci.id)
-            .map((ci) => ci.id as string);
-
-          // 送信されなかったIDは論理削除
-          const ciIdsToDelete = existingCiIds.filter((eid) => !inputCiIds.includes(eid));
-          if (ciIdsToDelete.length > 0) {
-            await tx.constructionInfo.updateMany({
-              where: { id: { in: ciIdsToDelete } },
-              data: { deleted_at: new Date() },
-            });
-            for (const delId of ciIdsToDelete) {
-              const before = existingCiMap.get(delId)!;
-              await recordEntityDeleted(tx, {
-                entityType: 'ConstructionInfo',
-                entityId: delId,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: {
-                  id: before.id,
-                  construction_type: before.construction_type,
-                  contractor: before.contractor,
-                  start_date: before.start_date?.toISOString() ?? null,
-                  completion_date: before.completion_date?.toISOString() ?? null,
-                },
-                req,
-              });
-            }
-          }
-
-          // 各レコードを作成/更新
-          for (const ci of input.constructionInfos) {
-            const ciData = {
-              construction_type: ci.constructionType || null,
-              start_date: ci.startDate ? new Date(ci.startDate) : null,
-              completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
-              contractor: ci.contractor || null,
-              supervisor: ci.supervisor || null,
-              progress: ci.progress || null,
-              work_item_1: ci.workItem1 || null,
-              work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
-              work_amount_1: ci.workAmount1 ?? null,
-              work_status_1: ci.workStatus1 || null,
-              work_item_2: ci.workItem2 || null,
-              work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
-              work_amount_2: ci.workAmount2 ?? null,
-              work_status_2: ci.workStatus2 || null,
-              permit_number: ci.permitNumber || null,
-              application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
-              permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
-              permit_status: ci.permitStatus || null,
-              payment_type_1: ci.paymentType1 || null,
-              payment_amount_1: ci.paymentAmount1 ?? null,
-              payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
-              payment_status_1: ci.paymentStatus1 || null,
-              payment_type_2: ci.paymentType2 || null,
-              payment_amount_2: ci.paymentAmount2 ?? null,
-              payment_date_2: ci.paymentScheduledDate2 ? new Date(ci.paymentScheduledDate2) : null,
-              payment_status_2: ci.paymentStatus2 || null,
-              scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
-              construction_content: ci.constructionContent || null,
-              notes: ci.notes || null,
-            };
-
-            // 履歴用にDate→ISOへシリアライズ
-            const serializeCi = (data: typeof ciData) => {
-              const result: Record<string, unknown> = {};
-              for (const [k, v] of Object.entries(data)) {
-                result[k] = v instanceof Date ? v.toISOString() : v;
-              }
-              return result;
-            };
-
-            if (ci.id && existingCiIds.includes(ci.id)) {
-              const before = existingCiMap.get(ci.id)!;
-              await tx.constructionInfo.update({
-                where: { id: ci.id },
-                data: ciData,
-              });
-              // beforeをciDataと同じ形にシリアライズ
-              const beforeSerialized: Record<string, unknown> = {};
-              for (const key of Object.keys(ciData)) {
-                const v = (before as any)[key];
-                beforeSerialized[key] = v instanceof Date ? v.toISOString() : v;
-              }
-              await recordEntityUpdated(tx, {
-                entityType: 'ConstructionInfo',
-                entityId: ci.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                beforeRecord: beforeSerialized,
-                afterRecord: serializeCi(ciData),
-                req,
-              });
-            } else {
-              const created = await tx.constructionInfo.create({
-                data: {
-                  contract_plot_id: id as string,
-                  ...ciData,
-                },
-              });
-              await recordEntityCreated(tx, {
-                entityType: 'ConstructionInfo',
-                entityId: created.id,
-                physicalPlotId,
-                contractPlotId: id as string,
-                afterRecord: { id: created.id, ...serializeCi(ciData) },
-                req,
-              });
-            }
-          }
-        }
-
-        // 12. 契約面積が変更された場合、物理区画のステータス更新
-        if (
-          input.contractPlot?.contractAreaSqm !== undefined &&
-          input.contractPlot.contractAreaSqm !== oldContractArea
-        ) {
-          await updatePhysicalPlotStatus(tx as any, physicalPlotId);
-        }
-
-        // 10. 履歴の自動記録
-        // ContractPlotの更新履歴
-        if (Object.keys(updateData).length > 0) {
-          const beforeContractPlotData = {
-            contract_area_sqm: existingContractPlot.contract_area_sqm.toString(),
-            location_description: existingContractPlot.location_description,
-            contract_date: existingContractPlot.contract_date?.toISOString(),
-            price: existingContractPlot.price,
-            payment_status: existingContractPlot.payment_status,
-            reservation_date: existingContractPlot.reservation_date?.toISOString(),
-            acceptance_number: existingContractPlot.acceptance_number,
-            permit_date: existingContractPlot.permit_date?.toISOString(),
-            start_date: existingContractPlot.start_date?.toISOString(),
-            uncollected_amount: existingContractPlot.uncollected_amount,
-            notes: existingContractPlot.notes,
-          };
-
-          const updatedCp = await tx.contractPlot.findUnique({ where: { id } });
-          const afterContractPlotData = updatedCp
-            ? {
-                contract_area_sqm: updatedCp.contract_area_sqm.toString(),
-                location_description: updatedCp.location_description,
-                contract_date: updatedCp.contract_date?.toISOString(),
-                price: updatedCp.price,
-                payment_status: updatedCp.payment_status,
-                reservation_date: updatedCp.reservation_date?.toISOString(),
-                acceptance_number: updatedCp.acceptance_number,
-                permit_date: updatedCp.permit_date?.toISOString(),
-                start_date: updatedCp.start_date?.toISOString(),
-                uncollected_amount: updatedCp.uncollected_amount,
-                notes: updatedCp.notes,
-              }
-            : beforeContractPlotData;
-
-          await recordContractPlotUpdated(
-            tx,
-            beforeContractPlotData,
-            afterContractPlotData,
-            physicalPlotId,
-            id as string,
-            req
-          );
-        }
-
-        // Customerの更新履歴
-        if (input.customer) {
-          const primaryRole = existingContractPlot.saleContractRoles?.find(
-            (role: any) => role.role === 'contractor'
-          );
-          const existingCustomer = primaryRole?.customer;
-
-          if (existingCustomer) {
-            const beforeCustomerData = {
-              name: existingCustomer.name,
-              name_kana: existingCustomer.name_kana,
-              birth_date: existingCustomer.birth_date?.toISOString(),
-              gender: existingCustomer.gender,
-              postal_code: existingCustomer.postal_code,
-              address: existingCustomer.address,
-              phone_number: existingCustomer.phone_number,
-              email: existingCustomer.email,
-            };
-
-            const updatedCustomer = await tx.customer.findUnique({
-              where: { id: existingCustomer.id },
-            });
-            const afterCustomerData = updatedCustomer
-              ? {
-                  name: updatedCustomer.name,
-                  name_kana: updatedCustomer.name_kana,
-                  birth_date: updatedCustomer.birth_date?.toISOString(),
-                  gender: updatedCustomer.gender,
-                  postal_code: updatedCustomer.postal_code,
-                  address: updatedCustomer.address,
-                  phone_number: updatedCustomer.phone_number,
-                  email: updatedCustomer.email,
-                }
-              : beforeCustomerData;
-
-            await recordCustomerUpdated(
-              tx,
-              beforeCustomerData,
-              afterCustomerData,
-              existingCustomer.id,
-              id as string,
-              physicalPlotId,
-              req
-            );
-          }
-        }
+        await updatePlotCore(tx, id as string, input, req);
       },
       {
-        maxWait: 10000, // ロック取得待機の上限 10 秒
-        timeout: 30000, // トランザクション全体の上限 30 秒
+        maxWait: 10000,
+        timeout: 30000,
       }
     );
 
@@ -1224,7 +1196,6 @@ export const updatePlot = async (
       },
     });
 
-    // 主契約者（role='contractor'）を取得（後方互換性のため）
     const primaryRole = updatedContractPlot?.saleContractRoles?.find(
       (role) => role.role === 'contractor'
     );
@@ -1237,7 +1208,6 @@ export const updatePlot = async (
         contractAreaSqm: updatedContractPlot?.contract_area_sqm.toNumber(),
         locationDescription: updatedContractPlot?.location_description,
 
-        // 販売契約情報（ContractPlotに統合済み）
         contractDate: updatedContractPlot?.contract_date,
         price: updatedContractPlot?.price,
         paymentStatus: updatedContractPlot?.payment_status,
@@ -1257,7 +1227,6 @@ export const updatePlot = async (
           status: updatedContractPlot?.physicalPlot.status,
         },
 
-        // 後方互換性: 主契約者の情報
         primaryCustomer: primaryCustomer
           ? {
               id: primaryCustomer.id,
@@ -1269,7 +1238,6 @@ export const updatePlot = async (
             }
           : null,
 
-        // 全ての役割と顧客情報
         roles:
           updatedContractPlot?.saleContractRoles?.map((role) => ({
             id: role.id,

--- a/src/plots/plotRoutes.ts
+++ b/src/plots/plotRoutes.ts
@@ -4,6 +4,7 @@ import {
   getPlotById,
   createPlot,
   bulkCreatePlots,
+  bulkUpdatePlots,
   updatePlot,
   deletePlot,
   getPlotContracts,
@@ -88,12 +89,20 @@ router.get(
 // 区画情報CRUD
 // ==========================================
 
-// 物理区画一括登録
+// 区画一括登録
 router.post(
   '/bulk',
   authenticate,
   requirePermission(['manager', 'admin']),
   withLogging('Plots', 'bulkCreatePlots', bulkCreatePlots)
+);
+
+// 区画一括編集
+router.put(
+  '/bulk',
+  authenticate,
+  requirePermission(['manager', 'admin']),
+  withLogging('Plots', 'bulkUpdatePlots', bulkUpdatePlots)
 );
 
 // 区画情報詳細取得

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -183,6 +183,235 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
 
+  /api/v1/plots/bulk:
+    post:
+      tags:
+        - Plots
+      summary: 区画情報一括登録
+      description: |
+        複数の区画を一括登録します。1件登録（POST /plots）と同等のフィールド構成で、
+        最大500件まで一度に登録できます。全件が1つのトランザクションで実行され、
+        1件でもエラーがあれば全件ロールバックします。
+        manager または admin 権限が必要です。
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - items
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  maxItems: 500
+                  items:
+                    type: object
+                    description: |
+                      CreatePlot リクエスト（物理区画 + 契約区画 + 販売契約 + 顧客 + オプション）+
+                      familyContacts[] / buriedPersons[] / constructionInfos[] / gravestoneInfo
+                    properties:
+                      physicalPlot:
+                        type: object
+                      contractPlot:
+                        type: object
+                      saleContract:
+                        type: object
+                      customer:
+                        type: object
+                      workInfo:
+                        type: object
+                      billingInfo:
+                        type: object
+                      usageFee:
+                        type: object
+                      managementFee:
+                        type: object
+                      collectiveBurial:
+                        type: object
+                      familyContacts:
+                        type: array
+                        items:
+                          type: object
+                      buriedPersons:
+                        type: array
+                        items:
+                          type: object
+                      constructionInfos:
+                        type: array
+                        items:
+                          type: object
+                      gravestoneInfo:
+                        type: object
+      responses:
+        "201":
+          description: 一括登録成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      totalRequested:
+                        type: integer
+                        example: 10
+                      created:
+                        type: integer
+                        example: 10
+                      results:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            row:
+                              type: integer
+                            id:
+                              type: string
+                              format: uuid
+                            physicalPlotId:
+                              type: string
+                              format: uuid
+                            plotNumber:
+                              type: string
+                              nullable: true
+        "400":
+          description: バリデーションエラー / バッチ内重複 / 既存区画番号と衝突
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      details:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            row:
+                              type: integer
+                            field:
+                              type: string
+                            message:
+                              type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    put:
+      tags:
+        - Plots
+      summary: 区画情報一括編集
+      description: |
+        既存の契約区画を plotNumber（区画番号）でマッチングして一括更新します。
+        未指定フィールドは変更されず、null 明示フィールドはクリアされます。
+        最大500件まで一度に編集可能。トランザクションで all-or-nothing 処理。
+        manager または admin 権限が必要です。
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - items
+              properties:
+                items:
+                  type: array
+                  minItems: 1
+                  maxItems: 500
+                  items:
+                    type: object
+                    required:
+                      - plotNumber
+                    description: |
+                      plotNumber（マッチングキー、必須）+ UpdatePlot 準拠の部分更新フィールド。
+                      空欄（未指定）= 変更しない、null 明示 = クリア。
+                    properties:
+                      plotNumber:
+                        type: string
+                        description: マッチングキーとなる区画番号
+                      physicalPlot:
+                        type: object
+                      contractPlot:
+                        type: object
+                      saleContract:
+                        type: object
+                      customer:
+                        type: object
+                      workInfo:
+                        type: object
+                      billingInfo:
+                        type: object
+                      usageFee:
+                        type: object
+                      managementFee:
+                        type: object
+                      buriedPersons:
+                        type: array
+                        items:
+                          type: object
+                      constructionInfos:
+                        type: array
+                        items:
+                          type: object
+                      collectiveBurial:
+                        type: object
+      responses:
+        "200":
+          description: 一括編集成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      totalRequested:
+                        type: integer
+                      updated:
+                        type: integer
+                      results:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            row:
+                              type: integer
+                            id:
+                              type: string
+                              format: uuid
+                            plotNumber:
+                              type: string
+        "400":
+          description: バリデーションエラー / バッチ内重複 / 区画番号が DB に存在しない
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /api/v1/plots/{id}:
     get:
       tags:

--- a/tests/plots/controllers/bulkCreatePlots.test.ts
+++ b/tests/plots/controllers/bulkCreatePlots.test.ts
@@ -1,11 +1,10 @@
 /**
- * 物理区画一括登録コントローラーのテスト
+ * 区画一括登録コントローラーのテスト
  * POST /api/v1/plots/bulk
  */
 
 import { Request, Response, NextFunction } from 'express';
 
-// Express Request type extension for tests
 declare global {
   namespace Express {
     interface Request {
@@ -21,20 +20,17 @@ declare global {
   }
 }
 
-// Mock Prisma instance
-const mockPhysicalPlotCreate = jest.fn();
+// Mock Prisma
 const mockPhysicalPlotFindMany = jest.fn();
 const mockTransaction = jest.fn();
 
 const mockPrisma: any = {
   physicalPlot: {
     findMany: mockPhysicalPlotFindMany,
-    create: mockPhysicalPlotCreate,
   },
   $transaction: mockTransaction,
 };
 
-// Mock PrismaClient
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
   Prisma: {
@@ -48,9 +44,31 @@ jest.mock('@prisma/client', () => ({
       }
     },
   },
+  AddressType: { home: 'home', work: 'work' },
+  Gender: { male: 'male', female: 'female' },
+  PaymentStatus: { unpaid: 'unpaid', paid: 'paid' },
+  ContractRole: { contractor: 'contractor', applicant: 'applicant' },
+  DmSetting: { allow: 'allow', deny: 'deny' },
 }));
 
-// Import after mocks
+// Mock db/prisma
+jest.mock('../../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+// Mock createPlotCore - we test it via createPlot tests elsewhere
+const mockCreatePlotCore = jest.fn();
+jest.mock('../../../src/plots/controllers/createPlot', () => ({
+  createPlotCore: (...args: unknown[]) => mockCreatePlotCore(...args),
+  createPlot: jest.fn(),
+}));
+
+// Mock history service
+jest.mock('../../../src/plots/services/historyService', () => ({
+  recordEntityCreated: jest.fn(),
+}));
+
 import { bulkCreatePlots } from '../../../src/plots/controllers/bulkCreatePlots';
 
 describe('bulkCreatePlots', () => {
@@ -63,264 +81,188 @@ describe('bulkCreatePlots', () => {
   beforeEach(() => {
     jsonMock = jest.fn().mockReturnThis();
     statusMock = jest.fn().mockReturnValue({ json: jsonMock });
-    mockResponse = {
-      status: statusMock,
-      json: jsonMock,
-    };
+    mockResponse = { status: statusMock, json: jsonMock };
     mockNext = jest.fn();
-
-    // Reset all mocks
     jest.clearAllMocks();
 
-    // Default: no existing plots in DB
     mockPhysicalPlotFindMany.mockResolvedValue([]);
 
-    // Default: transaction executes the callback with tx mock that has create
+    // Default transaction: run the callback with a bare tx mock (child entity mocks added per-test)
     mockTransaction.mockImplementation(async (callback: any) => {
       const txMock = {
-        physicalPlot: {
-          create: mockPhysicalPlotCreate,
+        familyContact: { create: jest.fn().mockResolvedValue({ id: 'fc-1', name: 'test' }) },
+        buriedPerson: { create: jest.fn().mockResolvedValue({ id: 'bp-1', name: 'test' }) },
+        constructionInfo: {
+          create: jest.fn().mockResolvedValue({ id: 'ci-1', construction_type: null }),
         },
       };
       return callback(txMock);
     });
+
+    // Default: createPlotCore returns IDs
+    mockCreatePlotCore.mockImplementation(async (_tx: unknown, item: any) => ({
+      contractPlotId: `cp-${item.physicalPlot.plotNumber}`,
+      physicalPlotId: `pp-${item.physicalPlot.plotNumber}`,
+      customerId: `cu-${item.physicalPlot.plotNumber}`,
+    }));
   });
 
-  // Helper to create valid items
-  const createValidItems = (count: number) => {
-    return Array.from({ length: count }, (_, i) => ({
-      plotNumber: `A-${i + 1}`,
-      areaName: `${Math.floor(i / 10) + 1}期`,
-      areaSqm: 3.6,
-      notes: `テスト区画${i + 1}`,
-    }));
-  };
+  const buildValidItem = (plotNumber: string, overrides: Record<string, unknown> = {}) => ({
+    physicalPlot: { plotNumber, areaName: '第1期', areaSqm: 3.6 },
+    contractPlot: { contractAreaSqm: 3.6 },
+    saleContract: { contractDate: '2026-04-01', price: 500000 },
+    customer: {
+      name: '田中太郎',
+      nameKana: 'タナカタロウ',
+      postalCode: '160-0000',
+      address: '東京都新宿区...',
+      phoneNumber: '09012345678',
+    },
+    ...overrides,
+  });
 
   describe('正常系', () => {
-    it('5件の物理区画を一括登録できること', async () => {
-      const items = createValidItems(5);
-      mockRequest = {
-        body: { items },
-      };
-
-      // Mock each create call
-      items.forEach((item, index) => {
-        mockPhysicalPlotCreate.mockResolvedValueOnce({
-          id: `uuid-${index}`,
-          plot_number: item.plotNumber,
-          area_name: item.areaName,
-          area_sqm: { toNumber: () => item.areaSqm },
-          status: 'available',
-          notes: item.notes,
-          created_at: new Date(),
-          updated_at: new Date(),
-          deleted_at: null,
-        });
-      });
+    it('3件の区画を一括登録できること', async () => {
+      const items = ['A-1', 'A-2', 'A-3'].map((pn) => buildValidItem(pn));
+      mockRequest = { body: { items } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
+      expect(mockNext).not.toHaveBeenCalled();
       expect(statusMock).toHaveBeenCalledWith(201);
       expect(jsonMock).toHaveBeenCalledWith({
         success: true,
         data: {
-          totalRequested: 5,
-          created: 5,
-          results: items.map((item, index) => ({
-            row: index,
-            id: `uuid-${index}`,
-            plotNumber: item.plotNumber,
-            areaName: item.areaName,
-          })),
+          totalRequested: 3,
+          created: 3,
+          results: expect.arrayContaining([
+            expect.objectContaining({ row: 0, plotNumber: 'A-1' }),
+            expect.objectContaining({ row: 1, plotNumber: 'A-2' }),
+            expect.objectContaining({ row: 2, plotNumber: 'A-3' }),
+          ]),
         },
       });
-
-      // Transaction should have been called
-      expect(mockTransaction).toHaveBeenCalledTimes(1);
-      // Each item should be created
-      expect(mockPhysicalPlotCreate).toHaveBeenCalledTimes(5);
+      expect(mockCreatePlotCore).toHaveBeenCalledTimes(3);
     });
 
-    it('areaSqmが未指定の場合デフォルト値3.6が使用されること', async () => {
-      const items = [{ plotNumber: 'B-1', areaName: '第2期' }];
-      mockRequest = {
-        body: { items },
-      };
+    it('familyContacts / buriedPersons / constructionInfos を含む複合登録ができること', async () => {
+      const fcCreateSpy = jest.fn().mockResolvedValue({ id: 'fc-1', name: '家族' });
+      const bpCreateSpy = jest.fn().mockResolvedValue({ id: 'bp-1', name: '埋葬' });
+      const ciCreateSpy = jest.fn().mockResolvedValue({ id: 'ci-1', construction_type: '工事' });
 
-      mockPhysicalPlotCreate.mockResolvedValueOnce({
-        id: 'uuid-0',
-        plot_number: 'B-1',
-        area_name: '第2期',
-        area_sqm: { toNumber: () => 3.6 },
-        status: 'available',
-        notes: null,
-        created_at: new Date(),
-        updated_at: new Date(),
-        deleted_at: null,
+      mockTransaction.mockImplementation(async (callback: any) => {
+        const txMock = {
+          familyContact: { create: fcCreateSpy },
+          buriedPerson: { create: bpCreateSpy },
+          constructionInfo: { create: ciCreateSpy },
+        };
+        return callback(txMock);
       });
+
+      const item = buildValidItem('A-1', {
+        familyContacts: [
+          {
+            name: '田中花子',
+            relationship: '配偶者',
+            address: '東京都新宿区...',
+            phoneNumber: '09011112222',
+          },
+        ],
+        buriedPersons: [{ name: '田中一郎', deathDate: '2020-03-15' }],
+        constructionInfos: [{ constructionType: '新規建立' }],
+      });
+      mockRequest = { body: { items: [item] } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
+      expect(mockNext).not.toHaveBeenCalled();
       expect(statusMock).toHaveBeenCalledWith(201);
-      expect(jsonMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          success: true,
-          data: expect.objectContaining({
-            totalRequested: 1,
-            created: 1,
-          }),
-        })
-      );
-
-      // Verify Prisma create was called with default areaSqm (Decimal(3.6))
-      expect(mockPhysicalPlotCreate).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          plot_number: 'B-1',
-          area_name: '第2期',
-          status: 'available',
-          notes: null,
-        }),
-      });
+      expect(fcCreateSpy).toHaveBeenCalledTimes(1);
+      expect(bpCreateSpy).toHaveBeenCalledTimes(1);
+      expect(ciCreateSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('notesが未指定の場合nullが設定されること', async () => {
-      const items = [{ plotNumber: 'C-1', areaName: '第3期', areaSqm: 1.8 }];
-      mockRequest = {
-        body: { items },
-      };
-
-      mockPhysicalPlotCreate.mockResolvedValueOnce({
-        id: 'uuid-0',
-        plot_number: 'C-1',
-        area_name: '第3期',
-        area_sqm: { toNumber: () => 1.8 },
-        status: 'available',
-        notes: null,
-        created_at: new Date(),
-        updated_at: new Date(),
-        deleted_at: null,
+    it('familyContacts で必須フィールド欠如の行はスキップされること', async () => {
+      const fcCreateSpy = jest.fn().mockResolvedValue({ id: 'fc-1', name: '家族' });
+      mockTransaction.mockImplementation(async (callback: any) => {
+        const txMock = {
+          familyContact: { create: fcCreateSpy },
+          buriedPerson: { create: jest.fn() },
+          constructionInfo: { create: jest.fn() },
+        };
+        return callback(txMock);
       });
+
+      const item = buildValidItem('A-1', {
+        familyContacts: [
+          // name 欠如 → スキップされる
+          { relationship: '配偶者', address: '...', phoneNumber: '09011112222' },
+          // 全て揃っている
+          {
+            name: '田中花子',
+            relationship: '配偶者',
+            address: '東京都新宿区...',
+            phoneNumber: '09011112222',
+          },
+        ],
+      });
+      mockRequest = { body: { items: [item] } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(statusMock).toHaveBeenCalledWith(201);
-      expect(mockPhysicalPlotCreate).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          notes: null,
-        }),
-      });
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(fcCreateSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('バリデーションエラー', () => {
-    it('plotNumberが欠けている場合エラーを返すこと', async () => {
-      const items = [{ areaName: '第1期', areaSqm: 3.6 }];
-      mockRequest = {
-        body: { items },
-      };
-
-      await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
-
-      // Error should be passed to next()
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toBe('一括登録でエラーが発生しました');
-      expect(error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            row: 0,
-            field: 'plotNumber',
-          }),
-        ])
-      );
-    });
-
-    it('areaNameが欠けている場合エラーを返すこと', async () => {
-      const items = [{ plotNumber: 'A-1', areaSqm: 3.6 }];
-      mockRequest = {
-        body: { items },
-      };
+    it('physicalPlot が欠けている場合エラーを返すこと', async () => {
+      const invalidItem: any = { contractPlot: { contractAreaSqm: 3.6 } };
+      mockRequest = { body: { items: [invalidItem] } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
+      const error = mockNext.mock.calls[0]![0] as any;
       expect(error.name).toBe('ValidationError');
-      expect(error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            row: 0,
-            field: 'areaName',
-          }),
-        ])
-      );
+      expect(mockCreatePlotCore).not.toHaveBeenCalled();
     });
 
     it('空配列の場合エラーを返すこと', async () => {
-      mockRequest = {
-        body: { items: [] },
-      };
+      mockRequest = { body: { items: [] } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
+      const error = mockNext.mock.calls[0]![0] as any;
       expect(error.name).toBe('ValidationError');
-      expect(error.message).toBe('一括登録でエラーが発生しました');
     });
 
     it('501件の場合最大件数エラーを返すこと', async () => {
-      const items = createValidItems(501);
-      mockRequest = {
-        body: { items },
-      };
+      const items = Array.from({ length: 501 }, (_, i) => buildValidItem(`A-${i}`));
+      mockRequest = { body: { items } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
+      const error = mockNext.mock.calls[0]![0] as any;
       expect(error.name).toBe('ValidationError');
-      expect(error.message).toBe('一括登録でエラーが発生しました');
       expect(error.details).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({
-            message: expect.stringContaining('500'),
-          }),
+          expect.objectContaining({ message: expect.stringContaining('500') }),
         ])
       );
-    });
-
-    it('itemsフィールドが存在しない場合エラーを返すこと', async () => {
-      mockRequest = {
-        body: {},
-      };
-
-      await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
-      expect(error.name).toBe('ValidationError');
     });
   });
 
   describe('重複チェック', () => {
     it('バッチ内で区画番号が重複している場合エラーを返すこと', async () => {
-      const items = [
-        { plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 },
-        { plotNumber: 'A-2', areaName: '第1期', areaSqm: 3.6 },
-        { plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 }, // duplicate
-      ];
-      mockRequest = {
-        body: { items },
-      };
+      const items = [buildValidItem('A-1'), buildValidItem('A-2'), buildValidItem('A-1')];
+      mockRequest = { body: { items } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
+      const error = mockNext.mock.calls[0]![0] as any;
       expect(error.name).toBe('ValidationError');
-      expect(error.message).toBe('一括登録でエラーが発生しました');
       expect(error.details).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -329,60 +271,35 @@ describe('bulkCreatePlots', () => {
           }),
         ])
       );
-
-      // Transaction should NOT have been called
       expect(mockTransaction).not.toHaveBeenCalled();
     });
 
-    it('データベースに既存の区画番号がある場合エラーを返すこと', async () => {
-      const items = [
-        { plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 },
-        { plotNumber: 'A-2', areaName: '第1期', areaSqm: 3.6 },
-        { plotNumber: 'A-3', areaName: '第1期', areaSqm: 3.6 },
-      ];
-      mockRequest = {
-        body: { items },
-      };
+    it('DB に既存の区画番号がある場合エラーを返すこと', async () => {
+      const items = ['A-1', 'A-2', 'A-3'].map((pn) => buildValidItem(pn));
+      mockRequest = { body: { items } };
 
-      // Simulate A-2 already exists in DB
       mockPhysicalPlotFindMany.mockResolvedValue([{ plot_number: 'A-2' }]);
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0][0] as any;
+      const error = mockNext.mock.calls[0]![0] as any;
       expect(error.name).toBe('ValidationError');
-      expect(error.message).toBe('一括登録でエラーが発生しました');
       expect(error.details).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            row: 1, // A-2 is at index 1
+            row: 1,
             field: 'plotNumber',
             message: expect.stringContaining('A-2'),
           }),
         ])
       );
-
-      // findMany should have been called to check existing
-      expect(mockPhysicalPlotFindMany).toHaveBeenCalledWith({
-        where: {
-          plot_number: { in: ['A-1', 'A-2', 'A-3'] },
-          deleted_at: null,
-        },
-        select: { plot_number: true },
-      });
-
-      // Transaction should NOT have been called
       expect(mockTransaction).not.toHaveBeenCalled();
     });
   });
 
   describe('トランザクションエラー', () => {
-    it('トランザクション中にエラーが発生した場合nextにエラーが渡されること', async () => {
-      const items = [{ plotNumber: 'A-1', areaName: '第1期', areaSqm: 3.6 }];
-      mockRequest = {
-        body: { items },
-      };
+    it('DB エラーが発生した場合 next にエラーが渡されること', async () => {
+      mockRequest = { body: { items: [buildValidItem('A-1')] } };
 
       const dbError = new Error('Database connection lost');
       mockTransaction.mockRejectedValue(dbError);
@@ -390,6 +307,32 @@ describe('bulkCreatePlots', () => {
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith(dbError);
+    });
+
+    it('createPlotCore が ValidationError を投げた場合、行番号付きで再スローされること', async () => {
+      mockRequest = { body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] } };
+
+      const { ValidationError } = jest.requireActual('../../../src/middleware/errorHandler');
+      mockCreatePlotCore
+        .mockImplementationOnce(async (_tx: any, item: any) => ({
+          contractPlotId: 'cp-1',
+          physicalPlotId: 'pp-1',
+          customerId: 'cu-1',
+          _item: item,
+        }))
+        .mockImplementationOnce(async () => {
+          throw new ValidationError('契約面積エラー', [
+            { field: 'contractAreaSqm', message: '面積エラー' },
+          ]);
+        });
+
+      await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(error.message).toContain('行 1');
+      expect(error.details).toEqual(expect.arrayContaining([expect.objectContaining({ row: 1 })]));
     });
   });
 });

--- a/tests/plots/controllers/bulkUpdatePlots.test.ts
+++ b/tests/plots/controllers/bulkUpdatePlots.test.ts
@@ -1,0 +1,273 @@
+/**
+ * 区画一括編集コントローラーのテスト
+ * PUT /api/v1/plots/bulk
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPhysicalPlotFindMany = jest.fn();
+const mockTransaction = jest.fn();
+
+const mockPrisma: any = {
+  physicalPlot: { findMany: mockPhysicalPlotFindMany },
+  $transaction: mockTransaction,
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: {
+    Decimal: class MockDecimal {
+      private value: number;
+      constructor(value: number) {
+        this.value = value;
+      }
+      toNumber() {
+        return this.value;
+      }
+    },
+  },
+}));
+
+jest.mock('../../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+const mockUpdatePlotCore = jest.fn();
+jest.mock('../../../src/plots/controllers/updatePlot', () => ({
+  updatePlotCore: (...args: unknown[]) => mockUpdatePlotCore(...args),
+  updatePlot: jest.fn(),
+}));
+
+import { bulkUpdatePlots } from '../../../src/plots/controllers/bulkUpdatePlots';
+
+describe('bulkUpdatePlots', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let mockNext: jest.MockedFunction<NextFunction>;
+  let jsonMock: jest.Mock;
+  let statusMock: jest.Mock;
+
+  beforeEach(() => {
+    jsonMock = jest.fn().mockReturnThis();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+    mockResponse = { status: statusMock, json: jsonMock };
+    mockNext = jest.fn();
+    jest.clearAllMocks();
+
+    mockTransaction.mockImplementation(async (callback: any) => {
+      return callback({});
+    });
+    mockUpdatePlotCore.mockResolvedValue(undefined);
+  });
+
+  const buildValidItem = (plotNumber: string, overrides: Record<string, unknown> = {}) => ({
+    plotNumber,
+    customer: { name: '新しい名前' },
+    ...overrides,
+  });
+
+  describe('正常系', () => {
+    it('既存契約を plotNumber マッチングで一括更新できること', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([
+        { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+        { plot_number: 'A-2', contractPlots: [{ id: 'cp-2' }] },
+      ]);
+
+      mockRequest = {
+        body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] },
+      };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(200);
+      expect(jsonMock).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          totalRequested: 2,
+          updated: 2,
+          results: [
+            { row: 0, id: 'cp-1', plotNumber: 'A-1' },
+            { row: 1, id: 'cp-2', plotNumber: 'A-2' },
+          ],
+        },
+      });
+      expect(mockUpdatePlotCore).toHaveBeenCalledTimes(2);
+    });
+
+    it('未指定フィールドは updatePlotCore に undefined として渡されること（部分更新仕様）', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([
+        { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+      ]);
+      mockRequest = {
+        body: { items: [{ plotNumber: 'A-1', customer: { name: '新名称' } }] },
+      };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const callArgs = mockUpdatePlotCore.mock.calls[0];
+      expect(callArgs![1]).toBe('cp-1');
+      const input = callArgs![2];
+      expect(input.customer).toEqual({ name: '新名称' });
+      expect(input.physicalPlot).toBeUndefined();
+      expect(input.contractPlot).toBeUndefined();
+      expect(input.plotNumber).toBeUndefined();
+    });
+  });
+
+  describe('バリデーションエラー', () => {
+    it('plotNumber が欠けている場合エラーを返すこと', async () => {
+      mockRequest = { body: { items: [{ customer: { name: 'X' } }] } };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('空配列の場合エラーを返すこと', async () => {
+      mockRequest = { body: { items: [] } };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+    });
+
+    it('501件の場合最大件数エラーを返すこと', async () => {
+      const items = Array.from({ length: 501 }, (_, i) => buildValidItem(`A-${i}`));
+      mockRequest = { body: { items } };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining('500') }),
+        ])
+      );
+    });
+  });
+
+  describe('マッチングエラー', () => {
+    it('バッチ内で plotNumber が重複している場合エラーを返すこと', async () => {
+      mockRequest = {
+        body: { items: [buildValidItem('A-1'), buildValidItem('A-1')] },
+      };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            field: 'plotNumber',
+            message: expect.stringContaining('A-1'),
+          }),
+        ])
+      );
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('DB に plotNumber が存在しない場合エラーを返すこと', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([
+        { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+      ]);
+      mockRequest = {
+        body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] },
+      };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            field: 'plotNumber',
+            message: expect.stringContaining('A-2'),
+          }),
+        ])
+      );
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('PhysicalPlot はあるが有効な契約が無い場合エラーを返すこと', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([{ plot_number: 'A-1', contractPlots: [] }]);
+      mockRequest = { body: { items: [buildValidItem('A-1')] } };
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(error.details).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining('有効な契約区画'),
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('トランザクションエラー', () => {
+    it('updatePlotCore が ValidationError を投げた場合、行番号付きで再スローされること', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([
+        { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+        { plot_number: 'A-2', contractPlots: [{ id: 'cp-2' }] },
+      ]);
+      mockRequest = {
+        body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] },
+      };
+
+      const { ValidationError } = jest.requireActual('../../../src/middleware/errorHandler');
+      mockUpdatePlotCore
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(
+          new ValidationError('契約面積エラー', [{ field: 'contractAreaSqm', message: 'xxx' }])
+        );
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const error = mockNext.mock.calls[0]![0] as any;
+      expect(error.name).toBe('ValidationError');
+      expect(error.message).toContain('行 1');
+      expect(error.details).toEqual(expect.arrayContaining([expect.objectContaining({ row: 1 })]));
+    });
+
+    it('DB エラーが発生した場合 next にエラーが渡されること', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([
+        { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+      ]);
+      mockRequest = { body: { items: [buildValidItem('A-1')] } };
+
+      const dbError = new Error('Database connection lost');
+      mockTransaction.mockRejectedValue(dbError);
+
+      await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(dbError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **POST /api/v1/plots/bulk 拡充**: 物理区画4項目のみ → 1件登録（createPlot）と同等の全セクション対応
- **PUT /api/v1/plots/bulk 新規実装**: plotNumber でマッチングして一括部分更新（未指定=変更なし、null=クリア）
- createPlot / updatePlot のトランザクション内処理を `createPlotCore` / `updatePlotCore` に切り出し、bulk から再利用

Closes #74

## 対応セクション（POST /bulk）

| セクション | ソース | 備考 |
|--|--|--|
| physicalPlot | createPlotSchema | 既存区画参照 or 新規作成 |
| contractPlot | createPlotSchema | 契約面積の妥当性検証あり |
| saleContract | createPlotSchema | roles サポート |
| customer | createPlotSchema | - |
| workInfo / billingInfo | createPlotSchema | 任意 |
| usageFee / managementFee | createPlotSchema | 任意 |
| collectiveBurial | createPlotSchema | 任意 |
| familyContacts[] | bulk 拡張 | 必須フィールド欠如行はスキップ |
| buriedPersons[] | bulk 拡張 | 任意 |
| constructionInfos[] | bulk 拡張 | 任意 |
| gravestoneInfo | bulk 拡張 | 任意（現状ペイロード受領のみ） |

## 一括編集（PUT /bulk）仕様

- マッチングキー: **plotNumber**（ルートに配置、必須）
- 更新対象: **最新 ContractPlot**（1 PhysicalPlot に複数契約がある場合は created_at DESC で最新を選択）
- 部分更新: **undefined = 変更しない**、**null 明示 = クリア**（updatePlotCore 仕様に準拠）
- 更新可能セクション: updatePlotSchema と同一
- History テーブルに全更新を記録（updatePlotCore 経由）

## 共通仕様

- 最大 **500 件**
- トランザクション **all-or-nothing**
- エラー行に **row 番号** を付与（フロントの行マッピング用）
- permission: **manager | admin**

## アーキテクチャ変更

`createPlot.ts` / `updatePlot.ts` からトランザクション内処理を外部化した:

```ts
export async function createPlotCore(tx, input, req): Promise<{...}>
export async function updatePlotCore(tx, id, input, req): Promise<void>
```

controller 自体は transaction wrapper + response builder のみ担当。
bulk 側は単一トランザクションで core 関数を N 回呼び出す構造。

## テスト

- `tests/plots/controllers/bulkCreatePlots.test.ts` — 10 ケース（新ペイロード形式に書き換え）
- `tests/plots/controllers/bulkUpdatePlots.test.ts` — 10 ケース（新規）
- 全 **714 テストパス**、lint 0 errors、build OK

## Frontend

フロントは [komine-crm-frontend#84](https://github.com/zaitsu82/komine-crm-frontend/pull/84) で実装済み。
本 PR マージ後に動作する想定。

## Test plan
- [ ] POST /bulk で1件登録と同じフィールドが全て保存されること
- [ ] POST /bulk で familyContacts/buriedPersons/constructionInfos が紐付いて作成されること
- [ ] POST /bulk でバッチ内重複・既存DB重複がエラーになること
- [ ] PUT /bulk で plotNumber マッチングで既存契約が更新されること
- [ ] PUT /bulk で未指定フィールドが変更されないこと、null でクリアされること
- [ ] PUT /bulk で存在しない plotNumber がエラーになること
- [ ] 500件超でバリデーションエラーになること
- [ ] 1件でも失敗すると全件ロールバックされること
- [ ] 権限（manager/admin）が正しく適用されること
- [ ] createPlot / updatePlot の既存動作に回帰が無いこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)