### PR TITLE
fix(docker): Render デプロイ失敗修正 — @komine/types SHA 固定 & install-links 恒久化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ RUN apk add --no-cache git
 
 WORKDIR /packages/types
 
-# TYPES_REF: ビルドする @komine/types の git ref (commit SHA / tag / branch)
-# Docker layer cache対策: このARGを変更することで types 再取得を強制できる。
-# Render側で Build Arg として最新 SHA を渡すか、Dockerfile を更新すること。
+# TYPES_REF: ビルドする @komine/types の git ref (commit SHA 固定)
+# セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
+# types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=main
+ARG TYPES_REF=982404c67ecb6270fd2e3cfcba662da430ddfc93
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \
@@ -29,6 +29,12 @@ RUN apk add --no-cache git
 # 作業ディレクトリの設定
 WORKDIR /app
 
+# npm_config_install_links: file:依存（@komine/types）を常に実体コピーで解決する。
+# フラグ指定だと後続の `npm install` が symlink に戻してしまうため、
+# 環境変数で全 npm 実行に適用して一貫性を確保する。
+# 詳細: zaitsu82/komine-crm-backend#60
+ENV npm_config_install_links=true
+
 # @komine/types パッケージを配置（file:../packages/types の解決用）
 COPY --from=types /packages/types /packages/types
 
@@ -40,10 +46,8 @@ COPY prisma.config.ts ./
 # 本番用依存関係のみインストール
 # Prisma v7: クライアントエンジンはJSベース（ネイティブバイナリ不要）
 # --ignore-scriptsでprepareスクリプト(husky)をスキップ（本番環境では不要）
-# --install-links: file:依存（@komine/types）をsymlinkでなく実体コピーでインストール
-#   → production ステージで /packages/types を持たなくても解決できる
 # --no-save prisma: preDeployCommand (prisma migrate deploy) 実行用にCLIを含める
-RUN npm ci --omit=dev --ignore-scripts --install-links && \
+RUN npm ci --omit=dev --ignore-scripts && \
     npm install --no-save prisma && \
     npx prisma generate && \
     npm cache clean --force
@@ -58,15 +62,17 @@ RUN apk add --no-cache git
 
 WORKDIR /app
 
+# file:依存（@komine/types）を常に実体コピーで解決（deps ステージと同じ）
+ENV npm_config_install_links=true
+
 # @komine/types パッケージを配置（file:../packages/types の解決用）
 COPY --from=types /packages/types /packages/types
 
 # 依存関係のインストール（devDependenciesを含む）
-# --install-links: file:依存（@komine/types）をsymlinkでなく実体コピーでインストール
 COPY package*.json ./
 COPY prisma ./prisma/
 COPY prisma.config.ts ./
-RUN npm ci --install-links && \
+RUN npm ci && \
     npx prisma generate
 
 # ソースコードをコピー


### PR DESCRIPTION
## 背景

Render のデプロイが以下エラーで失敗していた:

```
Error: Cannot find module '@komine/types'
Require stack:
- /app/dist/middleware/validation.js
- /app/dist/auth/authRoutes.js
- /app/dist/index.js
```

## 原因

### 1. `npm install` の install-links 非継承

deps ステージで:
```dockerfile
RUN npm ci --omit=dev --ignore-scripts --install-links && \
    npm install --no-save prisma && \   # ← ここに --install-links なし
    ...
```

- 1行目は `--install-links` 付きで `@komine/types` を実体コピーとして展開
- 2行目の `npm install --no-save prisma` は `--install-links` **なし**
- npm は package-lock を再解決し、**file: 依存を symlink に戻す**（`/packages/types` 向け）
- production ステージでは `/packages/types` をコピーしていないため symlink がリンク切れ → 起動時に Module not found

### 2. TYPES_REF=main のサプライチェーンリスク

```dockerfile
ARG TYPES_REF=main
```

- komine-types リポジトリの main ブランチが汚染されると次回デプロイで**即本番到達**
- 最近の npm エコシステムでは maintainer アカウント乗っ取り・worm 型攻撃（Shai-Hulud 等）が頻発
- 内部ツールでも commit SHA 固定で出所の明示が基本

## 修正

### Dockerfile

- deps / builder 両ステージに `ENV npm_config_install_links=true` を追加
  - フラグでなく環境変数にすることで、**後続の `npm install` が何度呼ばれても一貫して実体コピーで解決**
  - 将来別の npm install 行が追加されても同じバグを踏まない
- 個別の `--install-links` フラグを削除（ENV で代替）
- `TYPES_REF` を `main` → `982404c67ecb6270fd2e3cfcba662da430ddfc93` に固定
  - 現在の komine-types main HEAD（2026-04-16、PR #7 マージ時点）
  - types を更新するときは Dockerfile を明示的に書き換える運用に変更

## 動作確認

- [ ] CI の Docker Security Scan が通ること（Dockerfile ビルド検証を兼ねる）
- [ ] main マージ後、Render デプロイが成功すること
- [ ] `/health` が 200 を返すこと
- [ ] `/api/v1/yucho/billing` が 200 を返すこと（@komine/types の実体解決確認）

## セキュリティ上の改善

| 攻撃ベクトル | Before | After |
|---|---|---|
| komine-types main への悪意ある push | 次回デプロイで即本番到達 | Dockerfile 更新 PR が必須 |
| Docker layer cache での stale types | 手動 ARG 書き換え必要 | SHA 変更で自動再取得 |
| npm install の symlink 回帰 | フラグ漏れで再発可能 | ENV で全コマンド適用 |

Closes #60