### PR TITLE
feat(yucho): ゆうちょ連携API（請求データ取得・全銀CSV生成）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,9 @@ src/
 - **Auth** - Authentication system (`/api/v1/auth`)
   - Supabase-based JWT authentication
   - Login, logout, current user info, password change
+- **Yucho** - ゆうちょ連携 (`/api/v1/yucho`)
+  - `GET /yucho/billing` - 管理料・合祀料金の請求対象データ集約
+  - `GET /yucho/export` - 全銀協フォーマット(120バイト固定長)CSV生成
 
 ### Planned Business Entities
 The following entities are defined in the database schema but routes not yet implemented:

--- a/scripts/insert-test-data.js
+++ b/scripts/insert-test-data.js
@@ -221,7 +221,8 @@ async function insertTestData() {
         location_description: null,
         contract_date: new Date('2024-03-01'),
         price: 800000,
-        payment_status: 'paid',
+        contract_status: 'active',
+        payment_status: 'unpaid',
         reservation_date: new Date('2024-02-01'),
         acceptance_number: 'C-2024-001',
         permit_date: new Date('2024-02-15'),
@@ -239,6 +240,7 @@ async function insertTestData() {
         location_description: null,
         contract_date: new Date('2025-01-15'),
         price: 1000000,
+        contract_status: 'active',
         payment_status: 'partial_paid',
         reservation_date: new Date('2024-12-10'),
         acceptance_number: 'C-2025-003',
@@ -256,7 +258,8 @@ async function insertTestData() {
         location_description: '左半分',
         contract_date: new Date('2024-06-01'),
         price: 720000,
-        payment_status: 'paid',
+        contract_status: 'active',
+        payment_status: 'unpaid',
         reservation_date: new Date('2024-05-15'),
         acceptance_number: 'C-2024-010',
         permit_date: new Date('2024-05-25'),
@@ -274,6 +277,7 @@ async function insertTestData() {
         location_description: '右半分',
         contract_date: new Date('2024-09-01'),
         price: 720000,
+        contract_status: 'active',
         payment_status: 'unpaid',
         reservation_date: new Date('2024-08-20'),
         acceptance_number: 'C-2024-015',
@@ -370,11 +374,47 @@ async function insertTestData() {
       data: {
         customer_id: customer1.id,
         billing_type: 'bank_transfer',
-        bank_name: 'みずほ銀行',
-        branch_name: '新宿支店',
+        bank_name: 'ゆうちょ銀行',
+        branch_name: '〇一八', // 記号10180 → 支店コード018
         account_type: 'ordinary',
-        account_number: '1234567',
-        account_holder: '山田太郎',
+        account_number: '12345671', // ゆうちょ番号（方式A: そのまま格納）
+        account_holder: 'ヤマダタロウ',
+      },
+    });
+
+    await prisma.billingInfo.create({
+      data: {
+        customer_id: customer3.id,
+        billing_type: 'bank_transfer',
+        bank_name: 'ゆうちょ銀行',
+        branch_name: '〇二八', // 記号10280 → 支店コード028
+        account_type: 'ordinary',
+        account_number: '23456782',
+        account_holder: 'サトウケンイチ',
+      },
+    });
+
+    await prisma.billingInfo.create({
+      data: {
+        customer_id: customer4.id,
+        billing_type: 'bank_transfer',
+        bank_name: 'ゆうちょ銀行',
+        branch_name: '〇三八', // 記号10380 → 支店コード038
+        account_type: 'ordinary',
+        account_number: '34567893',
+        account_holder: 'スズキイチロウ',
+      },
+    });
+
+    await prisma.billingInfo.create({
+      data: {
+        customer_id: customer5.id,
+        billing_type: 'bank_transfer',
+        bank_name: 'ゆうちょ銀行',
+        branch_name: '〇四八', // 記号10480 → 支店コード048
+        account_type: 'ordinary',
+        account_number: '45678904',
+        account_holder: 'タナカミサキ',
       },
     });
 
@@ -408,10 +448,55 @@ async function insertTestData() {
         billing_type: '年次請求',
         billing_years: '毎年',
         area: '3.6㎡',
-        billing_month: '4月',
+        billing_month: '5月',
         management_fee: '24,000円',
         unit_price: '24,000円',
         last_billing_month: '2025年4月',
+        payment_method: '口座振替',
+      },
+    });
+
+    await prisma.managementFee.create({
+      data: {
+        contract_plot_id: contractPlot2.id,
+        calculation_type: '面積単価',
+        tax_type: '消費税10%',
+        billing_type: '年次請求',
+        billing_years: '毎年',
+        area: '5.0㎡',
+        billing_month: '5月',
+        management_fee: '35,000円',
+        unit_price: '7,000円/㎡',
+        payment_method: '口座振替',
+      },
+    });
+
+    await prisma.managementFee.create({
+      data: {
+        contract_plot_id: contractPlot3.id,
+        calculation_type: '一律料金',
+        tax_type: '消費税10%',
+        billing_type: '年次請求',
+        billing_years: '毎年',
+        area: '3.6㎡',
+        billing_month: '5月',
+        management_fee: '18,000円',
+        unit_price: '18,000円',
+        payment_method: '口座振替',
+      },
+    });
+
+    await prisma.managementFee.create({
+      data: {
+        contract_plot_id: contractPlot4.id,
+        calculation_type: '一律料金',
+        tax_type: '消費税10%',
+        billing_type: '年次請求',
+        billing_years: '毎年',
+        area: '3.6㎡',
+        billing_month: '5月',
+        management_fee: '18,000円',
+        unit_price: '18,000円',
         payment_method: '口座振替',
       },
     });
@@ -577,8 +662,23 @@ async function insertTestData() {
         burial_capacity: 6,
         current_burial_count: 2,
         validity_period_years: 33,
+        billing_scheduled_date: new Date('2026-05-15'),
         billing_status: 'pending',
+        billing_amount: 50000,
         notes: '永代供養墓（33年契約）',
+      },
+    });
+
+    await prisma.collectiveBurial.create({
+      data: {
+        contract_plot_id: contractPlot3.id,
+        burial_capacity: 4,
+        current_burial_count: 1,
+        validity_period_years: 13,
+        billing_scheduled_date: new Date('2026-05-20'),
+        billing_status: 'pending',
+        billing_amount: 30000,
+        notes: '合祀料金（13年契約）',
       },
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import masterRoutes from './masters/masterRoutes';
 import staffRoutes from './staff/staffRoutes';
 import collectiveBurialRoutes from './collective-burials/collectiveBurialRoutes';
 import documentRoutes from './documents/documentRoutes';
+import yuchoRoutes from './yucho/yuchoRoutes';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler';
 import { requestLogger, securityHeaders } from './middleware/logger';
 import { requestIdMiddleware } from './middleware/requestId';
@@ -105,6 +106,7 @@ app.use('/api/v1/masters', masterRoutes); // マスタデータルート
 app.use('/api/v1/staff', staffRoutes); // スタッフ管理ルート
 app.use('/api/v1/collective-burials', collectiveBurialRoutes); // 合祀管理ルート
 app.use('/api/v1/documents', documentRoutes); // 書類管理ルート
+app.use('/api/v1/yucho', yuchoRoutes); // ゆうちょ連携ルート
 
 // 404エラーハンドラー（すべてのルートの後に配置）
 app.use(notFoundHandler);

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -13,3 +13,4 @@ export * from './plotBusinessRules';
 export * from './inventoryValidation';
 export * from './authValidation';
 export * from './masterValidation';
+export * from './yuchoValidation';

--- a/src/validations/yuchoValidation.ts
+++ b/src/validations/yuchoValidation.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+/**
+ * ゆうちょ連携バリデーション
+ *
+ * 管理料・合祀料金の請求データ取得とCSV生成に関するクエリパラメータを検証する。
+ */
+
+// 請求対象カテゴリ
+export const YuchoCategoryEnum = z.enum(['management', 'collective', 'all']);
+export type YuchoCategory = z.infer<typeof YuchoCategoryEnum>;
+
+// 請求ステータスフィルタ
+//   unbilled: 未請求 (ManagementFee → 未集金/未払い相当, CollectiveBurial → pending)
+//   billed:   請求済 (CollectiveBurial.billing_status = billed)
+//   paid:     支払済 (CollectiveBurial.billing_status = paid)
+//   all:      全て
+export const YuchoStatusEnum = z.enum(['unbilled', 'billed', 'paid', 'all']);
+export type YuchoStatus = z.infer<typeof YuchoStatusEnum>;
+
+// CSV形式
+export const YuchoFormatEnum = z.enum(['zengin']);
+export type YuchoFormat = z.infer<typeof YuchoFormatEnum>;
+
+const yearSchema = z.coerce.number().int().min(1900).max(2999);
+const monthSchema = z.coerce.number().int().min(1).max(12);
+
+// 請求データ取得用クエリスキーマ
+export const yuchoBillingQuerySchema = z.object({
+  year: yearSchema,
+  month: monthSchema.optional(),
+  category: YuchoCategoryEnum.optional().default('all'),
+  status: YuchoStatusEnum.optional().default('unbilled'),
+});
+
+export type YuchoBillingQuery = z.infer<typeof yuchoBillingQuerySchema>;
+
+// CSV エクスポート用クエリスキーマ
+//   transferDate: 引落日（MMDDフォーマット用）
+//   clientCode:   委託者コード（10桁）
+//   clientName:   委託者名（半角40文字以内）
+//   bankCode:     金融機関コード（4桁、デフォルト 9900 = ゆうちょ）
+//   branchCode:   支店コード（3桁、デフォルト 000）
+export const yuchoExportQuerySchema = z.object({
+  year: yearSchema,
+  month: monthSchema.optional(),
+  category: YuchoCategoryEnum.optional().default('all'),
+  status: YuchoStatusEnum.optional().default('unbilled'),
+  format: YuchoFormatEnum.optional().default('zengin'),
+  transferDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'transferDate must be YYYY-MM-DD'),
+  clientCode: z.string().regex(/^\d{1,10}$/, 'clientCode must be up to 10 digits'),
+  clientName: z.string().min(1).max(40),
+  bankCode: z
+    .string()
+    .regex(/^\d{4}$/, 'bankCode must be 4 digits')
+    .optional()
+    .default('9900'),
+  branchCode: z
+    .string()
+    .regex(/^\d{3}$/, 'branchCode must be 3 digits')
+    .optional()
+    .default('000'),
+});
+
+export type YuchoExportQuery = z.infer<typeof yuchoExportQuerySchema>;
+
+// =============================================================================
+// レスポンス型定義
+// =============================================================================
+
+export interface YuchoBillingItem {
+  category: 'management' | 'collective';
+  sourceId: string;
+  contractPlotId: string;
+  plotNumber: string;
+  areaName: string;
+  contractDate: string;
+  customerId: string | null;
+  customerName: string | null;
+  customerNameKana: string | null;
+  billingAmount: number;
+  billingStatus: string;
+  scheduledDate: string | null;
+  billingMonth: number | null;
+  billingInfo: {
+    bankName: string | null;
+    branchName: string | null;
+    accountType: string | null;
+    accountNumber: string | null;
+    accountHolder: string | null;
+  } | null;
+}
+
+export interface YuchoBillingSummary {
+  totalCount: number;
+  totalAmount: number;
+  byCategory: {
+    management: { count: number; amount: number };
+    collective: { count: number; amount: number };
+  };
+}
+
+export interface YuchoBillingResponse {
+  period: { year: number; month: number | null };
+  items: YuchoBillingItem[];
+  summary: YuchoBillingSummary;
+}

--- a/src/yucho/yuchoController.ts
+++ b/src/yucho/yuchoController.ts
@@ -1,0 +1,85 @@
+/**
+ * ゆうちょ連携コントローラー
+ *
+ * - GET /api/v1/yucho/billing : 請求対象データの一覧取得
+ * - GET /api/v1/yucho/export  : ゆうちょ自動払込み用 全銀協CSVを生成・返却
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
+import { ValidationError } from '../middleware/errorHandler';
+import { yuchoBillingQuerySchema, yuchoExportQuerySchema } from '../validations/yuchoValidation';
+import { fetchYuchoBillingData } from './yuchoService';
+import { buildZenginCsv } from './yuchoCsv';
+
+const formatZodError = (err: ZodError): ValidationError => {
+  const details = err.issues.map((i) => ({
+    field: i.path.join('.'),
+    message: i.message,
+  }));
+  return new ValidationError('バリデーションエラー', details);
+};
+
+/**
+ * GET /api/v1/yucho/billing
+ */
+export const getYuchoBilling = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const parsed = yuchoBillingQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw formatZodError(parsed.error);
+    }
+
+    const data = await fetchYuchoBillingData(parsed.data);
+
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * GET /api/v1/yucho/export
+ */
+export const exportYuchoCsv = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const parsed = yuchoExportQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw formatZodError(parsed.error);
+    }
+    const params = parsed.data;
+
+    const data = await fetchYuchoBillingData({
+      year: params.year,
+      month: params.month,
+      category: params.category,
+      status: params.status,
+    });
+
+    const csv = buildZenginCsv({
+      header: {
+        clientCode: params.clientCode,
+        clientName: params.clientName,
+        transferDate: params.transferDate,
+        bankCode: params.bankCode,
+        branchCode: params.branchCode,
+      },
+      items: data.items,
+    });
+
+    const fileName = `yucho_${params.year}${params.month != null ? String(params.month).padStart(2, '0') : 'all'}.csv`;
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+    res.status(200).send(csv);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/yucho/yuchoCsv.ts
+++ b/src/yucho/yuchoCsv.ts
@@ -1,0 +1,347 @@
+/**
+ * 全銀協 預金口座振替フォーマット CSV ビルダー
+ *
+ * 1レコード120バイト固定長を CRLF で連結したテキストを生成する。
+ * 半角カナへの正規化と、固定幅へのパディング/切詰めを行う。
+ *
+ * レコード構成:
+ *   1: ヘッダー    — 委託者情報・引落日・委託者口座
+ *   2: データ      — 顧客口座・引落金額（顧客毎）
+ *   8: トレーラー  — 合計件数・合計金額
+ *   9: エンド      — レコード終端
+ */
+
+import type { YuchoBillingItem } from '../validations/yuchoValidation';
+
+const RECORD_LENGTH = 120;
+const LINE_SEP = '\r\n';
+
+/**
+ * 預金種目コード変換（Prisma enum → Zengin code）
+ *   ordinary (普通)  → 1
+ *   current  (当座)  → 2
+ *   savings  (貯蓄)  → 4
+ *   未設定          → 1 (普通扱い)
+ */
+const accountTypeCode = (type: string | null | undefined): string => {
+  switch (type) {
+    case 'current':
+      return '2';
+    case 'savings':
+      return '4';
+    case 'ordinary':
+    default:
+      return '1';
+  }
+};
+
+/**
+ * 全角カナ・ひらがなを半角カナに変換する簡易コンバーター。
+ * 全銀フォーマットは半角カナを要求するため。
+ */
+const KANA_MAP: Record<string, string> = {
+  ガ: 'ｶﾞ',
+  ギ: 'ｷﾞ',
+  グ: 'ｸﾞ',
+  ゲ: 'ｹﾞ',
+  ゴ: 'ｺﾞ',
+  ザ: 'ｻﾞ',
+  ジ: 'ｼﾞ',
+  ズ: 'ｽﾞ',
+  ゼ: 'ｾﾞ',
+  ゾ: 'ｿﾞ',
+  ダ: 'ﾀﾞ',
+  ヂ: 'ﾁﾞ',
+  ヅ: 'ﾂﾞ',
+  デ: 'ﾃﾞ',
+  ド: 'ﾄﾞ',
+  バ: 'ﾊﾞ',
+  ビ: 'ﾋﾞ',
+  ブ: 'ﾌﾞ',
+  ベ: 'ﾍﾞ',
+  ボ: 'ﾎﾞ',
+  パ: 'ﾊﾟ',
+  ピ: 'ﾋﾟ',
+  プ: 'ﾌﾟ',
+  ペ: 'ﾍﾟ',
+  ポ: 'ﾎﾟ',
+  ヴ: 'ｳﾞ',
+  ア: 'ｱ',
+  イ: 'ｲ',
+  ウ: 'ｳ',
+  エ: 'ｴ',
+  オ: 'ｵ',
+  カ: 'ｶ',
+  キ: 'ｷ',
+  ク: 'ｸ',
+  ケ: 'ｹ',
+  コ: 'ｺ',
+  サ: 'ｻ',
+  シ: 'ｼ',
+  ス: 'ｽ',
+  セ: 'ｾ',
+  ソ: 'ｿ',
+  タ: 'ﾀ',
+  チ: 'ﾁ',
+  ツ: 'ﾂ',
+  テ: 'ﾃ',
+  ト: 'ﾄ',
+  ナ: 'ﾅ',
+  ニ: 'ﾆ',
+  ヌ: 'ﾇ',
+  ネ: 'ﾈ',
+  ノ: 'ﾉ',
+  ハ: 'ﾊ',
+  ヒ: 'ﾋ',
+  フ: 'ﾌ',
+  ヘ: 'ﾍ',
+  ホ: 'ﾎ',
+  マ: 'ﾏ',
+  ミ: 'ﾐ',
+  ム: 'ﾑ',
+  メ: 'ﾒ',
+  モ: 'ﾓ',
+  ヤ: 'ﾔ',
+  ユ: 'ﾕ',
+  ヨ: 'ﾖ',
+  ラ: 'ﾗ',
+  リ: 'ﾘ',
+  ル: 'ﾙ',
+  レ: 'ﾚ',
+  ロ: 'ﾛ',
+  ワ: 'ﾜ',
+  ヲ: 'ｦ',
+  ン: 'ﾝ',
+  ァ: 'ｧ',
+  ィ: 'ｨ',
+  ゥ: 'ｩ',
+  ェ: 'ｪ',
+  ォ: 'ｫ',
+  ッ: 'ｯ',
+  ャ: 'ｬ',
+  ュ: 'ｭ',
+  ョ: 'ｮ',
+  '。': '｡',
+  '、': '､',
+  '「': '｢',
+  '」': '｣',
+  '・': '･',
+  ー: 'ｰ',
+  '　': ' ',
+};
+
+const HIRAGANA_OFFSET = 'ア'.charCodeAt(0) - 'あ'.charCodeAt(0);
+
+const toHalfWidthKana = (input: string): string => {
+  if (!input) return '';
+  let result = '';
+  for (const ch of input) {
+    if (ch >= 'ぁ' && ch <= 'ん') {
+      // ひらがなをカタカナへ → 半角カナ
+      const kata = String.fromCharCode(ch.charCodeAt(0) + HIRAGANA_OFFSET);
+      result += KANA_MAP[kata] ?? kata;
+    } else if (KANA_MAP[ch]) {
+      result += KANA_MAP[ch];
+    } else if (ch >= '\uFF61' && ch <= '\uFF9F') {
+      // 既に半角カナ
+      result += ch;
+    } else if (ch >= '\uFF10' && ch <= '\uFF19') {
+      // 全角数字 → 半角
+      result += String.fromCharCode(ch.charCodeAt(0) - 0xfee0);
+    } else if (ch >= '\uFF21' && ch <= '\uFF5A') {
+      // 全角英字 → 半角
+      result += String.fromCharCode(ch.charCodeAt(0) - 0xfee0);
+    } else if (ch.charCodeAt(0) < 0x80) {
+      // ASCII
+      result += ch;
+    } else {
+      // 変換できない文字はスペース
+      result += ' ';
+    }
+  }
+  return result;
+};
+
+/**
+ * 文字列を指定長に右側スペース埋めする。長すぎる場合は切詰め。
+ */
+const padRight = (value: string, width: number): string => {
+  if (value.length >= width) return value.slice(0, width);
+  return value + ' '.repeat(width - value.length);
+};
+
+/**
+ * 数値文字列を指定長にゼロ埋めする。長すぎる場合は切詰め(下位桁優先)。
+ */
+const padLeftZero = (value: string | number, width: number): string => {
+  const s = String(value).replace(/[^\d]/g, '');
+  if (s.length >= width) return s.slice(-width);
+  return '0'.repeat(width - s.length) + s;
+};
+
+interface HeaderParams {
+  clientCode: string; // 委託者コード(10桁)
+  clientName: string; // 委託者名(40バイト, 半角カナ)
+  transferDate: string; // YYYY-MM-DD
+  bankCode: string; // 取引銀行番号(4桁)
+  bankName?: string; // 取引銀行名(15バイト, デフォルト ﾕｳﾁﾖｷﾞﾝｺｳ)
+  branchCode: string; // 取引支店番号(3桁)
+  branchName?: string; // 取引支店名(15バイト)
+  accountType?: string; // 預金種目 (ordinary/current/savings)
+  accountNumber?: string; // 委託者口座番号(7桁)
+}
+
+/**
+ * ヘッダレコード（区分=1）120バイトを生成
+ */
+export const buildHeaderRecord = (params: HeaderParams): string => {
+  const transferMMDD = params.transferDate.replace(/-/g, '').slice(4, 8);
+  const parts = [
+    '1', // レコード区分
+    '91', // 種別コード（預金口座振替）
+    '0', // コード区分（JISコード）
+    padLeftZero(params.clientCode, 10),
+    padRight(toHalfWidthKana(params.clientName), 40),
+    transferMMDD, // 引落日 MMDD (4桁)
+    padLeftZero(params.bankCode, 4),
+    padRight(toHalfWidthKana(params.bankName ?? 'ﾕｳﾁﾖｷﾞﾝｺｳ'), 15),
+    padLeftZero(params.branchCode, 3),
+    padRight(toHalfWidthKana(params.branchName ?? ''), 15),
+    accountTypeCode(params.accountType ?? 'ordinary'),
+    padLeftZero(params.accountNumber ?? '', 7),
+  ];
+  const body = parts.join('');
+  return padRight(body, RECORD_LENGTH);
+};
+
+/**
+ * データレコード（区分=2）120バイトを生成
+ */
+export const buildDataRecord = (item: YuchoBillingItem): string => {
+  const info = item.billingInfo;
+  const parts = [
+    '2', // レコード区分
+    padLeftZero(extractBankCode(info?.bankName ?? ''), 4),
+    padRight(toHalfWidthKana(info?.bankName ?? ''), 15),
+    padLeftZero(extractBranchCode(info?.branchName ?? ''), 3),
+    padRight(toHalfWidthKana(info?.branchName ?? ''), 15),
+    '    ', // ダミー(4)
+    accountTypeCode(info?.accountType),
+    padLeftZero(info?.accountNumber ?? '', 7),
+    padRight(toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? ''), 30),
+    padLeftZero(item.billingAmount, 10),
+    '0', // 新規コード(0:その他)
+    padRight(item.contractPlotId.replace(/-/g, '').slice(0, 20), 20), // 顧客番号
+    '0', // 振替結果コード(0:未処理)
+  ];
+  const body = parts.join('');
+  return padRight(body, RECORD_LENGTH);
+};
+
+/**
+ * トレーラレコード（区分=8）120バイトを生成
+ */
+export const buildTrailerRecord = (totalCount: number, totalAmount: number): string => {
+  const parts = [
+    '8',
+    padLeftZero(totalCount, 6),
+    padLeftZero(totalAmount, 12),
+    padLeftZero(0, 6), // 振替済件数（未処理時は0）
+    padLeftZero(0, 12), // 振替済金額
+    padLeftZero(0, 6), // 振替不能件数
+    padLeftZero(0, 12), // 振替不能金額
+  ];
+  const body = parts.join('');
+  return padRight(body, RECORD_LENGTH);
+};
+
+/**
+ * エンドレコード（区分=9）120バイトを生成
+ */
+export const buildEndRecord = (): string => {
+  return padRight('9', RECORD_LENGTH);
+};
+
+/**
+ * 銀行名から銀行コードを推定。ゆうちょ銀行は 9900。
+ * 不明な場合は 0000 を返す（呼び出し側で上書き必要）。
+ */
+const extractBankCode = (bankName: string): string => {
+  if (bankName.includes('ゆうちょ') || bankName.includes('ﾕｳﾁﾖ') || bankName.includes('郵便')) {
+    return '9900';
+  }
+  return '0000';
+};
+
+/**
+ * 支店名から支店コード(3桁)を推定。漢数字を含む店舗名（〇一八店等）から数字を抽出。
+ * 不明な場合は 000 を返す。
+ */
+const KANJI_DIGIT: Record<string, string> = {
+  〇: '0',
+  零: '0',
+  一: '1',
+  壱: '1',
+  二: '2',
+  弐: '2',
+  三: '3',
+  参: '3',
+  四: '4',
+  五: '5',
+  六: '6',
+  七: '7',
+  八: '8',
+  九: '9',
+};
+
+const extractBranchCode = (branchName: string): string => {
+  // ASCII数字優先
+  const ascii = branchName.match(/\d{3}/);
+  if (ascii) return ascii[0];
+  // 漢数字3桁
+  let digits = '';
+  for (const ch of branchName) {
+    if (KANJI_DIGIT[ch] != null) {
+      digits += KANJI_DIGIT[ch];
+      if (digits.length === 3) break;
+    }
+  }
+  return digits.length === 3 ? digits : '000';
+};
+
+interface BuildCsvParams {
+  header: HeaderParams;
+  items: YuchoBillingItem[];
+}
+
+/**
+ * 全銀協フォーマットの完全な CSV (固定長レコード) を生成する。
+ * 出力例:
+ *   1{ヘッダー...}\r\n
+ *   2{データ1...}\r\n
+ *   2{データ2...}\r\n
+ *   8{トレーラー...}\r\n
+ *   9{エンド...}\r\n
+ */
+export const buildZenginCsv = ({ header, items }: BuildCsvParams): string => {
+  const billable = items.filter((i) => i.billingInfo && i.billingAmount > 0);
+  const totalAmount = billable.reduce((sum, i) => sum + i.billingAmount, 0);
+
+  const lines = [
+    buildHeaderRecord(header),
+    ...billable.map(buildDataRecord),
+    buildTrailerRecord(billable.length, totalAmount),
+    buildEndRecord(),
+  ];
+  return lines.join(LINE_SEP) + LINE_SEP;
+};
+
+// テスト用にエクスポート
+export const __internal = {
+  toHalfWidthKana,
+  padRight,
+  padLeftZero,
+  accountTypeCode,
+  extractBankCode,
+  extractBranchCode,
+};

--- a/src/yucho/yuchoRoutes.ts
+++ b/src/yucho/yuchoRoutes.ts
@@ -1,0 +1,29 @@
+/**
+ * ゆうちょ連携ルート
+ */
+
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import { requirePermission, ROLES } from '../middleware/permission';
+import { withLogging } from '../middleware/controllerLogger';
+import { getYuchoBilling, exportYuchoCsv } from './yuchoController';
+
+const router = Router();
+
+// 請求対象データ取得（manager以上）
+router.get(
+  '/billing',
+  authenticate,
+  requirePermission([ROLES.MANAGER, ROLES.ADMIN]),
+  withLogging('Yucho', 'getBilling', getYuchoBilling)
+);
+
+// CSV エクスポート（manager以上）
+router.get(
+  '/export',
+  authenticate,
+  requirePermission([ROLES.MANAGER, ROLES.ADMIN]),
+  withLogging('Yucho', 'exportCsv', exportYuchoCsv)
+);
+
+export default router;

--- a/src/yucho/yuchoService.ts
+++ b/src/yucho/yuchoService.ts
@@ -1,0 +1,282 @@
+/**
+ * ゆうちょ連携: 請求データ集約サービス
+ *
+ * ContractPlot.ManagementFee と CollectiveBurial を集約し、
+ * ゆうちょ自動払込み用の請求対象データを返す。
+ */
+
+import { PaymentStatus } from '@prisma/client';
+import prisma from '../db/prisma';
+import type { YuchoBillingItem, YuchoBillingResponse } from '../validations/yuchoValidation';
+
+interface FetchParams {
+  year: number;
+  month?: number | undefined;
+  category: 'management' | 'collective' | 'all';
+  status: 'unbilled' | 'billed' | 'paid' | 'all';
+}
+
+/**
+ * 月文字列(例: "4", "04", "4月")を数値に変換。失敗時は null。
+ */
+const parseBillingMonth = (value: string | null | undefined): number | null => {
+  if (!value) return null;
+  const m = value.match(/(\d{1,2})/);
+  if (!m) return null;
+  const num = parseInt(m[1] ?? '0', 10);
+  return num >= 1 && num <= 12 ? num : null;
+};
+
+/**
+ * 文字列の管理料金額を整数(円)に変換。"10,000" や "10000円" などの表記も許容。
+ */
+const parseManagementFeeAmount = (value: string | null | undefined): number => {
+  if (!value) return 0;
+  const cleaned = value.replace(/[^\d.-]/g, '');
+  if (!cleaned) return 0;
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? 0 : Math.round(num);
+};
+
+/**
+ * 契約者(役割: contractor)を最優先、無ければ申込者(applicant)を返す。
+ */
+const pickPayer = (
+  roles: Array<{
+    role: string;
+    customer: {
+      id: string;
+      name: string;
+      name_kana: string;
+      billingInfo: {
+        bank_name: string | null;
+        branch_name: string | null;
+        account_type: string | null;
+        account_number: string | null;
+        account_holder: string | null;
+      } | null;
+    } | null;
+  }>
+) => {
+  const contractor = roles.find((r) => r.role === 'contractor' && r.customer);
+  if (contractor) return contractor.customer;
+  const applicant = roles.find((r) => r.role === 'applicant' && r.customer);
+  return applicant?.customer ?? null;
+};
+
+/**
+ * 管理料の請求対象を取得
+ */
+const fetchManagementBillingItems = async (params: FetchParams): Promise<YuchoBillingItem[]> => {
+  const { year, month, status } = params;
+
+  // 管理料は契約区画ベース。billing_month が指定月と一致するものを抽出。
+  // status フィルタは ContractPlot.payment_status をベースに判定。
+  const paymentStatusFilter: PaymentStatus | { in: PaymentStatus[] } | undefined =
+    status === 'unbilled'
+      ? { in: [PaymentStatus.unpaid, PaymentStatus.partial_paid, PaymentStatus.overdue] }
+      : status === 'paid'
+        ? PaymentStatus.paid
+        : status === 'billed'
+          ? { in: [PaymentStatus.unpaid, PaymentStatus.partial_paid] }
+          : undefined;
+
+  const contractPlotWhere = {
+    deleted_at: null,
+    contract_status: { in: ['active' as const, 'reserved' as const] },
+    ...(paymentStatusFilter ? { payment_status: paymentStatusFilter } : {}),
+  };
+
+  const fees = await prisma.managementFee.findMany({
+    where: {
+      deleted_at: null,
+      contractPlot: contractPlotWhere,
+    },
+    include: {
+      contractPlot: {
+        include: {
+          physicalPlot: true,
+          saleContractRoles: {
+            where: { deleted_at: null },
+            include: {
+              customer: {
+                include: { billingInfo: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const items: YuchoBillingItem[] = [];
+  for (const fee of fees) {
+    const billingMonth = parseBillingMonth(fee.billing_month);
+    // 月指定がある場合は一致するもののみ
+    if (month != null && billingMonth !== month) continue;
+    // 月指定なし(年単位)の場合は billing_month が設定されているもののみ
+    if (month == null && billingMonth == null) continue;
+
+    const amount = parseManagementFeeAmount(fee.management_fee);
+    if (amount <= 0) continue;
+
+    const payer = pickPayer(fee.contractPlot.saleContractRoles);
+
+    // 請求予定日 = 指定年 + billing_month の月末
+    const scheduledDate =
+      billingMonth != null
+        ? (new Date(Date.UTC(year, billingMonth, 0)).toISOString().split('T')[0] ?? null)
+        : null;
+
+    items.push({
+      category: 'management',
+      sourceId: fee.id,
+      contractPlotId: fee.contract_plot_id,
+      plotNumber: fee.contractPlot.physicalPlot.plot_number,
+      areaName: fee.contractPlot.physicalPlot.area_name,
+      contractDate: fee.contractPlot.contract_date.toISOString().split('T')[0] ?? '',
+      customerId: payer?.id ?? null,
+      customerName: payer?.name ?? null,
+      customerNameKana: payer?.name_kana ?? null,
+      billingAmount: amount,
+      billingStatus: fee.contractPlot.payment_status,
+      scheduledDate,
+      billingMonth,
+      billingInfo: payer?.billingInfo
+        ? {
+            bankName: payer.billingInfo.bank_name,
+            branchName: payer.billingInfo.branch_name,
+            accountType: payer.billingInfo.account_type,
+            accountNumber: payer.billingInfo.account_number,
+            accountHolder: payer.billingInfo.account_holder,
+          }
+        : null,
+    });
+  }
+
+  return items;
+};
+
+/**
+ * 合祀料金の請求対象を取得
+ */
+const fetchCollectiveBillingItems = async (params: FetchParams): Promise<YuchoBillingItem[]> => {
+  const { year, month, status } = params;
+
+  const billingStatusFilter =
+    status === 'unbilled'
+      ? 'pending'
+      : status === 'billed'
+        ? 'billed'
+        : status === 'paid'
+          ? 'paid'
+          : undefined;
+
+  const startDate =
+    month != null ? new Date(Date.UTC(year, month - 1, 1)) : new Date(Date.UTC(year, 0, 1));
+  const endDate =
+    month != null ? new Date(Date.UTC(year, month, 1)) : new Date(Date.UTC(year + 1, 0, 1));
+
+  const burials = await prisma.collectiveBurial.findMany({
+    where: {
+      deleted_at: null,
+      billing_scheduled_date: { gte: startDate, lt: endDate },
+      ...(billingStatusFilter ? { billing_status: billingStatusFilter } : {}),
+      contractPlot: { deleted_at: null },
+    },
+    include: {
+      contractPlot: {
+        include: {
+          physicalPlot: true,
+          saleContractRoles: {
+            where: { deleted_at: null },
+            include: {
+              customer: {
+                include: { billingInfo: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return burials
+    .filter((b) => (b.billing_amount ?? 0) > 0)
+    .map((b) => {
+      const payer = pickPayer(b.contractPlot.saleContractRoles);
+      const scheduledDate = b.billing_scheduled_date?.toISOString().split('T')[0] ?? null;
+      const billingMonth = b.billing_scheduled_date
+        ? b.billing_scheduled_date.getUTCMonth() + 1
+        : null;
+
+      return {
+        category: 'collective' as const,
+        sourceId: b.id,
+        contractPlotId: b.contract_plot_id,
+        plotNumber: b.contractPlot.physicalPlot.plot_number,
+        areaName: b.contractPlot.physicalPlot.area_name,
+        contractDate: b.contractPlot.contract_date.toISOString().split('T')[0] ?? '',
+        customerId: payer?.id ?? null,
+        customerName: payer?.name ?? null,
+        customerNameKana: payer?.name_kana ?? null,
+        billingAmount: b.billing_amount ?? 0,
+        billingStatus: b.billing_status,
+        scheduledDate,
+        billingMonth,
+        billingInfo: payer?.billingInfo
+          ? {
+              bankName: payer.billingInfo.bank_name,
+              branchName: payer.billingInfo.branch_name,
+              accountType: payer.billingInfo.account_type,
+              accountNumber: payer.billingInfo.account_number,
+              accountHolder: payer.billingInfo.account_holder,
+            }
+          : null,
+      };
+    });
+};
+
+/**
+ * 請求対象を取得して整形・サマリ計算する。
+ */
+export const fetchYuchoBillingData = async (params: FetchParams): Promise<YuchoBillingResponse> => {
+  const promises: Array<Promise<YuchoBillingItem[]>> = [];
+  if (params.category === 'management' || params.category === 'all') {
+    promises.push(fetchManagementBillingItems(params));
+  }
+  if (params.category === 'collective' || params.category === 'all') {
+    promises.push(fetchCollectiveBillingItems(params));
+  }
+
+  const results = await Promise.all(promises);
+  const items = results.flat();
+
+  // 区画番号順でソート
+  items.sort((a, b) => a.plotNumber.localeCompare(b.plotNumber));
+
+  const summary = {
+    totalCount: items.length,
+    totalAmount: items.reduce((sum, i) => sum + i.billingAmount, 0),
+    byCategory: {
+      management: {
+        count: items.filter((i) => i.category === 'management').length,
+        amount: items
+          .filter((i) => i.category === 'management')
+          .reduce((sum, i) => sum + i.billingAmount, 0),
+      },
+      collective: {
+        count: items.filter((i) => i.category === 'collective').length,
+        amount: items
+          .filter((i) => i.category === 'collective')
+          .reduce((sum, i) => sum + i.billingAmount, 0),
+      },
+    },
+  };
+
+  return {
+    period: { year: params.year, month: params.month ?? null },
+    items,
+    summary,
+  };
+};

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,5854 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Cemetery CRM API",
+    "description": "墓石管理システム（Cemetery Management System）のバックエンドAPI",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Cemetery CRM Support"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:4000",
+      "description": "ローカル開発環境"
+    },
+    {
+      "url": "http://localhost:4000/api/v1",
+      "description": "API v1 ベースURL"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Auth",
+      "description": "認証関連のエンドポイント"
+    },
+    {
+      "name": "Plots",
+      "description": "区画（墓石）管理"
+    },
+    {
+      "name": "Masters",
+      "description": "マスターデータ"
+    },
+    {
+      "name": "Staff",
+      "description": "スタッフ管理"
+    },
+    {
+      "name": "Documents",
+      "description": "書類管理（PDF生成・ファイルアップロード）"
+    },
+    {
+      "name": "Yucho",
+      "description": "ゆうちょ連携（自動払込み用CSV生成）"
+    }
+  ],
+  "paths": {
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "ログイン",
+        "description": "メールアドレスとパスワードでログインし、JWTトークンを取得",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "email",
+                  "password"
+                ],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "example": "user@example.com"
+                  },
+                  "password": {
+                    "type": "string",
+                    "format": "password",
+                    "example": "password123"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ログイン成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "user": {
+                          "$ref": "#/components/schemas/StaffPublic"
+                        },
+                        "session": {
+                          "type": "object",
+                          "properties": {
+                            "access_token": {
+                              "type": "string"
+                            },
+                            "refresh_token": {
+                              "type": "string"
+                            },
+                            "expires_at": {
+                              "type": "integer",
+                              "description": "トークンの有効期限（UNIXタイムスタンプ）",
+                              "example": 1704067200
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
+    "/api/v1/plots": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "契約区画一覧取得",
+        "description": "契約区画の一覧を取得（検索・ページネーション対応）。物理区画と契約情報を含む。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（1から開始）",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "検索キーワード（区画番号、顧客名で検索）",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "usageStatus",
+            "in": "query",
+            "description": "使用状況フィルタ",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cemeteryType",
+            "in": "query",
+            "description": "墓地タイプフィルタ",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ContractPlotSummary"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "新規契約区画作成",
+        "description": "物理区画と契約区画を同時に作成。顧客情報、販売契約、オプション情報も含む。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePlotInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "作成されたContractPlotのID"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "契約区画を作成しました"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/bulk": {
+      "post": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "区画情報一括登録",
+        "description": "複数の区画を一括登録します。1件登録（POST /plots）と同等のフィールド構成で、\n最大500件まで一度に登録できます。全件が1つのトランザクションで実行され、\n1件でもエラーがあれば全件ロールバックします。\nmanager または admin 権限が必要です。\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "items"
+                ],
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 500,
+                    "items": {
+                      "type": "object",
+                      "description": "CreatePlot リクエスト（物理区画 + 契約区画 + 販売契約 + 顧客 + オプション）+\nfamilyContacts[] / buriedPersons[] / constructionInfos[] / gravestoneInfo\n",
+                      "properties": {
+                        "physicalPlot": {
+                          "type": "object"
+                        },
+                        "contractPlot": {
+                          "type": "object"
+                        },
+                        "saleContract": {
+                          "type": "object"
+                        },
+                        "customer": {
+                          "type": "object"
+                        },
+                        "workInfo": {
+                          "type": "object"
+                        },
+                        "billingInfo": {
+                          "type": "object"
+                        },
+                        "usageFee": {
+                          "type": "object"
+                        },
+                        "managementFee": {
+                          "type": "object"
+                        },
+                        "collectiveBurial": {
+                          "type": "object"
+                        },
+                        "familyContacts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "buriedPersons": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "constructionInfos": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "gravestoneInfo": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "一括登録成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "totalRequested": {
+                          "type": "integer",
+                          "example": 10
+                        },
+                        "created": {
+                          "type": "integer",
+                          "example": 10
+                        },
+                        "results": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "row": {
+                                "type": "integer"
+                              },
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "physicalPlotId": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "plotNumber": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "バリデーションエラー / バッチ内重複 / 既存区画番号と衝突",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "row": {
+                                "type": "integer"
+                              },
+                              "field": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "区画情報一括編集",
+        "description": "既存の契約区画を plotNumber（区画番号）でマッチングして一括更新します。\n未指定フィールドは変更されず、null 明示フィールドはクリアされます。\n最大500件まで一度に編集可能。トランザクションで all-or-nothing 処理。\nmanager または admin 権限が必要です。\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "items"
+                ],
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 500,
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "plotNumber"
+                      ],
+                      "description": "plotNumber（マッチングキー、必須）+ UpdatePlot 準拠の部分更新フィールド。\n空欄（未指定）= 変更しない、null 明示 = クリア。\n",
+                      "properties": {
+                        "plotNumber": {
+                          "type": "string",
+                          "description": "マッチングキーとなる区画番号"
+                        },
+                        "physicalPlot": {
+                          "type": "object"
+                        },
+                        "contractPlot": {
+                          "type": "object"
+                        },
+                        "saleContract": {
+                          "type": "object"
+                        },
+                        "customer": {
+                          "type": "object"
+                        },
+                        "workInfo": {
+                          "type": "object"
+                        },
+                        "billingInfo": {
+                          "type": "object"
+                        },
+                        "usageFee": {
+                          "type": "object"
+                        },
+                        "managementFee": {
+                          "type": "object"
+                        },
+                        "buriedPersons": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "constructionInfos": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "collectiveBurial": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "一括編集成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "totalRequested": {
+                          "type": "integer"
+                        },
+                        "updated": {
+                          "type": "integer"
+                        },
+                        "results": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "row": {
+                                "type": "integer"
+                              },
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "plotNumber": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "バリデーションエラー / バッチ内重複 / 区画番号が DB に存在しない"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/{id}": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "契約区画詳細取得",
+        "description": "指定した契約区画の詳細情報を取得。物理区画、顧客、販売契約、オプション情報を含む。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "契約区画ID（UUID）",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ContractPlotDetail"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "契約区画更新",
+        "description": "契約区画情報を更新。部分更新をサポート（contractPlot, saleContract, customer, workInfo, billingInfo, usageFee, managementFee）。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "契約区画ID（UUID）",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePlotInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "更新成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "契約区画を更新しました"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "契約区画削除（論理削除）",
+        "description": "契約区画を論理削除。関連する販売契約、使用料、管理料、請求情報、勤務先情報も削除。顧客は他の契約がない場合のみ削除。物理区画のステータスは自動更新。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "契約区画ID（UUID）",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "example": "契約区画を削除しました"
+                        },
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/{id}/contracts": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "物理区画の契約一覧取得",
+        "description": "指定した物理区画に紐づく全ての契約を取得。分割販売の場合、複数の契約が返される。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "物理区画ID（UUID）",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PhysicalPlotContracts"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "物理区画に新規契約追加",
+        "description": "既存の物理区画に新しい契約を追加（分割販売）。契約面積の検証を実施し、物理区画のステータスを自動更新。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "物理区画ID（UUID）",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePlotContractInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "作成されたContractPlotのID"
+                        },
+                        "message": {
+                          "type": "string",
+                          "example": "契約を作成しました"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/inventory/summary": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "在庫全体サマリー取得",
+        "description": "全区画の在庫状況サマリーを取得。総区画数、使用済数、残数、使用率、総面積、残面積を返す。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/InventorySummary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/inventory/periods": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "期別サマリー取得",
+        "description": "期別（第1期〜第4期）の在庫サマリーを取得。特定の期のみ取得も可能。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "description": "期（指定しない場合は全期）",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "第1期",
+                "第2期",
+                "第3期",
+                "第3期樹林部",
+                "第4期"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "periods": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/PeriodSummary"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/inventory/sections": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "セクション別集計取得",
+        "description": "セクション別（A, B, 吉相など）の在庫集計を取得。フィルタ・ソート・ページネーション対応。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "description": "期でフィルタ",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "第1期",
+                "第2期",
+                "第3期",
+                "第3期樹林部",
+                "第4期"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "ステータスでフィルタ",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "available",
+                "partially_sold",
+                "sold_out"
+              ]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "セクション名で検索",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "ソートキー",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "period",
+                "section",
+                "totalCount",
+                "usedCount",
+                "remainingCount",
+                "usageRate"
+              ],
+              "default": "period"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "description": "ソート順",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/SectionInventoryItem"
+                          }
+                        },
+                        "pagination": {
+                          "$ref": "#/components/schemas/Pagination"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/inventory/areas": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "面積別集計取得",
+        "description": "面積別（3.6㎡, 1.8㎡など）の在庫集計を取得。フィルタ・ソート・ページネーション対応。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "period",
+            "in": "query",
+            "description": "期でフィルタ",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "第1期",
+                "第2期",
+                "第3期",
+                "第3期樹林部",
+                "第4期"
+              ]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "面積・タイプで検索",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "ソートキー",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "period",
+                "areaSqm",
+                "totalCount",
+                "usedCount",
+                "remainingCount",
+                "remainingAreaSqm",
+                "plotType"
+              ],
+              "default": "period"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "description": "ソート順",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AreaInventoryItem"
+                          }
+                        },
+                        "pagination": {
+                          "$ref": "#/components/schemas/Pagination"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/plots/{id}/inventory": {
+      "get": {
+        "tags": [
+          "Plots"
+        ],
+        "summary": "物理区画の在庫状況取得",
+        "description": "物理区画の在庫状況を取得。総面積、割当済面積、利用可能面積、利用率、ステータスを返す。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "物理区画ID（UUID）",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/PhysicalPlotInventory"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/staff": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "summary": "スタッフ一覧取得",
+        "description": "スタッフの一覧を取得（ページネーション対応）。削除済みスタッフは含まれません。",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（1から開始）",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "description": "役割でフィルタ",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "viewer",
+                "operator",
+                "manager",
+                "admin"
+              ]
+            }
+          },
+          {
+            "name": "is_active",
+            "in": "query",
+            "description": "アクティブ状態でフィルタ",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "staff": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/StaffAdmin"
+                          }
+                        },
+                        "pagination": {
+                          "type": "object",
+                          "properties": {
+                            "page": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "limit": {
+                              "type": "integer",
+                              "example": 20
+                            },
+                            "total": {
+                              "type": "integer",
+                              "example": 50
+                            },
+                            "totalPages": {
+                              "type": "integer",
+                              "example": 3
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Staff"
+        ],
+        "summary": "スタッフ新規登録",
+        "description": "新しいスタッフを登録します。\n- Supabase Admin APIでユーザーを作成\n- 取得したsupabase_uidでStaffテーブルにレコード作成\n- トランザクション処理でロールバック対応\n- 管理者権限（admin）のみアクセス可能\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateStaffRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/StaffAdmin"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      }
+    },
+    "/api/v1/staff/{id}": {
+      "get": {
+        "tags": [
+          "Staff"
+        ],
+        "summary": "スタッフ詳細取得",
+        "description": "指定されたIDのスタッフ情報を取得",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "スタッフID",
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/StaffAdmin"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Staff"
+        ],
+        "summary": "スタッフ情報更新",
+        "description": "スタッフ情報を更新します。\n- 名前、メールアドレス、役割の更新\n- Supabase側のメールアドレス更新も同期\n- 管理者権限（admin）のみアクセス可能\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "スタッフID",
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStaffRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "更新成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/StaffAdmin"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Staff"
+        ],
+        "summary": "スタッフ削除（ソフトデリート）",
+        "description": "スタッフを論理削除します。\n- deleted_atに現在日時を設定\n- is_activeをfalseに更新\n- 物理削除は行わない\n- 管理者権限（admin）のみアクセス可能\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "スタッフID",
+            "schema": {
+              "type": "integer",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "example": "スタッフを削除しました"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/documents": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "書類一覧取得",
+        "description": "書類の一覧を取得（検索・フィルター・ページネーション対応）",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（1から開始）",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "1ページあたりの件数",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "contractPlotId",
+            "in": "query",
+            "description": "契約区画IDでフィルター",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "顧客IDでフィルター",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "書類タイプでフィルター",
+            "schema": {
+              "$ref": "#/components/schemas/DocumentType"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "ステータスでフィルター",
+            "schema": {
+              "$ref": "#/components/schemas/DocumentStatus"
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "ソート項目",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created_at",
+                "updated_at",
+                "name",
+                "type",
+                "status"
+              ],
+              "default": "created_at"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "query",
+            "description": "ソート順",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/DocumentListItem"
+                          }
+                        },
+                        "pagination": {
+                          "$ref": "#/components/schemas/Pagination"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "書類作成",
+        "description": "新規書類メタデータを作成",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDocumentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "作成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/DocumentDetail"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/generate-pdf": {
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "PDF生成",
+        "description": "テンプレートからPDFを生成（Base64エンコードで返却）",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GeneratePdfRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "PDF生成成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/GeneratePdfResponse"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{id}": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "書類詳細取得",
+        "description": "指定されたIDの書類詳細を取得",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "書類ID",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/DocumentDetail"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "書類更新",
+        "description": "書類のメタデータを更新",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "書類ID",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDocumentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "更新成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/DocumentDetail"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "書類削除（論理削除）",
+        "description": "書類を論理削除（deleted_atに日時を設定）",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "書類ID",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "削除成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "example": "書類を削除しました"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{id}/upload": {
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "ファイルアップロード",
+        "description": "書類にファイルをアップロード（最大10MB）",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "書類ID",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "アップロードするファイル（PDF, Word, Excel, 画像）"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "アップロード成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "fileName": {
+                          "type": "string",
+                          "example": "invoice_2024.pdf"
+                        },
+                        "fileSize": {
+                          "type": "integer",
+                          "example": 102400
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/pdf"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/{id}/download": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "ダウンロードURL取得",
+        "description": "ファイルのダウンロードURL（Pre-signed URL）を取得",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "書類ID",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "URL取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string",
+                          "format": "uri",
+                          "description": "ダウンロードURL（有効期限15分）"
+                        },
+                        "fileName": {
+                          "type": "string",
+                          "example": "invoice_2024.pdf"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/pdf"
+                        },
+                        "expiresIn": {
+                          "type": "integer",
+                          "description": "有効期限（秒）",
+                          "example": 900
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/documents/file/{fileKey}": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "ローカルファイルダウンロード",
+        "description": "ローカルストレージからファイルを直接ダウンロード（開発環境用）",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fileKey",
+            "in": "path",
+            "required": true,
+            "description": "ファイルキー",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ファイルダウンロード",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/masters/section-name": {
+      "get": {
+        "tags": [
+          "Masters"
+        ],
+        "summary": "区画名マスタ一覧取得",
+        "description": "有効な区画名マスタデータを表示順で取得",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "区画名マスタ一覧",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SectionNameMaster"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/masters/all": {
+      "get": {
+        "tags": [
+          "Masters"
+        ],
+        "summary": "全マスタデータ一括取得",
+        "description": "全マスタテーブルのデータを一括取得",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "全マスタデータ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "sectionName": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/SectionNameMaster"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/yucho/billing": {
+      "get": {
+        "tags": [
+          "Yucho"
+        ],
+        "summary": "ゆうちょ請求対象データ取得",
+        "description": "指定期間の管理料・合祀料金の請求対象データを集約して返す。\n各レコードには契約区画情報、顧客情報、口座情報、請求金額が含まれる。\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1900,
+              "maximum": 2999
+            },
+            "description": "対象年（西暦）"
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "description": "対象月。指定なしの場合は年単位で集計"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "management",
+                "collective",
+                "all"
+              ],
+              "default": "all"
+            },
+            "description": "請求対象カテゴリ"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "unbilled",
+                "billed",
+                "paid",
+                "all"
+              ],
+              "default": "unbilled"
+            },
+            "description": "請求ステータスフィルタ"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "請求対象データ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "period": {
+                          "type": "object",
+                          "properties": {
+                            "year": {
+                              "type": "integer"
+                            },
+                            "month": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "enum": [
+                                  "management",
+                                  "collective"
+                                ]
+                              },
+                              "sourceId": {
+                                "type": "string"
+                              },
+                              "contractPlotId": {
+                                "type": "string"
+                              },
+                              "plotNumber": {
+                                "type": "string"
+                              },
+                              "areaName": {
+                                "type": "string"
+                              },
+                              "customerId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "customerName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "customerNameKana": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "billingAmount": {
+                                "type": "integer"
+                              },
+                              "billingStatus": {
+                                "type": "string"
+                              },
+                              "scheduledDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "billingMonth": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "billingInfo": {
+                                "type": "object",
+                                "nullable": true,
+                                "properties": {
+                                  "bankName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "branchName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "accountType": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "accountNumber": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "accountHolder": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "summary": {
+                          "type": "object",
+                          "properties": {
+                            "totalCount": {
+                              "type": "integer"
+                            },
+                            "totalAmount": {
+                              "type": "integer"
+                            },
+                            "byCategory": {
+                              "type": "object"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/yucho/export": {
+      "get": {
+        "tags": [
+          "Yucho"
+        ],
+        "summary": "ゆうちょ自動払込み用CSV出力",
+        "description": "全銀協フォーマット（120バイト固定長レコード）のCSVを生成して返す。\nヘッダー(1) + データ(2) + トレーラー(8) + エンド(9) の構成。\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "management",
+                "collective",
+                "all"
+              ],
+              "default": "all"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "unbilled",
+                "billed",
+                "paid",
+                "all"
+              ],
+              "default": "unbilled"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "zengin"
+              ],
+              "default": "zengin"
+            }
+          },
+          {
+            "name": "transferDate",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "description": "引落日 (YYYY-MM-DD)"
+          },
+          {
+            "name": "clientCode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{1,10}$"
+            },
+            "description": "委託者コード（最大10桁）"
+          },
+          {
+            "name": "clientName",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 40
+            },
+            "description": "委託者名（半角40文字以内）"
+          },
+          {
+            "name": "bankCode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}$",
+              "default": "9900"
+            },
+            "description": "取引銀行コード（4桁、デフォルト 9900 = ゆうちょ）"
+          },
+          {
+            "name": "branchCode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{3}$",
+              "default": "000"
+            },
+            "description": "取引支店コード（3桁）"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "全銀協フォーマット CSV",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Supabaseから発行されたJWTトークンを使用"
+      }
+    },
+    "schemas": {
+      "SectionNameMaster": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1
+          },
+          "code": {
+            "type": "string",
+            "example": "1-A"
+          },
+          "name": {
+            "type": "string",
+            "example": "A"
+          },
+          "period": {
+            "type": "string",
+            "example": "第1期"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "nullable": true,
+            "example": 1
+          },
+          "isActive": {
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "DocumentType": {
+        "type": "string",
+        "description": "書類タイプ",
+        "enum": [
+          "invoice",
+          "postcard",
+          "contract",
+          "permit",
+          "other"
+        ],
+        "example": "invoice"
+      },
+      "DocumentStatus": {
+        "type": "string",
+        "description": "書類ステータス",
+        "enum": [
+          "draft",
+          "generated",
+          "sent",
+          "archived"
+        ],
+        "example": "draft"
+      },
+      "DocumentListItem": {
+        "type": "object",
+        "description": "書類一覧アイテム",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "書類ID"
+          },
+          "contractPlotId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "契約区画ID"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "description": "顧客ID"
+          },
+          "type": {
+            "$ref": "#/components/schemas/DocumentType"
+          },
+          "name": {
+            "type": "string",
+            "description": "書類名",
+            "example": "請求書_2024年1月分"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "説明"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DocumentStatus"
+          },
+          "fileName": {
+            "type": "string",
+            "nullable": true,
+            "description": "ファイル名",
+            "example": "invoice_2024_01.pdf"
+          },
+          "fileSize": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ファイルサイズ（バイト）",
+            "example": 102400
+          },
+          "mimeType": {
+            "type": "string",
+            "nullable": true,
+            "description": "MIMEタイプ",
+            "example": "application/pdf"
+          },
+          "templateType": {
+            "type": "string",
+            "nullable": true,
+            "description": "テンプレートタイプ"
+          },
+          "generatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "生成日時"
+          },
+          "sentAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "送付日時"
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true,
+            "description": "作成者"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "description": "備考"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "作成日時"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "更新日時"
+          },
+          "contractPlot": {
+            "type": "object",
+            "nullable": true,
+            "description": "関連区画情報",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "plotNumber": {
+                "type": "string"
+              },
+              "areaName": {
+                "type": "string"
+              }
+            }
+          },
+          "customer": {
+            "type": "object",
+            "nullable": true,
+            "description": "関連顧客情報",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nameKana": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "DocumentDetail": {
+        "type": "object",
+        "description": "書類詳細",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DocumentListItem"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "fileKey": {
+                "type": "string",
+                "nullable": true,
+                "description": "ファイルキー（S3/ローカル）"
+              },
+              "templateData": {
+                "type": "object",
+                "nullable": true,
+                "description": "テンプレートデータ（JSON）"
+              },
+              "contractPlot": {
+                "type": "object",
+                "nullable": true,
+                "description": "関連区画詳細",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "contractAreaSqm": {
+                    "type": "number"
+                  },
+                  "contractDate": {
+                    "type": "string",
+                    "format": "date",
+                    "nullable": true
+                  },
+                  "physicalPlot": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "plotNumber": {
+                        "type": "string"
+                      },
+                      "areaName": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "customer": {
+                "type": "object",
+                "nullable": true,
+                "description": "関連顧客詳細",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "nameKana": {
+                    "type": "string"
+                  },
+                  "postalCode": {
+                    "type": "string"
+                  },
+                  "address": {
+                    "type": "string"
+                  },
+                  "phoneNumber": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "email": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CreateDocumentRequest": {
+        "type": "object",
+        "description": "書類作成リクエスト",
+        "required": [
+          "type",
+          "name"
+        ],
+        "properties": {
+          "contractPlotId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "契約区画ID"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "顧客ID"
+          },
+          "type": {
+            "$ref": "#/components/schemas/DocumentType"
+          },
+          "name": {
+            "type": "string",
+            "description": "書類名",
+            "maxLength": 200,
+            "example": "請求書_2024年1月分"
+          },
+          "description": {
+            "type": "string",
+            "description": "説明"
+          },
+          "templateType": {
+            "type": "string",
+            "description": "テンプレートタイプ（invoice, postcard）"
+          },
+          "templateData": {
+            "type": "object",
+            "description": "テンプレートデータ"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考"
+          }
+        }
+      },
+      "UpdateDocumentRequest": {
+        "type": "object",
+        "description": "書類更新リクエスト",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "書類名",
+            "maxLength": 200
+          },
+          "description": {
+            "type": "string",
+            "description": "説明"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DocumentStatus"
+          },
+          "templateData": {
+            "type": "object",
+            "description": "テンプレートデータ"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考"
+          }
+        }
+      },
+      "GeneratePdfRequest": {
+        "type": "object",
+        "description": "PDF生成リクエスト",
+        "required": [
+          "templateType",
+          "templateData"
+        ],
+        "properties": {
+          "templateType": {
+            "type": "string",
+            "enum": [
+              "invoice",
+              "postcard"
+            ],
+            "description": "テンプレートタイプ"
+          },
+          "templateData": {
+            "type": "object",
+            "description": "テンプレートデータ（請求書またははがき用）"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "関連する書類ID（指定時はファイルを保存）"
+          },
+          "name": {
+            "type": "string",
+            "description": "書類名"
+          },
+          "contractPlotId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "契約区画ID"
+          },
+          "customerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "顧客ID"
+          }
+        }
+      },
+      "GeneratePdfResponse": {
+        "type": "object",
+        "description": "PDF生成レスポンス",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "書類ID"
+          },
+          "pdf": {
+            "type": "string",
+            "description": "Base64エンコードされたPDF"
+          },
+          "mimeType": {
+            "type": "string",
+            "example": "application/pdf"
+          },
+          "fileSize": {
+            "type": "integer",
+            "description": "ファイルサイズ（バイト）",
+            "example": 102400
+          }
+        }
+      },
+      "Staff": {
+        "type": "object",
+        "description": "スタッフ情報（内部処理・DB操作用、APIレスポンスでは使用しない）",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "スタッフID",
+            "example": 1
+          },
+          "supabase_uid": {
+            "type": "string",
+            "description": "Supabase User ID（内部管理用）",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "スタッフ名",
+            "example": "山田太郎",
+            "maxLength": 100
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "メールアドレス",
+            "example": "yamada@example.com",
+            "maxLength": 254
+          },
+          "role": {
+            "type": "string",
+            "description": "役割",
+            "enum": [
+              "viewer",
+              "operator",
+              "manager",
+              "admin"
+            ],
+            "example": "operator"
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "アクティブ状態",
+            "example": true
+          },
+          "last_login_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "最終ログイン日時",
+            "nullable": true,
+            "example": "2024-01-01T12:00:00Z"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "作成日時",
+            "example": "2024-01-01T10:00:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "更新日時",
+            "example": "2024-01-01T12:00:00Z"
+          }
+        }
+      },
+      "StaffPublic": {
+        "type": "object",
+        "description": "スタッフ情報（一般公開用・認証レスポンス用）",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "スタッフID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "スタッフ名",
+            "example": "山田太郎"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "メールアドレス",
+            "example": "yamada@example.com"
+          },
+          "role": {
+            "type": "string",
+            "description": "役割",
+            "enum": [
+              "viewer",
+              "operator",
+              "manager",
+              "admin"
+            ],
+            "example": "operator"
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "アクティブ状態",
+            "example": true
+          }
+        }
+      },
+      "StaffAdmin": {
+        "type": "object",
+        "description": "スタッフ情報（管理者用・管理API用、supabase_uidを含まない）",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "スタッフID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "スタッフ名",
+            "example": "山田太郎"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "メールアドレス",
+            "example": "yamada@example.com"
+          },
+          "role": {
+            "type": "string",
+            "description": "役割",
+            "enum": [
+              "viewer",
+              "operator",
+              "manager",
+              "admin"
+            ],
+            "example": "operator"
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "アクティブ状態",
+            "example": true
+          },
+          "last_login_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "最終ログイン日時",
+            "nullable": true,
+            "example": "2024-01-01T12:00:00Z"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "作成日時",
+            "example": "2024-01-01T10:00:00Z"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "更新日時",
+            "example": "2024-01-01T12:00:00Z"
+          }
+        }
+      },
+      "CreateStaffRequest": {
+        "type": "object",
+        "description": "スタッフ新規登録リクエスト",
+        "required": [
+          "name",
+          "email",
+          "password",
+          "role"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "スタッフ名",
+            "example": "山田太郎",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "メールアドレス",
+            "example": "yamada@example.com",
+            "maxLength": 254
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "description": "パスワード（8文字以上）",
+            "example": "SecurePass123!",
+            "minLength": 8
+          },
+          "role": {
+            "type": "string",
+            "description": "役割",
+            "enum": [
+              "viewer",
+              "operator",
+              "manager",
+              "admin"
+            ],
+            "example": "operator"
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "アクティブ状態",
+            "default": true,
+            "example": true
+          }
+        }
+      },
+      "UpdateStaffRequest": {
+        "type": "object",
+        "description": "スタッフ更新リクエスト（すべてのフィールドはオプション）",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "スタッフ名",
+            "example": "山田太郎",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "メールアドレス",
+            "example": "yamada@example.com",
+            "maxLength": 254
+          },
+          "role": {
+            "type": "string",
+            "description": "役割",
+            "enum": [
+              "viewer",
+              "operator",
+              "manager",
+              "admin"
+            ],
+            "example": "manager"
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "アクティブ状態",
+            "example": true
+          }
+        }
+      },
+      "ContractPlotSummary": {
+        "type": "object",
+        "description": "契約区画のサマリー情報（一覧表示用）",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "契約区画ID",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "plotNumber": {
+            "type": "string",
+            "description": "区画番号",
+            "example": "A-01"
+          },
+          "areaName": {
+            "type": "string",
+            "description": "区域名",
+            "example": "一般墓地A"
+          },
+          "contractAreaSqm": {
+            "type": "number",
+            "format": "float",
+            "description": "契約面積（㎡）",
+            "example": 3.6
+          },
+          "customerName": {
+            "type": "string",
+            "description": "顧客名",
+            "example": "山田太郎"
+          },
+          "saleStatus": {
+            "type": "string",
+            "description": "物理区画の契約状況（契約面積に基づいて計算）",
+            "enum": [
+              "fully_contracted",
+              "partially_contracted",
+              "available"
+            ],
+            "example": "fully_contracted"
+          },
+          "contractDate": {
+            "type": "string",
+            "format": "date",
+            "description": "契約日",
+            "example": "2024-01-01"
+          },
+          "phoneNumber": {
+            "type": "string",
+            "description": "電話番号",
+            "example": "09012345678"
+          },
+          "applicantName": {
+            "type": "string",
+            "description": "申込者名",
+            "example": "山田花子"
+          },
+          "currentBuriedPersons": {
+            "type": "number",
+            "description": "現在埋葬人数",
+            "example": 2
+          },
+          "nextBillingDate": {
+            "type": "string",
+            "format": "date",
+            "description": "次回請求日（使用料・管理料から計算）",
+            "example": "2024-01-01"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考",
+            "example": "🚨ご高齢のため、重要な説明は家族同席の上で行うこと。"
+          }
+        }
+      },
+      "ContractPlotDetail": {
+        "type": "object",
+        "description": "契約区画の詳細情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "契約区画ID"
+          },
+          "plot_number": {
+            "type": "string",
+            "description": "墓石コード（区画番号）",
+            "example": "A-01"
+          },
+          "area_name": {
+            "type": "string",
+            "description": "区域（期）",
+            "example": "第1期"
+          },
+          "area_name_detail": {
+            "type": "string",
+            "description": "区域（詳細）",
+            "example": "吉相"
+          },
+          "contractAreaSqm": {
+            "type": "number",
+            "format": "float",
+            "description": "契約面積（㎡）"
+          },
+          "saleStatus": {
+            "type": "string",
+            "description": "販売ステータス",
+            "nullable": true
+          },
+          "ApplicantInfo": {
+            "$ref": "#/components/schemas/ApplicantInfo"
+          },
+          "SaleContract": {
+            "$ref": "#/components/schemas/SaleContractInfo"
+          },
+          "UsageFee": {
+            "$ref": "#/components/schemas/UsageFeeInfo",
+            "nullable": true
+          },
+          "ManagementFee": {
+            "$ref": "#/components/schemas/ManagementFeeInfo",
+            "nullable": true
+          }
+        }
+      },
+      "ApplicantInfo": {
+        "type": "object",
+        "description": "申込者情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "applicantDate": {
+            "type": "string",
+            "format": "date",
+            "example": "2024-01-01"
+          },
+          "price": {
+            "type": "number",
+            "example": 1000000
+          },
+          "paymentStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "reservationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "acceptanceNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "permitDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "Customer": {
+            "$ref": "#/components/schemas/CustomerInfo"
+          }
+        }
+      },
+      "SaleContractInfo": {
+        "type": "object",
+        "description": "販売契約情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "contractDate": {
+            "type": "string",
+            "format": "date",
+            "description": "契約日",
+            "example": "2024-01-01"
+          },
+          "price": {
+            "type": "integer",
+            "description": "価格（円単位）",
+            "example": 1000000
+          },
+          "paymentStatus": {
+            "type": "string",
+            "description": "支払いステータス",
+            "nullable": true
+          },
+          "reservationDate": {
+            "type": "string",
+            "format": "date",
+            "description": "予約日",
+            "nullable": true,
+            "example": "2024-01-01"
+          },
+          "acceptanceNumber": {
+            "type": "string",
+            "description": "承諾書番号",
+            "nullable": true,
+            "example": "AC-2024-0001"
+          },
+          "permitDate": {
+            "type": "string",
+            "format": "date",
+            "description": "許可日",
+            "nullable": true,
+            "example": "2024-01-15"
+          },
+          "permitNumber": {
+            "type": "string",
+            "description": "許可番号",
+            "maxLength": 50,
+            "nullable": true,
+            "example": "KYO-2024-0001"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "description": "開始年月日",
+            "nullable": true,
+            "example": "2024-02-01"
+          },
+          "notes": {
+            "type": "string",
+            "description": "備考",
+            "nullable": true
+          },
+          "Customer": {
+            "$ref": "#/components/schemas/CustomerInfo"
+          }
+        }
+      },
+      "CustomerInfo": {
+        "type": "object",
+        "description": "顧客情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "example": "山田太郎"
+          },
+          "nameKana": {
+            "type": "string",
+            "example": "ヤマダタロウ"
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "gender": {
+            "type": "string",
+            "enum": [
+              "male",
+              "female",
+              "other"
+            ],
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "example": "150-0001"
+          },
+          "address": {
+            "type": "string",
+            "example": "東京都渋谷区"
+          },
+          "registeredAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "example": "03-1234-5678",
+            "nullable": true
+          },
+          "faxNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "WorkInfo": {
+            "$ref": "#/components/schemas/WorkInfoInfo",
+            "nullable": true
+          },
+          "BillingInfo": {
+            "$ref": "#/components/schemas/BillingInfoInfo",
+            "nullable": true
+          }
+        }
+      },
+      "WorkInfoInfo": {
+        "type": "object",
+        "description": "勤務先情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "companyName": {
+            "type": "string"
+          },
+          "companyNameKana": {
+            "type": "string"
+          },
+          "workPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "workAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "workPhoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "dmSetting": {
+            "type": "string"
+          },
+          "addressType": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "BillingInfoInfo": {
+        "type": "object",
+        "description": "請求情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "billingType": {
+            "type": "string",
+            "nullable": true
+          },
+          "accountType": {
+            "type": "string",
+            "nullable": true
+          },
+          "bankName": {
+            "type": "string",
+            "nullable": true
+          },
+          "branchName": {
+            "type": "string",
+            "nullable": true
+          },
+          "accountNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "accountHolder": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "UsageFeeInfo": {
+        "type": "object",
+        "description": "使用料情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "calculationType": {
+            "type": "string",
+            "nullable": true
+          },
+          "taxType": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingType": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingYears": {
+            "type": "string",
+            "nullable": true
+          },
+          "area": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitPrice": {
+            "type": "string",
+            "nullable": true
+          },
+          "usageFee": {
+            "type": "string",
+            "nullable": true
+          },
+          "paymentMethod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ManagementFeeInfo": {
+        "type": "object",
+        "description": "管理料情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "calculationType": {
+            "type": "string",
+            "nullable": true
+          },
+          "taxType": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingType": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingYears": {
+            "type": "string",
+            "nullable": true
+          },
+          "area": {
+            "type": "string",
+            "nullable": true
+          },
+          "billingMonth": {
+            "type": "string",
+            "nullable": true
+          },
+          "managementFee": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitPrice": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastBillingMonth": {
+            "type": "string",
+            "nullable": true
+          },
+          "paymentMethod": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "BuriedPersonInfo": {
+        "type": "object",
+        "description": "埋葬者情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameKana": {
+            "type": "string",
+            "nullable": true
+          },
+          "relationship": {
+            "type": "string",
+            "nullable": true
+          },
+          "deathDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "age": {
+            "type": "integer",
+            "nullable": true
+          },
+          "gender": {
+            "type": "string",
+            "enum": [
+              "male",
+              "female",
+              "other"
+            ],
+            "nullable": true
+          },
+          "burialDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "graveNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "CollectiveBurialInfo": {
+        "type": "object",
+        "description": "合祀情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "burialType": {
+            "type": "string"
+          },
+          "requestDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "executionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "FamilyContactInfo": {
+        "type": "object",
+        "description": "家族連絡先情報",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "relationship": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "nullable": true
+          }
+        }
+      },
+      "PhysicalPlotContracts": {
+        "type": "object",
+        "description": "物理区画の契約一覧情報",
+        "properties": {
+          "physicalPlot": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "plotNumber": {
+                "type": "string",
+                "example": "A-01"
+              },
+              "areaName": {
+                "type": "string",
+                "example": "一般墓地A"
+              },
+              "areaSqm": {
+                "type": "number",
+                "format": "float",
+                "example": 3.6
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "partial",
+                  "sold_out"
+                ]
+              }
+            }
+          },
+          "contracts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "contractAreaSqm": {
+                  "type": "number",
+                  "format": "float"
+                },
+                "saleStatus": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "customerName": {
+                  "type": "string"
+                },
+                "contractDate": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "price": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "summary": {
+            "type": "object",
+            "properties": {
+              "totalContracts": {
+                "type": "integer",
+                "description": "契約総数",
+                "example": 2
+              },
+              "totalAllocatedArea": {
+                "type": "number",
+                "format": "float",
+                "description": "割当済総面積（㎡）",
+                "example": 3.6
+              }
+            }
+          }
+        }
+      },
+      "PhysicalPlotInventory": {
+        "type": "object",
+        "description": "物理区画の在庫情報",
+        "properties": {
+          "physicalPlot": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "plotNumber": {
+                "type": "string",
+                "example": "A-01"
+              },
+              "areaName": {
+                "type": "string",
+                "example": "一般墓地A"
+              },
+              "areaSqm": {
+                "type": "number",
+                "format": "float",
+                "example": 3.6
+              }
+            }
+          },
+          "inventory": {
+            "type": "object",
+            "properties": {
+              "totalArea": {
+                "type": "number",
+                "format": "float",
+                "description": "総面積（㎡）",
+                "example": 3.6
+              },
+              "allocatedArea": {
+                "type": "number",
+                "format": "float",
+                "description": "割当済面積（㎡）",
+                "example": 1.8
+              },
+              "availableArea": {
+                "type": "number",
+                "format": "float",
+                "description": "利用可能面積（㎡）",
+                "example": 1.8
+              },
+              "utilizationRate": {
+                "type": "number",
+                "format": "float",
+                "description": "利用率（%）",
+                "example": 50
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "partial",
+                  "sold_out"
+                ],
+                "description": "在庫ステータス",
+                "example": "partial"
+              }
+            }
+          },
+          "contracts": {
+            "type": "array",
+            "description": "既存契約一覧",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "contractAreaSqm": {
+                  "type": "number",
+                  "format": "float"
+                },
+                "saleStatus": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "customerName": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "CreatePlotInput": {
+        "type": "object",
+        "description": "新規契約区画作成リクエスト",
+        "required": [
+          "physicalPlot",
+          "contractPlot",
+          "saleContract",
+          "applicant",
+          "contractor"
+        ],
+        "properties": {
+          "physicalPlot": {
+            "type": "object",
+            "required": [
+              "plotNumber",
+              "areaName",
+              "areaSqm"
+            ],
+            "properties": {
+              "plotNumber": {
+                "type": "string",
+                "description": "区画番号（大文字英数字とハイフンのみ）",
+                "pattern": "^[A-Z0-9-]+$",
+                "maxLength": 50,
+                "example": "A-01"
+              },
+              "areaName": {
+                "type": "string",
+                "description": "区画（期）",
+                "maxLength": 100,
+                "example": "第2期"
+              },
+              "areaNameDetail": {
+                "type": "string",
+                "description": "区画（詳細）",
+                "maxLength": 100,
+                "example": "8"
+              },
+              "areaSqm": {
+                "type": "number",
+                "format": "float",
+                "description": "面積（㎡）",
+                "minimum": 0.01,
+                "example": 3.6
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "contractPlot": {
+            "type": "object",
+            "required": [
+              "contractAreaSqm"
+            ],
+            "properties": {
+              "contractAreaSqm": {
+                "type": "number",
+                "format": "float",
+                "description": "契約面積（㎡）",
+                "minimum": 0.01,
+                "example": 3.6
+              },
+              "saleStatus": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true,
+                "example": "completed"
+              },
+              "locationDescription": {
+                "type": "string",
+                "maxLength": 200,
+                "nullable": true,
+                "example": "南側"
+              }
+            }
+          },
+          "saleContract": {
+            "type": "object",
+            "required": [
+              "contractDate",
+              "price"
+            ],
+            "properties": {
+              "contractDate": {
+                "type": "string",
+                "format": "date",
+                "description": "契約日",
+                "example": "2024-01-01"
+              },
+              "price": {
+                "type": "number",
+                "description": "価格",
+                "minimum": 0,
+                "example": 1000000
+              },
+              "paymentStatus": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "reservationDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "acceptanceNumber": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "permitDate": {
+                "type": "string",
+                "format": "date",
+                "description": "許可日",
+                "nullable": true
+              },
+              "permitNumber": {
+                "type": "string",
+                "maxLength": 50,
+                "description": "許可番号",
+                "nullable": true,
+                "example": "KYO-2024-0001"
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "applicant": {
+            "type": "object",
+            "description": "申込者情報",
+            "required": [
+              "name",
+              "nameKana",
+              "postalCode",
+              "address"
+            ],
+            "properties": {
+              "applicationDate": {
+                "type": "string",
+                "format": "date",
+                "description": "申込日",
+                "nullable": true,
+                "example": "2024-01-01"
+              },
+              "staffName": {
+                "type": "string",
+                "description": "担当者氏名",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "田中一郎"
+              },
+              "name": {
+                "type": "string",
+                "description": "申込者氏名",
+                "minLength": 1,
+                "maxLength": 100,
+                "example": "山田花子"
+              },
+              "nameKana": {
+                "type": "string",
+                "description": "申込者氏名カナ（カタカナのみ）",
+                "pattern": "^[ァ-ヶー\\s]+$",
+                "maxLength": 100,
+                "example": "ヤマダハナコ"
+              },
+              "postalCode": {
+                "type": "string",
+                "description": "郵便番号",
+                "minLength": 1,
+                "maxLength": 10,
+                "example": "150-0001"
+              },
+              "phoneNumber": {
+                "type": "string",
+                "description": "電話番号",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5678"
+              },
+              "address": {
+                "type": "string",
+                "description": "住所",
+                "minLength": 1,
+                "maxLength": 200,
+                "example": "東京都渋谷区"
+              }
+            }
+          },
+          "contractor": {
+            "type": "object",
+            "description": "契約者情報",
+            "required": [
+              "name",
+              "nameKana",
+              "postalCode",
+              "address"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "契約者氏名",
+                "minLength": 1,
+                "maxLength": 100,
+                "example": "山田太郎"
+              },
+              "nameKana": {
+                "type": "string",
+                "description": "契約者氏名カナ（カタカナのみ）",
+                "pattern": "^[ァ-ヶー\\s]+$",
+                "maxLength": 100,
+                "example": "ヤマダタロウ"
+              },
+              "birthDate": {
+                "type": "string",
+                "format": "date",
+                "description": "生年月日",
+                "nullable": true,
+                "example": "1980-01-01"
+              },
+              "gender": {
+                "type": "string",
+                "description": "性別",
+                "enum": [
+                  "male",
+                  "female",
+                  "other"
+                ],
+                "nullable": true
+              },
+              "postalCode": {
+                "type": "string",
+                "description": "郵便番号",
+                "minLength": 1,
+                "maxLength": 10,
+                "example": "150-0001"
+              },
+              "address": {
+                "type": "string",
+                "description": "住所",
+                "minLength": 1,
+                "maxLength": 200,
+                "example": "東京都渋谷区"
+              },
+              "registeredAddress": {
+                "type": "string",
+                "description": "本籍地住所",
+                "maxLength": 200,
+                "nullable": true,
+                "example": "東京都新宿区"
+              },
+              "phoneNumber": {
+                "type": "string",
+                "description": "電話番号",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5678"
+              },
+              "faxNumber": {
+                "type": "string",
+                "description": "ファックス",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5679"
+              },
+              "email": {
+                "type": "string",
+                "description": "メール",
+                "format": "email",
+                "nullable": true,
+                "example": "yamada@example.com"
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "workInfo": {
+            "type": "object",
+            "description": "勤務先情報",
+            "nullable": true,
+            "properties": {
+              "companyName": {
+                "type": "string",
+                "description": "勤務先名称",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "株式会社サンプル"
+              },
+              "companyNameKana": {
+                "type": "string",
+                "description": "勤務先仮名（カタカナのみ）",
+                "pattern": "^[ァ-ヶー\\s]+$",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "カブシキガイシャサンプル"
+              },
+              "workPostalCode": {
+                "type": "string",
+                "description": "郵便番号",
+                "maxLength": 10,
+                "nullable": true,
+                "example": "150-0001"
+              },
+              "workPhoneNumber": {
+                "type": "string",
+                "description": "電話番号",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5678"
+              },
+              "workAddress": {
+                "type": "string",
+                "description": "勤務先住所",
+                "maxLength": 200,
+                "nullable": true,
+                "example": "東京都渋谷区"
+              },
+              "workFaxNumber": {
+                "type": "string",
+                "description": "ファックス",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5679"
+              },
+              "dmSetting": {
+                "type": "string",
+                "description": "DM送信設定",
+                "enum": [
+                  "allow",
+                  "deny",
+                  "limited"
+                ],
+                "nullable": true,
+                "example": "allow"
+              },
+              "addressType": {
+                "type": "string",
+                "description": "宛先区分（連絡先タイプ）",
+                "enum": [
+                  "home",
+                  "work",
+                  "other"
+                ],
+                "nullable": true,
+                "example": "home"
+              },
+              "notes": {
+                "type": "string",
+                "description": "備考",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "billingInfo": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "billingType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "accountType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "bankName": {
+                "type": "string",
+                "maxLength": 100,
+                "nullable": true
+              },
+              "branchName": {
+                "type": "string",
+                "maxLength": 100,
+                "nullable": true
+              },
+              "accountNumber": {
+                "type": "string",
+                "maxLength": 20,
+                "nullable": true
+              },
+              "accountHolder": {
+                "type": "string",
+                "maxLength": 100,
+                "nullable": true
+              }
+            }
+          },
+          "usageFee": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "calculationType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "taxType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingYears": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "area": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "unitPrice": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "usageFee": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "paymentMethod": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              }
+            }
+          },
+          "managementFee": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "calculationType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "taxType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingYears": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "area": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingMonth": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "managementFee": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "unitPrice": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "lastBillingMonth": {
+                "type": "string",
+                "pattern": "^\\d{4}年\\d{1,2}月$",
+                "nullable": true,
+                "example": "2024年3月"
+              },
+              "paymentMethod": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              }
+            }
+          },
+          "gravestone": {
+            "type": "object",
+            "description": "墓石情報",
+            "nullable": true,
+            "properties": {
+              "gravestoneBase": {
+                "type": "string",
+                "description": "墓石台（墓石基礎）",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "コンクリート基礎"
+              },
+              "enclosurePosition": {
+                "type": "string",
+                "description": "包囲位置（囲障位置）",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "前面開放"
+              },
+              "gravestoneDealer": {
+                "type": "string",
+                "description": "墓石取扱い（石材店）",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "石材店A"
+              },
+              "gravestoneType": {
+                "type": "string",
+                "description": "墓石タイプ（墓石種別）",
+                "maxLength": 50,
+                "nullable": true,
+                "example": "和型"
+              },
+              "surroundingArea": {
+                "type": "string",
+                "description": "周辺設備（周辺区画）",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "水場あり"
+              },
+              "establishmentDeadline": {
+                "type": "string",
+                "format": "date",
+                "description": "設立期限（設置期限）",
+                "nullable": true,
+                "example": "2024-12-31"
+              },
+              "establishmentDate": {
+                "type": "string",
+                "format": "date",
+                "description": "設立日（設置日）",
+                "nullable": true,
+                "example": "2024-06-01"
+              }
+            }
+          },
+          "familyContacts": {
+            "type": "array",
+            "description": "家族・連絡先情報（配列）",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "emergencyContactFlag": {
+                  "type": "boolean",
+                  "description": "緊急連絡先フラグ",
+                  "default": false,
+                  "example": true
+                },
+                "name": {
+                  "type": "string",
+                  "description": "氏名",
+                  "maxLength": 100,
+                  "example": "山田次郎"
+                },
+                "birthDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "生年月日",
+                  "nullable": true,
+                  "example": "1985-05-15"
+                },
+                "relationship": {
+                  "type": "string",
+                  "description": "続柄",
+                  "maxLength": 50,
+                  "example": "長男"
+                },
+                "postalCode": {
+                  "type": "string",
+                  "description": "郵便番号",
+                  "maxLength": 10,
+                  "nullable": true,
+                  "example": "150-0001"
+                },
+                "address": {
+                  "type": "string",
+                  "description": "住所",
+                  "maxLength": 200,
+                  "example": "東京都渋谷区"
+                },
+                "phoneNumber": {
+                  "type": "string",
+                  "description": "電話番号",
+                  "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                  "example": "03-1234-5678"
+                },
+                "faxNumber": {
+                  "type": "string",
+                  "description": "ファックス",
+                  "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                  "nullable": true,
+                  "example": "03-1234-5679"
+                },
+                "email": {
+                  "type": "string",
+                  "format": "email",
+                  "description": "メールアドレス",
+                  "nullable": true,
+                  "example": "jiro@example.com"
+                },
+                "registeredAddress": {
+                  "type": "string",
+                  "description": "本籍地住所",
+                  "maxLength": 200,
+                  "nullable": true,
+                  "example": "東京都新宿区"
+                },
+                "mailingType": {
+                  "type": "string",
+                  "description": "郵送先タイプ",
+                  "enum": [
+                    "home",
+                    "work",
+                    "other"
+                  ],
+                  "nullable": true,
+                  "example": "home"
+                },
+                "notes": {
+                  "type": "string",
+                  "description": "備考",
+                  "maxLength": 1000,
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "buriedPersons": {
+            "type": "array",
+            "description": "埋葬者一覧（配列）",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "氏名",
+                  "maxLength": 100,
+                  "example": "山田三郎"
+                },
+                "nameKana": {
+                  "type": "string",
+                  "description": "氏名カナ（カタカナのみ）",
+                  "pattern": "^[ァ-ヶー\\s]+$",
+                  "maxLength": 100,
+                  "nullable": true,
+                  "example": "ヤマダサブロウ"
+                },
+                "relationship": {
+                  "type": "string",
+                  "description": "続柄",
+                  "maxLength": 50,
+                  "nullable": true,
+                  "example": "祖父"
+                },
+                "deathDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "死亡日",
+                  "nullable": true,
+                  "example": "2020-03-15"
+                },
+                "age": {
+                  "type": "integer",
+                  "description": "年齢",
+                  "nullable": true,
+                  "example": 85
+                },
+                "gender": {
+                  "type": "string",
+                  "description": "性別",
+                  "enum": [
+                    "male",
+                    "female",
+                    "other"
+                  ],
+                  "nullable": true,
+                  "example": "male"
+                },
+                "burialDate": {
+                  "type": "string",
+                  "format": "date",
+                  "description": "埋葬日",
+                  "nullable": true,
+                  "example": "2020-03-20"
+                },
+                "notes": {
+                  "type": "string",
+                  "description": "備考",
+                  "maxLength": 1000,
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "UpdatePlotInput": {
+        "type": "object",
+        "description": "契約区画更新リクエスト（全フィールドオプション）",
+        "properties": {
+          "contractPlot": {
+            "type": "object",
+            "properties": {
+              "contractAreaSqm": {
+                "type": "number",
+                "format": "float",
+                "minimum": 0.01
+              },
+              "saleStatus": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "locationDescription": {
+                "type": "string",
+                "maxLength": 200,
+                "nullable": true
+              }
+            }
+          },
+          "saleContract": {
+            "type": "object",
+            "properties": {
+              "contractDate": {
+                "type": "string",
+                "format": "date"
+              },
+              "price": {
+                "type": "number",
+                "minimum": 0
+              },
+              "paymentStatus": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "reservationDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "acceptanceNumber": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "permitDate": {
+                "type": "string",
+                "format": "date",
+                "description": "許可日",
+                "nullable": true
+              },
+              "permitNumber": {
+                "type": "string",
+                "maxLength": 50,
+                "description": "許可番号",
+                "nullable": true,
+                "example": "KYO-2024-0001"
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "customer": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "nameKana": {
+                "type": "string",
+                "pattern": "^[ァ-ヶー\\s]+$",
+                "maxLength": 100
+              },
+              "birthDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "gender": {
+                "type": "string",
+                "enum": [
+                  "male",
+                  "female",
+                  "other"
+                ],
+                "nullable": true
+              },
+              "postalCode": {
+                "type": "string",
+                "maxLength": 10
+              },
+              "address": {
+                "type": "string",
+                "maxLength": 200
+              },
+              "registeredAddress": {
+                "type": "string",
+                "maxLength": 200,
+                "nullable": true
+              },
+              "phoneNumber": {
+                "type": "string",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true
+              },
+              "faxNumber": {
+                "type": "string",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "nullable": true
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "workInfo": {
+            "type": "object",
+            "description": "勤務先情報",
+            "nullable": true,
+            "properties": {
+              "companyName": {
+                "type": "string",
+                "description": "勤務先名称",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "株式会社サンプル"
+              },
+              "companyNameKana": {
+                "type": "string",
+                "description": "勤務先仮名（カタカナのみ）",
+                "pattern": "^[ァ-ヶー\\s]+$",
+                "maxLength": 100,
+                "nullable": true,
+                "example": "カブシキガイシャサンプル"
+              },
+              "workPostalCode": {
+                "type": "string",
+                "description": "郵便番号",
+                "maxLength": 10,
+                "nullable": true,
+                "example": "150-0001"
+              },
+              "workPhoneNumber": {
+                "type": "string",
+                "description": "電話番号",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5678"
+              },
+              "workAddress": {
+                "type": "string",
+                "description": "勤務先住所",
+                "maxLength": 200,
+                "nullable": true,
+                "example": "東京都渋谷区"
+              },
+              "workFaxNumber": {
+                "type": "string",
+                "description": "ファックス",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true,
+                "example": "03-1234-5679"
+              },
+              "dmSetting": {
+                "type": "string",
+                "description": "DM送信設定",
+                "enum": [
+                  "allow",
+                  "deny",
+                  "limited"
+                ],
+                "nullable": true,
+                "example": "allow"
+              },
+              "addressType": {
+                "type": "string",
+                "description": "宛先区分（連絡先タイプ）",
+                "enum": [
+                  "home",
+                  "work",
+                  "other"
+                ],
+                "nullable": true,
+                "example": "home"
+              },
+              "notes": {
+                "type": "string",
+                "description": "備考",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "billingInfo": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "billingType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "accountType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "bankName": {
+                "type": "string",
+                "maxLength": 100,
+                "nullable": true
+              },
+              "branchName": {
+                "type": "string",
+                "maxLength": 100,
+                "nullable": true
+              },
+              "accountNumber": {
+                "type": "string",
+                "maxLength": 20,
+                "nullable": true
+              },
+              "accountHolder": {
+                "type": "string",
+                "maxLength": 100,
+                "nullable": true
+              }
+            }
+          },
+          "usageFee": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "calculationType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "taxType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingYears": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "area": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "unitPrice": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "usageFee": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "paymentMethod": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              }
+            }
+          },
+          "managementFee": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "calculationType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "taxType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingType": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingYears": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "area": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "billingMonth": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "managementFee": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "unitPrice": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "lastBillingMonth": {
+                "type": "string",
+                "pattern": "^\\d{4}年\\d{1,2}月$",
+                "nullable": true
+              },
+              "paymentMethod": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "CreatePlotContractInput": {
+        "type": "object",
+        "description": "物理区画への新規契約追加リクエスト（physicalPlot不要）",
+        "required": [
+          "contractPlot",
+          "saleContract",
+          "customer"
+        ],
+        "properties": {
+          "contractPlot": {
+            "type": "object",
+            "required": [
+              "contractAreaSqm"
+            ],
+            "properties": {
+              "contractAreaSqm": {
+                "type": "number",
+                "format": "float",
+                "description": "契約面積（㎡）",
+                "minimum": 0.01,
+                "example": 1.8
+              },
+              "saleStatus": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "locationDescription": {
+                "type": "string",
+                "maxLength": 200,
+                "nullable": true
+              }
+            }
+          },
+          "saleContract": {
+            "type": "object",
+            "required": [
+              "contractDate",
+              "price"
+            ],
+            "properties": {
+              "contractDate": {
+                "type": "string",
+                "format": "date",
+                "example": "2024-06-01"
+              },
+              "price": {
+                "type": "number",
+                "minimum": 0,
+                "example": 500000
+              },
+              "paymentStatus": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "reservationDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "acceptanceNumber": {
+                "type": "string",
+                "maxLength": 50,
+                "nullable": true
+              },
+              "permitDate": {
+                "type": "string",
+                "format": "date",
+                "description": "許可日",
+                "nullable": true
+              },
+              "permitNumber": {
+                "type": "string",
+                "maxLength": 50,
+                "description": "許可番号",
+                "nullable": true,
+                "example": "KYO-2024-0001"
+              },
+              "startDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "customer": {
+            "type": "object",
+            "required": [
+              "name",
+              "nameKana",
+              "postalCode",
+              "address"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100,
+                "example": "田中花子"
+              },
+              "nameKana": {
+                "type": "string",
+                "pattern": "^[ァ-ヶー\\s]+$",
+                "maxLength": 100,
+                "example": "タナカハナコ"
+              },
+              "birthDate": {
+                "type": "string",
+                "format": "date",
+                "nullable": true
+              },
+              "gender": {
+                "type": "string",
+                "enum": [
+                  "male",
+                  "female",
+                  "other"
+                ],
+                "nullable": true
+              },
+              "postalCode": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 10,
+                "example": "150-0002"
+              },
+              "address": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "example": "東京都渋谷区"
+              },
+              "registeredAddress": {
+                "type": "string",
+                "maxLength": 200,
+                "nullable": true
+              },
+              "phoneNumber": {
+                "type": "string",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true
+              },
+              "faxNumber": {
+                "type": "string",
+                "pattern": "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$",
+                "nullable": true
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "nullable": true
+              },
+              "notes": {
+                "type": "string",
+                "maxLength": 1000,
+                "nullable": true
+              }
+            }
+          },
+          "workInfo": {
+            "type": "object",
+            "nullable": true
+          },
+          "billingInfo": {
+            "type": "object",
+            "nullable": true
+          },
+          "usageFee": {
+            "type": "object",
+            "nullable": true
+          },
+          "managementFee": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "InventorySummary": {
+        "type": "object",
+        "description": "在庫全体サマリー",
+        "properties": {
+          "totalCount": {
+            "type": "integer",
+            "description": "総区画数",
+            "example": 3626
+          },
+          "usedCount": {
+            "type": "integer",
+            "description": "使用済区画数",
+            "example": 2963
+          },
+          "remainingCount": {
+            "type": "integer",
+            "description": "残区画数",
+            "example": 663
+          },
+          "usageRate": {
+            "type": "number",
+            "format": "float",
+            "description": "使用率（%）",
+            "example": 81.7
+          },
+          "totalAreaSqm": {
+            "type": "number",
+            "format": "float",
+            "description": "総面積（㎡）",
+            "example": 13053.6
+          },
+          "remainingAreaSqm": {
+            "type": "number",
+            "format": "float",
+            "description": "残面積（㎡）",
+            "example": 2386.8
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "最終更新日時"
+          }
+        }
+      },
+      "PeriodSummary": {
+        "type": "object",
+        "description": "期別サマリー",
+        "properties": {
+          "period": {
+            "type": "string",
+            "description": "期（第1期〜第4期）",
+            "enum": [
+              "第1期",
+              "第2期",
+              "第3期",
+              "第3期樹林部",
+              "第4期"
+            ],
+            "example": "第1期"
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "総区画数",
+            "example": 1591
+          },
+          "usedCount": {
+            "type": "integer",
+            "description": "使用済区画数",
+            "example": 1320
+          },
+          "remainingCount": {
+            "type": "integer",
+            "description": "残区画数",
+            "example": 271
+          },
+          "usageRate": {
+            "type": "number",
+            "format": "float",
+            "description": "使用率（%）",
+            "example": 83
+          }
+        }
+      },
+      "SectionInventoryItem": {
+        "type": "object",
+        "description": "セクション別在庫アイテム",
+        "properties": {
+          "period": {
+            "type": "string",
+            "description": "期",
+            "example": "第1期"
+          },
+          "section": {
+            "type": "string",
+            "description": "セクション（A, B, 吉相など）",
+            "example": "A"
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "総区画数",
+            "example": 100
+          },
+          "usedCount": {
+            "type": "integer",
+            "description": "使用済区画数",
+            "example": 85
+          },
+          "remainingCount": {
+            "type": "integer",
+            "description": "残区画数",
+            "example": 15
+          },
+          "usageRate": {
+            "type": "number",
+            "format": "float",
+            "description": "使用率（%）",
+            "example": 85
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "description": "カテゴリ（樹林・天空など）",
+            "example": "樹林・天空"
+          }
+        }
+      },
+      "AreaInventoryItem": {
+        "type": "object",
+        "description": "面積別在庫アイテム",
+        "properties": {
+          "period": {
+            "type": "string",
+            "description": "期",
+            "example": "第1期"
+          },
+          "areaSqm": {
+            "type": "number",
+            "format": "float",
+            "description": "面積（㎡）",
+            "example": 3.6
+          },
+          "totalCount": {
+            "type": "integer",
+            "description": "総区画数",
+            "example": 50
+          },
+          "usedCount": {
+            "type": "integer",
+            "description": "使用済区画数",
+            "example": 40
+          },
+          "remainingCount": {
+            "type": "integer",
+            "description": "残区画数",
+            "example": 10
+          },
+          "remainingAreaSqm": {
+            "type": "number",
+            "format": "float",
+            "description": "残面積（㎡）",
+            "example": 36
+          },
+          "plotType": {
+            "type": "string",
+            "description": "区画タイプ（自由、吉相、樹林、天空など）",
+            "example": "自由"
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "example": 100
+          },
+          "page": {
+            "type": "integer",
+            "example": 1
+          },
+          "limit": {
+            "type": "integer",
+            "example": 20
+          },
+          "totalPages": {
+            "type": "integer",
+            "example": 5
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "example": "VALIDATION_ERROR"
+              },
+              "message": {
+                "type": "string",
+                "example": "バリデーションエラーが発生しました"
+              },
+              "details": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "field": {
+                      "type": "string",
+                      "example": "plot.plotNumber"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "区画番号は必須です"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "バリデーションエラー",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "バリデーションエラーが発生しました",
+                "details": [
+                  {
+                    "field": "plot.plotNumber",
+                    "message": "区画番号は必須です"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "認証エラー",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "UNAUTHORIZED",
+                "message": "認証が必要です",
+                "details": []
+              }
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "権限エラー",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "FORBIDDEN",
+                "message": "この操作を実行する権限がありません",
+                "details": []
+              }
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "リソースが見つからない",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "NOT_FOUND",
+                "message": "指定されたリソースが見つかりません",
+                "details": []
+              }
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "データ競合エラー",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "CONFLICT",
+                "message": "区画番号が既に存在します",
+                "details": []
+              }
+            }
+          }
+        }
+      },
+      "ServiceUnavailable": {
+        "description": "サービス利用不可",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "example": {
+              "success": false,
+              "error": {
+                "code": "SERVICE_UNAVAILABLE",
+                "message": "Supabase認証サービスが利用できません",
+                "details": []
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -23,6 +23,8 @@ tags:
     description: スタッフ管理
   - name: Documents
     description: 書類管理（PDF生成・ファイルアップロード）
+  - name: Yucho
+    description: ゆうちょ連携（自動払込み用CSV生成）
 
 paths:
   /api/v1/auth/login:
@@ -452,7 +454,8 @@ paths:
       tags:
         - Plots
       summary: 契約区画更新
-      description: 契約区画情報を更新。部分更新をサポート（contractPlot, saleContract, customer, workInfo, billingInfo, usageFee, managementFee）。
+      description: 契約区画情報を更新。部分更新をサポート（contractPlot, saleContract, customer, workInfo,
+        billingInfo, usageFee, managementFee）。
       security:
         - bearerAuth: []
       parameters:
@@ -667,7 +670,7 @@ paths:
           description: 期（指定しない場合は全期）
           schema:
             type: string
-            enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
+            enum: [ "第1期", "第2期", "第3期", "第3期樹林部", "第4期" ]
       responses:
         "200":
           description: 取得成功
@@ -705,13 +708,13 @@ paths:
           description: 期でフィルタ
           schema:
             type: string
-            enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
+            enum: [ "第1期", "第2期", "第3期", "第3期樹林部", "第4期" ]
         - name: status
           in: query
           description: ステータスでフィルタ
           schema:
             type: string
-            enum: ["available", "partially_sold", "sold_out"]
+            enum: [ "available", "partially_sold", "sold_out" ]
         - name: search
           in: query
           description: セクション名で検索
@@ -737,7 +740,7 @@ paths:
           description: ソート順
           schema:
             type: string
-            enum: ["asc", "desc"]
+            enum: [ "asc", "desc" ]
             default: "asc"
         - name: page
           in: query
@@ -793,7 +796,7 @@ paths:
           description: 期でフィルタ
           schema:
             type: string
-            enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
+            enum: [ "第1期", "第2期", "第3期", "第3期樹林部", "第4期" ]
         - name: search
           in: query
           description: 面積・タイプで検索
@@ -820,7 +823,7 @@ paths:
           description: ソート順
           schema:
             type: string
-            enum: ["asc", "desc"]
+            enum: [ "asc", "desc" ]
             default: "asc"
         - name: page
           in: query
@@ -927,7 +930,7 @@ paths:
           description: 役割でフィルタ
           schema:
             type: string
-            enum: [viewer, operator, manager, admin]
+            enum: [ viewer, operator, manager, admin ]
         - name: is_active
           in: query
           description: アクティブ状態でフィルタ
@@ -1193,14 +1196,14 @@ paths:
           description: ソート項目
           schema:
             type: string
-            enum: [created_at, updated_at, name, type, status]
+            enum: [ created_at, updated_at, name, type, status ]
             default: created_at
         - name: sortOrder
           in: query
           description: ソート順
           schema:
             type: string
-            enum: [asc, desc]
+            enum: [ asc, desc ]
             default: desc
       responses:
         "200":
@@ -1604,6 +1607,234 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v1/yucho/billing:
+    get:
+      tags:
+        - Yucho
+      summary: ゆうちょ請求対象データ取得
+      description: |
+        指定期間の管理料・合祀料金の請求対象データを集約して返す。
+        各レコードには契約区画情報、顧客情報、口座情報、請求金額が含まれる。
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1900
+            maximum: 2999
+          description: 対象年（西暦）
+        - name: month
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+          description: 対象月。指定なしの場合は年単位で集計
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ management, collective, all ]
+            default: all
+          description: 請求対象カテゴリ
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ unbilled, billed, paid, all ]
+            default: unbilled
+          description: 請求ステータスフィルタ
+      responses:
+        "200":
+          description: 請求対象データ
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      period:
+                        type: object
+                        properties:
+                          year:
+                            type: integer
+                          month:
+                            type: integer
+                            nullable: true
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            category:
+                              type: string
+                              enum: [ management, collective ]
+                            sourceId:
+                              type: string
+                            contractPlotId:
+                              type: string
+                            plotNumber:
+                              type: string
+                            areaName:
+                              type: string
+                            customerId:
+                              type: string
+                              nullable: true
+                            customerName:
+                              type: string
+                              nullable: true
+                            customerNameKana:
+                              type: string
+                              nullable: true
+                            billingAmount:
+                              type: integer
+                            billingStatus:
+                              type: string
+                            scheduledDate:
+                              type: string
+                              nullable: true
+                            billingMonth:
+                              type: integer
+                              nullable: true
+                            billingInfo:
+                              type: object
+                              nullable: true
+                              properties:
+                                bankName:
+                                  type: string
+                                  nullable: true
+                                branchName:
+                                  type: string
+                                  nullable: true
+                                accountType:
+                                  type: string
+                                  nullable: true
+                                accountNumber:
+                                  type: string
+                                  nullable: true
+                                accountHolder:
+                                  type: string
+                                  nullable: true
+                      summary:
+                        type: object
+                        properties:
+                          totalCount:
+                            type: integer
+                          totalAmount:
+                            type: integer
+                          byCategory:
+                            type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v1/yucho/export:
+    get:
+      tags:
+        - Yucho
+      summary: ゆうちょ自動払込み用CSV出力
+      description: |
+        全銀協フォーマット（120バイト固定長レコード）のCSVを生成して返す。
+        ヘッダー(1) + データ(2) + トレーラー(8) + エンド(9) の構成。
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+        - name: month
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ management, collective, all ]
+            default: all
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ unbilled, billed, paid, all ]
+            default: unbilled
+        - name: format
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ zengin ]
+            default: zengin
+        - name: transferDate
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+          description: 引落日 (YYYY-MM-DD)
+        - name: clientCode
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: "^\\d{1,10}$"
+          description: 委託者コード（最大10桁）
+        - name: clientName
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 40
+          description: 委託者名（半角40文字以内）
+        - name: bankCode
+          in: query
+          required: false
+          schema:
+            type: string
+            pattern: "^\\d{4}$"
+            default: "9900"
+          description: 取引銀行コード（4桁、デフォルト 9900 = ゆうちょ）
+        - name: branchCode
+          in: query
+          required: false
+          schema:
+            type: string
+            pattern: "^\\d{3}$"
+            default: "000"
+          description: 取引支店コード（3桁）
+      responses:
+        "200":
+          description: 全銀協フォーマット CSV
+          content:
+            text/csv:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1890,7 +2121,7 @@ components:
       properties:
         templateType:
           type: string
-          enum: [invoice, postcard]
+          enum: [ invoice, postcard ]
           description: テンプレートタイプ
         templateData:
           type: object
@@ -1958,7 +2189,7 @@ components:
         role:
           type: string
           description: 役割
-          enum: [viewer, operator, manager, admin]
+          enum: [ viewer, operator, manager, admin ]
           example: operator
         is_active:
           type: boolean
@@ -2001,7 +2232,7 @@ components:
         role:
           type: string
           description: 役割
-          enum: [viewer, operator, manager, admin]
+          enum: [ viewer, operator, manager, admin ]
           example: operator
         is_active:
           type: boolean
@@ -2028,7 +2259,7 @@ components:
         role:
           type: string
           description: 役割
-          enum: [viewer, operator, manager, admin]
+          enum: [ viewer, operator, manager, admin ]
           example: operator
         is_active:
           type: boolean
@@ -2081,7 +2312,7 @@ components:
         role:
           type: string
           description: 役割
-          enum: [viewer, operator, manager, admin]
+          enum: [ viewer, operator, manager, admin ]
           example: operator
         is_active:
           type: boolean
@@ -2108,7 +2339,7 @@ components:
         role:
           type: string
           description: 役割
-          enum: [viewer, operator, manager, admin]
+          enum: [ viewer, operator, manager, admin ]
           example: manager
         is_active:
           type: boolean
@@ -2146,7 +2377,7 @@ components:
         saleStatus:
           type: string
           description: 物理区画の契約状況（契約面積に基づいて計算）
-          enum: [fully_contracted, partially_contracted, available]
+          enum: [ fully_contracted, partially_contracted, available ]
           example: fully_contracted
         contractDate:
           type: string
@@ -2327,7 +2558,7 @@ components:
           nullable: true
         gender:
           type: string
-          enum: [male, female, other]
+          enum: [ male, female, other ]
           nullable: true
         postalCode:
           type: string
@@ -2508,7 +2739,7 @@ components:
           nullable: true
         gender:
           type: string
-          enum: [male, female, other]
+          enum: [ male, female, other ]
           nullable: true
         burialDate:
           type: string
@@ -2594,7 +2825,7 @@ components:
               example: 3.6
             status:
               type: string
-              enum: [available, partial, sold_out]
+              enum: [ available, partial, sold_out ]
         contracts:
           type: array
           items:
@@ -2674,7 +2905,7 @@ components:
               example: 50.0
             status:
               type: string
-              enum: [available, partial, sold_out]
+              enum: [ available, partial, sold_out ]
               description: 在庫ステータス
               example: partial
         contracts:
@@ -2838,7 +3069,7 @@ components:
             nameKana:
               type: string
               description: 申込者氏名カナ（カタカナのみ）
-              pattern: '^[ァ-ヶー\s]+$'
+              pattern: "^[ァ-ヶー\\s]+$"
               maxLength: 100
               example: ヤマダハナコ
             postalCode:
@@ -2850,7 +3081,7 @@ components:
             phoneNumber:
               type: string
               description: 電話番号
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5678"
             address:
@@ -2877,7 +3108,7 @@ components:
             nameKana:
               type: string
               description: 契約者氏名カナ（カタカナのみ）
-              pattern: '^[ァ-ヶー\s]+$'
+              pattern: "^[ァ-ヶー\\s]+$"
               maxLength: 100
               example: ヤマダタロウ
             birthDate:
@@ -2889,7 +3120,7 @@ components:
             gender:
               type: string
               description: 性別
-              enum: [male, female, other]
+              enum: [ male, female, other ]
               nullable: true
             postalCode:
               type: string
@@ -2912,13 +3143,13 @@ components:
             phoneNumber:
               type: string
               description: 電話番号
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5678"
             faxNumber:
               type: string
               description: ファックス
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5679"
             email:
@@ -2945,7 +3176,7 @@ components:
             companyNameKana:
               type: string
               description: 勤務先仮名（カタカナのみ）
-              pattern: '^[ァ-ヶー\s]+$'
+              pattern: "^[ァ-ヶー\\s]+$"
               maxLength: 100
               nullable: true
               example: カブシキガイシャサンプル
@@ -2958,7 +3189,7 @@ components:
             workPhoneNumber:
               type: string
               description: 電話番号
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5678"
             workAddress:
@@ -2970,19 +3201,19 @@ components:
             workFaxNumber:
               type: string
               description: ファックス
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5679"
             dmSetting:
               type: string
               description: DM送信設定
-              enum: [allow, deny, limited]
+              enum: [ allow, deny, limited ]
               nullable: true
               example: allow
             addressType:
               type: string
               description: 宛先区分（連絡先タイプ）
-              enum: [home, work, other]
+              enum: [ home, work, other ]
               nullable: true
               example: home
             notes:
@@ -3092,7 +3323,7 @@ components:
               nullable: true
             lastBillingMonth:
               type: string
-              pattern: '^\d{4}年\d{1,2}月$'
+              pattern: "^\\d{4}年\\d{1,2}月$"
               nullable: true
               example: "2024年3月"
             paymentMethod:
@@ -3188,12 +3419,12 @@ components:
               phoneNumber:
                 type: string
                 description: 電話番号
-                pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+                pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
                 example: "03-1234-5678"
               faxNumber:
                 type: string
                 description: ファックス
-                pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+                pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
                 nullable: true
                 example: "03-1234-5679"
               email:
@@ -3211,7 +3442,7 @@ components:
               mailingType:
                 type: string
                 description: 郵送先タイプ
-                enum: [home, work, other]
+                enum: [ home, work, other ]
                 nullable: true
                 example: home
               notes:
@@ -3234,7 +3465,7 @@ components:
               nameKana:
                 type: string
                 description: 氏名カナ（カタカナのみ）
-                pattern: '^[ァ-ヶー\s]+$'
+                pattern: "^[ァ-ヶー\\s]+$"
                 maxLength: 100
                 nullable: true
                 example: ヤマダサブロウ
@@ -3258,7 +3489,7 @@ components:
               gender:
                 type: string
                 description: 性別
-                enum: [male, female, other]
+                enum: [ male, female, other ]
                 nullable: true
                 example: male
               burialDate:
@@ -3340,7 +3571,7 @@ components:
               maxLength: 100
             nameKana:
               type: string
-              pattern: '^[ァ-ヶー\s]+$'
+              pattern: "^[ァ-ヶー\\s]+$"
               maxLength: 100
             birthDate:
               type: string
@@ -3348,7 +3579,7 @@ components:
               nullable: true
             gender:
               type: string
-              enum: [male, female, other]
+              enum: [ male, female, other ]
               nullable: true
             postalCode:
               type: string
@@ -3362,11 +3593,11 @@ components:
               nullable: true
             phoneNumber:
               type: string
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
             faxNumber:
               type: string
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
             email:
               type: string
@@ -3390,7 +3621,7 @@ components:
             companyNameKana:
               type: string
               description: 勤務先仮名（カタカナのみ）
-              pattern: '^[ァ-ヶー\s]+$'
+              pattern: "^[ァ-ヶー\\s]+$"
               maxLength: 100
               nullable: true
               example: カブシキガイシャサンプル
@@ -3403,7 +3634,7 @@ components:
             workPhoneNumber:
               type: string
               description: 電話番号
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5678"
             workAddress:
@@ -3415,19 +3646,19 @@ components:
             workFaxNumber:
               type: string
               description: ファックス
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
               example: "03-1234-5679"
             dmSetting:
               type: string
               description: DM送信設定
-              enum: [allow, deny, limited]
+              enum: [ allow, deny, limited ]
               nullable: true
               example: allow
             addressType:
               type: string
               description: 宛先区分（連絡先タイプ）
-              enum: [home, work, other]
+              enum: [ home, work, other ]
               nullable: true
               example: home
             notes:
@@ -3537,7 +3768,7 @@ components:
               nullable: true
             lastBillingMonth:
               type: string
-              pattern: '^\d{4}年\d{1,2}月$'
+              pattern: "^\\d{4}年\\d{1,2}月$"
               nullable: true
             paymentMethod:
               type: string
@@ -3631,7 +3862,7 @@ components:
               example: 田中花子
             nameKana:
               type: string
-              pattern: '^[ァ-ヶー\s]+$'
+              pattern: "^[ァ-ヶー\\s]+$"
               maxLength: 100
               example: タナカハナコ
             birthDate:
@@ -3640,7 +3871,7 @@ components:
               nullable: true
             gender:
               type: string
-              enum: [male, female, other]
+              enum: [ male, female, other ]
               nullable: true
             postalCode:
               type: string
@@ -3658,11 +3889,11 @@ components:
               nullable: true
             phoneNumber:
               type: string
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
             faxNumber:
               type: string
-              pattern: '^0\d{1,4}-?\d{1,4}-?\d{4}$'
+              pattern: "^0\\d{1,4}-?\\d{1,4}-?\\d{4}$"
               nullable: true
             email:
               type: string
@@ -3730,7 +3961,7 @@ components:
         period:
           type: string
           description: 期（第1期〜第4期）
-          enum: ["第1期", "第2期", "第3期", "第3期樹林部", "第4期"]
+          enum: [ "第1期", "第2期", "第3期", "第3期樹林部", "第4期" ]
           example: "第1期"
         totalCount:
           type: integer

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -118,6 +118,10 @@ describe('Server Index', () => {
       __esModule: true,
       default: 'document-routes',
     }));
+    jest.doMock('../src/yucho/yuchoRoutes', () => ({
+      __esModule: true,
+      default: 'yucho-routes',
+    }));
 
     // ミドルウェアのモック
     jest.doMock('../src/middleware/errorHandler', () => ({
@@ -244,9 +248,9 @@ describe('Server Index', () => {
 
     // セキュリティミドルウェア（helmet, cors, hpp, json, urlencoded, cookieParser, sanitizeInput, rateLimiter）
     // + requestIdMiddleware + ログミドルウェア（requestLogger, securityHeaders）
-    // + Swagger UI + 6 API routes (auth, plots, masters, staff, collective-burials, documents)
-    // + notFoundHandler + errorHandler = 20 use calls
-    expect(mockApp.use).toHaveBeenCalledTimes(20);
+    // + Swagger UI + 7 API routes (auth, plots, masters, staff, collective-burials, documents, yucho)
+    // + notFoundHandler + errorHandler = 21 use calls
+    expect(mockApp.use).toHaveBeenCalledTimes(21);
     // 1 health check endpoint
     expect(mockApp.get).toHaveBeenCalledTimes(1);
   });

--- a/tests/yucho/yuchoController.test.ts
+++ b/tests/yucho/yuchoController.test.ts
@@ -1,0 +1,316 @@
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma = {
+  managementFee: { findMany: jest.fn() },
+  collectiveBurial: { findMany: jest.fn() },
+};
+
+jest.mock('../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+  prisma: mockPrisma,
+}));
+
+import { getYuchoBilling, exportYuchoCsv } from '../../src/yucho/yuchoController';
+
+const buildContractPlot = (overrides: Record<string, unknown> = {}) => ({
+  id: 'cp-1',
+  contract_date: new Date('2024-01-15'),
+  payment_status: 'unpaid',
+  contract_status: 'active',
+  physicalPlot: {
+    id: 'pp-1',
+    plot_number: 'A-1',
+    area_name: '第1期',
+  },
+  saleContractRoles: [
+    {
+      role: 'contractor',
+      customer: {
+        id: 'cust-1',
+        name: '山田太郎',
+        name_kana: 'ヤマダタロウ',
+        billingInfo: {
+          bank_name: 'ゆうちょ銀行',
+          branch_name: '〇一八',
+          account_type: 'ordinary',
+          account_number: '1234567',
+          account_holder: 'ヤマダタロウ',
+        },
+      },
+    },
+  ],
+  ...overrides,
+});
+
+const buildResponse = (): Partial<Response> => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+  setHeader: jest.fn().mockReturnThis(),
+  send: jest.fn().mockReturnThis(),
+});
+
+const buildRequest = (query: Record<string, string>): Partial<Request> => ({
+  query,
+  params: {},
+  body: {},
+  user: {
+    id: 1,
+    email: 'admin@example.com',
+    name: 'Admin',
+    role: 'admin',
+    is_active: true,
+    supabase_uid: 'admin-uid',
+  },
+});
+
+describe('yuchoController', () => {
+  let res: Partial<Response>;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = buildResponse();
+    next = jest.fn();
+  });
+
+  describe('getYuchoBilling', () => {
+    it('returns aggregated management + collective items with summary', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'fee-1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '12000',
+          contractPlot: buildContractPlot(),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([
+        {
+          id: 'cb-1',
+          contract_plot_id: 'cp-2',
+          billing_amount: 50000,
+          billing_status: 'pending',
+          billing_scheduled_date: new Date('2026-04-15'),
+          contractPlot: buildContractPlot({
+            id: 'cp-2',
+            physicalPlot: { id: 'pp-2', plot_number: 'B-2', area_name: '第2期' },
+          }),
+        },
+      ]);
+
+      const req = buildRequest({ year: '2026', month: '4' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      expect(payload.data.period).toEqual({ year: 2026, month: 4 });
+      expect(payload.data.items).toHaveLength(2);
+      expect(payload.data.summary.totalCount).toBe(2);
+      expect(payload.data.summary.totalAmount).toBe(62000);
+      expect(payload.data.summary.byCategory.management.amount).toBe(12000);
+      expect(payload.data.summary.byCategory.collective.amount).toBe(50000);
+    });
+
+    it('filters out management fees whose billing_month does not match', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '10000',
+          contractPlot: buildContractPlot(),
+        },
+        {
+          id: 'f2',
+          contract_plot_id: 'cp-2',
+          billing_month: '5',
+          management_fee: '8000',
+          contractPlot: buildContractPlot({ id: 'cp-2' }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data.items).toHaveLength(1);
+      expect(payload.data.items[0].sourceId).toBe('f1');
+    });
+
+    it('skips management fees with non-positive amounts', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '0',
+          contractPlot: buildContractPlot(),
+        },
+        {
+          id: 'f2',
+          contract_plot_id: 'cp-2',
+          billing_month: '4',
+          management_fee: '',
+          contractPlot: buildContractPlot({ id: 'cp-2' }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data.items).toHaveLength(0);
+    });
+
+    it('honours category=collective by skipping management fee query', async () => {
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', category: 'collective' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      expect(mockPrisma.managementFee.findMany).not.toHaveBeenCalled();
+      expect(mockPrisma.collectiveBurial.findMany).toHaveBeenCalled();
+    });
+
+    it('returns 400-style ValidationError for invalid year', async () => {
+      const req = buildRequest({ year: 'abc' });
+      await getYuchoBilling(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+    });
+
+    it('prefers contractor role over applicant when picking the payer', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '10000',
+          contractPlot: buildContractPlot({
+            saleContractRoles: [
+              {
+                role: 'applicant',
+                customer: {
+                  id: 'a1',
+                  name: '申込太郎',
+                  name_kana: 'モウシコミタロウ',
+                  billingInfo: null,
+                },
+              },
+              {
+                role: 'contractor',
+                customer: {
+                  id: 'c1',
+                  name: '契約花子',
+                  name_kana: 'ケイヤクハナコ',
+                  billingInfo: {
+                    bank_name: 'ゆうちょ銀行',
+                    branch_name: '〇一八',
+                    account_type: 'ordinary',
+                    account_number: '7654321',
+                    account_holder: 'ケイヤクハナコ',
+                  },
+                },
+              },
+            ],
+          }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data.items[0].customerId).toBe('c1');
+      expect(payload.data.items[0].billingInfo.accountNumber).toBe('7654321');
+    });
+  });
+
+  describe('exportYuchoCsv', () => {
+    const validQuery = {
+      year: '2026',
+      month: '4',
+      transferDate: '2026-04-27',
+      clientCode: '1234567',
+      clientName: 'コミネレイエン',
+    };
+
+    it('returns text/csv with attachment disposition and Zengin records', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '12000',
+          contractPlot: buildContractPlot(),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest(validQuery);
+      await exportYuchoCsv(req as Request, res as Response, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=utf-8');
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        expect.stringContaining('yucho_202604.csv')
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      const sent = (res.send as jest.Mock).mock.calls[0][0] as string;
+      const lines = sent.split('\r\n').filter((l) => l.length > 0);
+      expect(lines[0]?.[0]).toBe('1');
+      expect(lines.find((l) => l[0] === '2')).toBeDefined();
+      expect(lines.find((l) => l[0] === '8')).toBeDefined();
+      expect(lines.find((l) => l[0] === '9')).toBeDefined();
+    });
+
+    it('rejects missing transferDate via ValidationError', async () => {
+      const { transferDate: _omit, ...rest } = validQuery;
+      void _omit;
+      const req = buildRequest(rest);
+      await exportYuchoCsv(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+    });
+
+    it('rejects malformed transferDate', async () => {
+      const req = buildRequest({ ...validQuery, transferDate: '2026/04/27' });
+      await exportYuchoCsv(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+    });
+
+    it('uses "all" suffix in filename when month is omitted', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const { month: _m, ...rest } = validQuery;
+      void _m;
+      const req = buildRequest(rest);
+      await exportYuchoCsv(req as Request, res as Response, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        expect.stringContaining('yucho_2026all.csv')
+      );
+    });
+  });
+});

--- a/tests/yucho/yuchoCsv.test.ts
+++ b/tests/yucho/yuchoCsv.test.ts
@@ -1,0 +1,213 @@
+import {
+  buildHeaderRecord,
+  buildDataRecord,
+  buildTrailerRecord,
+  buildEndRecord,
+  buildZenginCsv,
+  __internal,
+} from '../../src/yucho/yuchoCsv';
+import type { YuchoBillingItem } from '../../src/validations/yuchoValidation';
+
+const RECORD_LENGTH = 120;
+
+const baseItem = (overrides: Partial<YuchoBillingItem> = {}): YuchoBillingItem => ({
+  category: 'management',
+  sourceId: 'fee-1',
+  contractPlotId: '11111111-2222-3333-4444-555555555555',
+  plotNumber: 'A-1',
+  areaName: '第1期',
+  contractDate: '2026-01-01',
+  customerId: 'cust-1',
+  customerName: '山田太郎',
+  customerNameKana: 'ヤマダタロウ',
+  billingAmount: 12000,
+  billingStatus: 'unpaid',
+  scheduledDate: '2026-04-30',
+  billingMonth: 4,
+  billingInfo: {
+    bankName: 'ゆうちょ銀行',
+    branchName: '〇一八',
+    accountType: 'ordinary',
+    accountNumber: '1234567',
+    accountHolder: 'ヤマダタロウ',
+  },
+  ...overrides,
+});
+
+describe('yuchoCsv internals', () => {
+  describe('toHalfWidthKana', () => {
+    it('converts full-width katakana to half-width', () => {
+      expect(__internal.toHalfWidthKana('ヤマダタロウ')).toBe('ﾔﾏﾀﾞﾀﾛｳ');
+    });
+    it('converts hiragana to half-width katakana', () => {
+      expect(__internal.toHalfWidthKana('やまだ')).toBe('ﾔﾏﾀﾞ');
+    });
+    it('converts full-width digits/letters to half-width', () => {
+      expect(__internal.toHalfWidthKana('ＡＢＣ１２３')).toBe('ABC123');
+    });
+    it('keeps ASCII unchanged', () => {
+      expect(__internal.toHalfWidthKana('ABC 123')).toBe('ABC 123');
+    });
+    it('returns empty string for empty input', () => {
+      expect(__internal.toHalfWidthKana('')).toBe('');
+    });
+  });
+
+  describe('padRight / padLeftZero', () => {
+    it('right-pads to width with spaces', () => {
+      expect(__internal.padRight('AB', 5)).toBe('AB   ');
+    });
+    it('truncates if too long', () => {
+      expect(__internal.padRight('ABCDEFG', 4)).toBe('ABCD');
+    });
+    it('zero-pads number to width', () => {
+      expect(__internal.padLeftZero(123, 6)).toBe('000123');
+    });
+    it('strips non-digits before padding', () => {
+      expect(__internal.padLeftZero('12,345', 6)).toBe('012345');
+    });
+    it('truncates to lower digits when too long', () => {
+      expect(__internal.padLeftZero(1234567890, 6)).toBe('567890');
+    });
+  });
+
+  describe('accountTypeCode', () => {
+    it.each([
+      ['ordinary', '1'],
+      ['current', '2'],
+      ['savings', '4'],
+      [null, '1'],
+      ['unknown', '1'],
+    ])('maps %s → %s', (input, expected) => {
+      expect(__internal.accountTypeCode(input as string | null)).toBe(expected);
+    });
+  });
+
+  describe('extractBankCode / extractBranchCode', () => {
+    it('returns 9900 for ゆうちょ銀行', () => {
+      expect(__internal.extractBankCode('ゆうちょ銀行')).toBe('9900');
+    });
+    it('returns 0000 for unknown banks', () => {
+      expect(__internal.extractBankCode('みずほ銀行')).toBe('0000');
+    });
+    it('extracts ASCII branch code', () => {
+      expect(__internal.extractBranchCode('018店')).toBe('018');
+    });
+    it('extracts kanji branch code', () => {
+      expect(__internal.extractBranchCode('〇一八')).toBe('018');
+    });
+    it('returns 000 when no digits found', () => {
+      expect(__internal.extractBranchCode('本店')).toBe('000');
+    });
+  });
+});
+
+describe('Zengin record builders', () => {
+  it('buildHeaderRecord is exactly 120 bytes and starts with "1"', () => {
+    const record = buildHeaderRecord({
+      clientCode: '1234567',
+      clientName: 'コミネレイエン',
+      transferDate: '2026-04-27',
+      bankCode: '9900',
+      branchCode: '018',
+      accountType: 'ordinary',
+      accountNumber: '1234567',
+    });
+    expect(record).toHaveLength(RECORD_LENGTH);
+    expect(record[0]).toBe('1');
+    // 種別コード = 91, コード区分 = 0
+    expect(record.slice(1, 4)).toBe('910');
+    // 委託者コードはゼロ埋め10桁
+    expect(record.slice(4, 14)).toBe('0001234567');
+    // 引落日 (MMDD)
+    expect(record.slice(54, 58)).toBe('0427');
+  });
+
+  it('buildDataRecord is exactly 120 bytes and starts with "2"', () => {
+    const record = buildDataRecord(baseItem());
+    expect(record).toHaveLength(RECORD_LENGTH);
+    expect(record[0]).toBe('2');
+    // 銀行コード(4) + 銀行名(15) + 支店コード(3)
+    expect(record.slice(1, 5)).toBe('9900');
+    expect(record.slice(20, 23)).toBe('018');
+  });
+
+  it('buildTrailerRecord starts with "8" and contains zero-padded count/amount', () => {
+    const record = buildTrailerRecord(3, 36000);
+    expect(record).toHaveLength(RECORD_LENGTH);
+    expect(record[0]).toBe('8');
+    expect(record.slice(1, 7)).toBe('000003');
+    expect(record.slice(7, 19)).toBe('000000036000');
+  });
+
+  it('buildEndRecord starts with "9" and is 120 bytes', () => {
+    const record = buildEndRecord();
+    expect(record).toHaveLength(RECORD_LENGTH);
+    expect(record[0]).toBe('9');
+  });
+});
+
+describe('buildZenginCsv', () => {
+  const header = {
+    clientCode: '1234567',
+    clientName: 'コミネレイエン',
+    transferDate: '2026-04-27',
+    bankCode: '9900',
+    branchCode: '018',
+  };
+
+  it('terminates each record with CRLF', () => {
+    const items = [baseItem()];
+    const csv = buildZenginCsv({ header, items });
+    expect(csv.endsWith('\r\n')).toBe(true);
+    const segments = csv.split('\r\n');
+    // 4 records (header, data, trailer, end) + trailing empty from final CRLF
+    expect(segments).toHaveLength(5);
+    expect(segments[segments.length - 1]).toBe('');
+  });
+
+  it('produces 5 lines for 2 items (header + 2 data + trailer + end)', () => {
+    const items = [baseItem(), baseItem({ sourceId: 'fee-2', billingAmount: 8000 })];
+    const csv = buildZenginCsv({ header, items });
+    const lines = csv.split('\r\n').filter((l) => l.length > 0);
+    expect(lines.length).toBe(5);
+    expect(lines[0]?.[0]).toBe('1');
+    expect(lines[1]?.[0]).toBe('2');
+    expect(lines[2]?.[0]).toBe('2');
+    expect(lines[3]?.[0]).toBe('8');
+    expect(lines[4]?.[0]).toBe('9');
+  });
+
+  it('skips items with no billingInfo', () => {
+    const items = [baseItem(), baseItem({ sourceId: 'fee-2', billingInfo: null })];
+    const csv = buildZenginCsv({ header, items });
+    const dataLines = csv.split('\r\n').filter((l) => l.startsWith('2'));
+    expect(dataLines.length).toBe(1);
+  });
+
+  it('skips items with zero amount', () => {
+    const items = [baseItem(), baseItem({ sourceId: 'fee-2', billingAmount: 0 })];
+    const csv = buildZenginCsv({ header, items });
+    const dataLines = csv.split('\r\n').filter((l) => l.startsWith('2'));
+    expect(dataLines.length).toBe(1);
+  });
+
+  it('trailer total amount equals sum of billable items', () => {
+    const items = [
+      baseItem({ billingAmount: 12000 }),
+      baseItem({ sourceId: 'fee-2', billingAmount: 8000 }),
+      baseItem({ sourceId: 'fee-3', billingAmount: 5000 }),
+    ];
+    const csv = buildZenginCsv({ header, items });
+    const trailer = csv.split('\r\n').find((l) => l.startsWith('8'));
+    expect(trailer?.slice(1, 7)).toBe('000003');
+    expect(trailer?.slice(7, 19)).toBe('000000025000');
+  });
+
+  it('outputs only header + trailer + end when no items provided', () => {
+    const csv = buildZenginCsv({ header, items: [] });
+    const lines = csv.split('\r\n').filter((l) => l.length > 0);
+    expect(lines.length).toBe(3); // header + trailer + end
+    expect(lines[1]?.slice(1, 7)).toBe('000000'); // count = 0
+  });
+});

--- a/tests/yucho/yuchoRoutes.test.ts
+++ b/tests/yucho/yuchoRoutes.test.ts
@@ -1,0 +1,65 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+
+jest.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = {
+      id: 1,
+      email: 'test@example.com',
+      name: 'テストユーザー',
+      role: 'admin',
+      is_active: true,
+      supabase_uid: 'test-uid',
+    };
+    next();
+  },
+}));
+
+jest.mock('../../src/middleware/permission', () => ({
+  ROLES: { VIEWER: 'viewer', OPERATOR: 'operator', MANAGER: 'manager', ADMIN: 'admin' },
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../src/yucho/yuchoController', () => ({
+  getYuchoBilling: jest.fn((_req, res) =>
+    res.status(200).json({ success: true, data: { items: [] } })
+  ),
+  exportYuchoCsv: jest.fn((_req, res) => {
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Disposition', 'attachment; filename="test.csv"');
+    return res.status(200).send('1\r\n8\r\n9\r\n');
+  }),
+}));
+
+import yuchoRoutes from '../../src/yucho/yuchoRoutes';
+import { getYuchoBilling, exportYuchoCsv } from '../../src/yucho/yuchoController';
+
+describe('Yucho Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/yucho', yuchoRoutes);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/v1/yucho/billing → 200 and calls controller', async () => {
+    const res = await request(app).get('/api/v1/yucho/billing?year=2026&month=4');
+    expect(res.status).toBe(200);
+    expect(getYuchoBilling).toHaveBeenCalled();
+    expect(res.body.success).toBe(true);
+  });
+
+  it('GET /api/v1/yucho/export → 200 with CSV content type', async () => {
+    const res = await request(app).get(
+      '/api/v1/yucho/export?year=2026&month=4&transferDate=2026-04-27&clientCode=1234567&clientName=KOMINE'
+    );
+    expect(res.status).toBe(200);
+    expect(exportYuchoCsv).toHaveBeenCalled();
+    expect(res.headers['content-type']).toContain('text/csv');
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/v1/yucho/billing` — 管理料(ManagementFee) + 合祀料金(CollectiveBurial) の請求対象データを指定年月で集約し、支払者(contractor優先)の口座情報を付与して返却。
- `GET /api/v1/yucho/export` — 全銀協フォーマット(120バイト固定長、ヘッダー/データ/トレーラー/エンド) の CSV を生成・ダウンロード。半角カナ変換・ゆうちょ支店コード推定を同梱。
- Zodバリデーション、ユニット/ルートテスト (新規 42件、総計 756件全てパス)、Swagger docs を `Yucho` タグで追加。

## 設計メモ（お客さん確認事項に対応）
- **口座情報の保存先**: 既存の `Customer.BillingInfo` を活用(bank_name/branch_name/account_type/account_number/account_holder)。追加スキーマ変更なし。ゆうちょ記号・番号を BillingInfo にどうマッピングするかは運用確認後に調整可能。
- **CSV形式**: 一旦 全銀協フォーマット(Zengin) を実装(format=zengin)。ゆうちょ標準形式への差し替え/拡張は `format` enum の追加で対応予定。
- **委託者コード / 引落日 / 委託者名**: リクエストパラメータで都度指定する方式。将来的にマスタ化も可。
- **請求履歴トラッキング**: `ContractPlot.payment_status` / `CollectiveBurial.billing_status` をそのまま利用。CSV出力済みフラグの専用カラムは未追加(要件明確化後にスキーマ追加検討)。

## Test plan
- [x] `npx jest tests/yucho/` — 42 tests passing
- [x] `npx jest` — 756 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npm run swagger:validate` — OpenAPI spec valid
- [ ] ステージング環境で実データを使った動作確認
- [ ] 出力CSVをゆうちょBizダイレクトへアップロードして受理確認(お客さん側)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)