### PR TITLE
fix(docker): resolve @komine/types module resolution and layer cache issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,14 @@ RUN apk add --no-cache git
 
 WORKDIR /packages/types
 
-RUN git clone --depth 1 https://github.com/zaitsu82/komine-types.git . && \
+# TYPES_REF: ビルドする @komine/types の git ref (commit SHA / tag / branch)
+# Docker layer cache対策: このARGを変更することで types 再取得を強制できる。
+# Render側で Build Arg として最新 SHA を渡すか、Dockerfile を更新すること。
+# 詳細: zaitsu82/komine-crm-backend#60
+ARG TYPES_REF=main
+
+RUN git clone https://github.com/zaitsu82/komine-types.git . && \
+    git checkout ${TYPES_REF} && \
     npm ci && \
     npm run build
 
@@ -33,8 +40,10 @@ COPY prisma.config.ts ./
 # 本番用依存関係のみインストール
 # Prisma v7: クライアントエンジンはJSベース（ネイティブバイナリ不要）
 # --ignore-scriptsでprepareスクリプト(husky)をスキップ（本番環境では不要）
+# --install-links: file:依存（@komine/types）をsymlinkでなく実体コピーでインストール
+#   → production ステージで /packages/types を持たなくても解決できる
 # --no-save prisma: preDeployCommand (prisma migrate deploy) 実行用にCLIを含める
-RUN npm ci --omit=dev --ignore-scripts && \
+RUN npm ci --omit=dev --ignore-scripts --install-links && \
     npm install --no-save prisma && \
     npx prisma generate && \
     npm cache clean --force
@@ -53,10 +62,11 @@ WORKDIR /app
 COPY --from=types /packages/types /packages/types
 
 # 依存関係のインストール（devDependenciesを含む）
+# --install-links: file:依存（@komine/types）をsymlinkでなく実体コピーでインストール
 COPY package*.json ./
 COPY prisma ./prisma/
 COPY prisma.config.ts ./
-RUN npm ci && \
+RUN npm ci --install-links && \
     npx prisma generate
 
 # ソースコードをコピー


### PR DESCRIPTION
## Summary

- Renderデプロイ時の `Cannot find module '@komine/types'` ランタイムエラーを修正
- Docker layer cache による古い types 再利用問題（#60）を同時に解決

## 背景

### 1. 今回のRenderデプロイエラー（ランタイム）

\`\`\`
Error: Cannot find module '@komine/types'
Require stack:
- /app/dist/middleware/validation.js
- /app/dist/auth/authRoutes.js
- /app/dist/index.js
\`\`\`

**原因**: \`package.json\` の \`\"@komine/types\": \"file:../packages/types\"\` は、npm 7+ のデフォルトで **symlink** として \`node_modules\` に installされる。production ステージは \`/app/node_modules\` しかコピーしていないため、symlinkのリンク先 \`/packages/types\` が存在せず壊れる。

### 2. Issue #60（ビルド時の古いtypes再利用）

Stage 0 の \`git clone --depth 1\` が Docker layer cache に刺さり、types側の更新が反映されない問題。2026-04-08 の TS2339 エラーの直接原因。

## 変更内容

### \`npm ci --install-links\` 追加（deps / builder ステージ）

\`file:\` 依存を symlinkでなく**実体コピー**として install するようにした。これにより production ステージは \`/packages/types\` を持たなくても node_modules だけで自己完結する。

### \`TYPES_REF\` ARG 追加（Stage 0）

\`\`\`dockerfile
ARG TYPES_REF=main
RUN git clone https://github.com/zaitsu82/komine-types.git . && \
    git checkout \${TYPES_REF} && \
    npm ci && \
    npm run build
\`\`\`

types更新後に Render の Build Arg で最新 SHA を渡せばキャッシュバスト可能。Dockerfile編集なしで更新できる運用に。

## Test plan

- [ ] Render上で再デプロイして起動成功を確認（`Cannot find module` が出ない）
- [ ] \`/health\` エンドポイントが200を返す
- [ ] 認証エンドポイント（\`/api/v1/auth/*\`）が正常応答
- [ ] types更新時の運用フロー（TYPES_REF の更新方法）を README or SETUP.md に追記（別PRでもOK）

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)