### PR TITLE
feat(plots): chunked tx and partial-success response for bulk ops (#76 Phase 1)

### DIFF
--- a/src/plots/controllers/bulkCreatePlots.ts
+++ b/src/plots/controllers/bulkCreatePlots.ts
@@ -4,7 +4,12 @@
  *
  * 複数の区画を一件登録（createPlot）と同等のフィールド構成で一括登録します。
  * familyContacts, buriedPersons, constructionInfos も合わせて作成可能。
- * トランザクションによる all-or-nothing 処理。
+ *
+ * Phase 1 対応 (issue #76):
+ * - 全件 1 トランザクション → 1 件ごとの独立トランザクション
+ *   （1 行の失敗が他行に波及しない）
+ * - familyContacts / buriedPersons / constructionInfos は createManyAndReturn で一括 INSERT
+ * - 部分成功レスポンス { totalRequested, succeeded, failed[], results[] }
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -25,7 +30,6 @@ import { recordEntityCreated } from '../services/historyService';
 
 /**
  * 一括登録用の単一アイテムバリデーションスキーマ
- * createPlotSchema に familyContacts / buriedPersons / constructionInfos / gravestoneInfo を追加
  */
 const bulkCreateItemSchema = createPlotSchema.extend({
   familyContacts: z.array(familyContactSchema).optional(),
@@ -42,6 +46,169 @@ const bulkCreateRequestSchema = z.object({
 });
 
 export type BulkCreateItem = z.infer<typeof bulkCreateItemSchema>;
+
+type BulkFailure = {
+  row: number;
+  plotNumber?: string | null;
+  error: {
+    message: string;
+    details?: Array<{ field?: string; message: string }>;
+  };
+};
+
+type BulkSuccess = {
+  row: number;
+  id: string;
+  physicalPlotId: string;
+  plotNumber: string | null;
+};
+
+/**
+ * 1件分の登録処理（独立トランザクション）
+ */
+async function createSingleItem(
+  item: BulkCreateItem,
+  req: Request
+): Promise<{ id: string; physicalPlotId: string; plotNumber: string | null }> {
+  return prisma.$transaction(
+    async (tx) => {
+      const { contractPlotId, physicalPlotId } = await createPlotCore(
+        tx,
+        item as CreatePlotRequest,
+        req
+      );
+
+      // family contacts — createManyAndReturn で一括 INSERT → 個別に履歴記録
+      if (item.familyContacts && item.familyContacts.length > 0) {
+        const fcData = item.familyContacts
+          .filter((fc) => fc.name && fc.phoneNumber && fc.address && fc.relationship)
+          .map((fc) => ({
+            contract_plot_id: contractPlotId,
+            name: fc.name as string,
+            name_kana: fc.nameKana || null,
+            relationship: fc.relationship as string,
+            address: fc.address as string,
+            phone_number: fc.phoneNumber as string,
+            phone_number_2: fc.phoneNumber2 || null,
+            fax_number: fc.faxNumber || null,
+            email: fc.email || null,
+            registered_address: fc.registeredAddress || null,
+            mailing_type: (fc.mailingType as AddressType) || null,
+            work_company_name: fc.workCompanyName || null,
+            work_company_name_kana: fc.workCompanyNameKana || null,
+            work_address: fc.workAddress || null,
+            work_phone_number: fc.workPhoneNumber || null,
+            contact_method: fc.contactMethod || null,
+            notes: fc.notes || null,
+          }));
+
+        if (fcData.length > 0) {
+          const created = await tx.familyContact.createManyAndReturn({ data: fcData });
+          for (const row of created) {
+            await recordEntityCreated(tx, {
+              entityType: 'FamilyContact',
+              entityId: row.id,
+              physicalPlotId,
+              contractPlotId,
+              afterRecord: { id: row.id, name: row.name },
+              req,
+            });
+          }
+        }
+      }
+
+      // buried persons
+      if (item.buriedPersons && item.buriedPersons.length > 0) {
+        const bpData = item.buriedPersons
+          .filter((bp) => bp.name)
+          .map((bp) => ({
+            contract_plot_id: contractPlotId,
+            name: bp.name as string,
+            name_kana: bp.nameKana || null,
+            relationship: bp.relationship || null,
+            birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
+            death_date: bp.deathDate ? new Date(bp.deathDate) : null,
+            age: bp.age ?? null,
+            gender: bp.gender === 'male' || bp.gender === 'female' ? (bp.gender as Gender) : null,
+            burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
+            posthumous_name: bp.posthumousName || null,
+            report_date: bp.reportDate ? new Date(bp.reportDate) : null,
+            religion: bp.religion || null,
+            notes: bp.notes || null,
+          }));
+
+        if (bpData.length > 0) {
+          const created = await tx.buriedPerson.createManyAndReturn({ data: bpData });
+          for (const row of created) {
+            await recordEntityCreated(tx, {
+              entityType: 'BuriedPerson',
+              entityId: row.id,
+              physicalPlotId,
+              contractPlotId,
+              afterRecord: { id: row.id, name: row.name },
+              req,
+            });
+          }
+        }
+      }
+
+      // construction infos
+      if (item.constructionInfos && item.constructionInfos.length > 0) {
+        const ciData = item.constructionInfos.map((ci) => ({
+          contract_plot_id: contractPlotId,
+          construction_type: ci.constructionType || null,
+          start_date: ci.startDate ? new Date(ci.startDate) : null,
+          completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
+          contractor: ci.contractor || null,
+          supervisor: ci.supervisor || null,
+          progress: ci.progress || null,
+          work_item_1: ci.workItem1 || null,
+          work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
+          work_amount_1: ci.workAmount1 ?? null,
+          work_status_1: ci.workStatus1 || null,
+          work_item_2: ci.workItem2 || null,
+          work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
+          work_amount_2: ci.workAmount2 ?? null,
+          work_status_2: ci.workStatus2 || null,
+          permit_number: ci.permitNumber || null,
+          application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
+          permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
+          permit_status: ci.permitStatus || null,
+          payment_type_1: ci.paymentType1 || null,
+          payment_amount_1: ci.paymentAmount1 ?? null,
+          payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
+          payment_status_1: ci.paymentStatus1 || null,
+          payment_type_2: ci.paymentType2 || null,
+          payment_amount_2: ci.paymentAmount2 ?? null,
+          payment_date_2: ci.paymentScheduledDate2 ? new Date(ci.paymentScheduledDate2) : null,
+          payment_status_2: ci.paymentStatus2 || null,
+          scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
+          construction_content: ci.constructionContent || null,
+          notes: ci.notes || null,
+        }));
+
+        const created = await tx.constructionInfo.createManyAndReturn({ data: ciData });
+        for (const row of created) {
+          await recordEntityCreated(tx, {
+            entityType: 'ConstructionInfo',
+            entityId: row.id,
+            physicalPlotId,
+            contractPlotId,
+            afterRecord: { id: row.id, construction_type: row.construction_type },
+            req,
+          });
+        }
+      }
+
+      return {
+        id: contractPlotId,
+        physicalPlotId,
+        plotNumber: item.physicalPlot.plotNumber || null,
+      };
+    },
+    { maxWait: 10000, timeout: 30000 }
+  );
+}
 
 /**
  * 区画一括登録
@@ -71,223 +238,112 @@ export const bulkCreatePlots = async (
 
     const { items } = parseResult.data;
 
-    // 2. バッチ内の plotNumber 重複チェック（新規物理区画のみ）
-    const plotNumbers = items
-      .filter((item) => !item.physicalPlot.id && item.physicalPlot.plotNumber)
-      .map((item) => item.physicalPlot.plotNumber as string);
+    // 事前に「処理対象外」とする行（部分失敗として failed に入れる）
+    const preFailures: BulkFailure[] = [];
+    const skipRows = new Set<number>();
 
-    const duplicatesInBatch = plotNumbers.filter(
-      (num, index) => plotNumbers.indexOf(num) !== index
-    );
-
-    if (duplicatesInBatch.length > 0) {
-      const uniqueDuplicates = [...new Set(duplicatesInBatch)];
-      const details = uniqueDuplicates.map((plotNumber) => {
-        const rows = items
-          .map((item, index) => (item.physicalPlot.plotNumber === plotNumber ? index : -1))
-          .filter((index) => index !== -1);
-        return {
-          row: rows[1],
-          field: 'plotNumber',
-          message: `区画番号「${plotNumber}」がバッチ内で重複しています（行 ${rows.join(', ')}）`,
-        };
-      });
-
-      throw new ValidationError('一括登録でエラーが発生しました', details);
+    // 2. バッチ内の plotNumber 重複 — 後続出現を failed に
+    const seenPlotNumbers = new Map<string, number>(); // plotNumber → first-seen-row
+    for (let i = 0; i < items.length; i++) {
+      const pn = items[i]!.physicalPlot.plotNumber;
+      if (!pn) continue;
+      if (seenPlotNumbers.has(pn)) {
+        preFailures.push({
+          row: i,
+          plotNumber: pn,
+          error: {
+            message: `区画番号「${pn}」がバッチ内で重複しています（行 ${seenPlotNumbers.get(pn)} と同じ）`,
+            details: [{ field: 'plotNumber', message: `行 ${seenPlotNumbers.get(pn)} と重複` }],
+          },
+        });
+        skipRows.add(i);
+      } else {
+        seenPlotNumbers.set(pn, i);
+      }
     }
 
-    // 3. DB上の既存区画番号との重複チェック
-    if (plotNumbers.length > 0) {
+    // 3. DB 上の既存区画番号との重複 — 該当行を failed に
+    //    新規物理区画（physicalPlot.id 未指定）のみ対象
+    const newPlotNumbers = items
+      .map((item, idx) => ({
+        idx,
+        pn: item.physicalPlot.plotNumber,
+        hasId: !!item.physicalPlot.id,
+      }))
+      .filter((x) => x.pn && !x.hasId && !skipRows.has(x.idx));
+
+    if (newPlotNumbers.length > 0) {
       const existingPlots = await prisma.physicalPlot.findMany({
         where: {
-          plot_number: { in: plotNumbers },
+          plot_number: { in: newPlotNumbers.map((x) => x.pn as string) },
           deleted_at: null,
         },
         select: { plot_number: true },
       });
 
-      if (existingPlots.length > 0) {
-        const existingNumbers = existingPlots.map((p) => p.plot_number);
-        const details = existingNumbers.map((plotNumber) => {
-          const row = items.findIndex((item) => item.physicalPlot.plotNumber === plotNumber);
-          return {
-            row,
-            field: 'plotNumber',
-            message: `区画番号「${plotNumber}」は既にデータベースに存在します`,
-          };
-        });
-
-        throw new ValidationError('一括登録でエラーが発生しました', details);
+      const existingSet = new Set(existingPlots.map((p) => p.plot_number));
+      for (const { idx, pn } of newPlotNumbers) {
+        if (pn && existingSet.has(pn)) {
+          preFailures.push({
+            row: idx,
+            plotNumber: pn,
+            error: {
+              message: `区画番号「${pn}」は既にデータベースに存在します`,
+              details: [{ field: 'plotNumber', message: '既存区画と重複' }],
+            },
+          });
+          skipRows.add(idx);
+        }
       }
     }
 
-    // 4. トランザクションで一括作成
-    const createdPlots = await prisma.$transaction(
-      async (tx) => {
-        const results = [];
+    // 4. 1件ずつ独立 tx で処理（失敗が他行に波及しない）
+    const successes: BulkSuccess[] = [];
+    const failures: BulkFailure[] = [...preFailures];
 
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i]!;
+    for (let i = 0; i < items.length; i++) {
+      if (skipRows.has(i)) continue;
 
-          try {
-            const { contractPlotId, physicalPlotId } = await createPlotCore(
-              tx,
-              item as CreatePlotRequest,
-              req
-            );
-
-            // 4.1 family contacts（ContractPlot紐付け）
-            if (item.familyContacts && item.familyContacts.length > 0) {
-              for (const fc of item.familyContacts) {
-                // 必須フィールドが揃っていない行はスキップ（DB NOT NULL 制約回避）
-                if (!fc.name || !fc.phoneNumber || !fc.address || !fc.relationship) continue;
-                const created = await tx.familyContact.create({
-                  data: {
-                    contract_plot_id: contractPlotId,
-                    name: fc.name,
-                    name_kana: fc.nameKana || null,
-                    relationship: fc.relationship,
-                    address: fc.address,
-                    phone_number: fc.phoneNumber,
-                    phone_number_2: fc.phoneNumber2 || null,
-                    fax_number: fc.faxNumber || null,
-                    email: fc.email || null,
-                    registered_address: fc.registeredAddress || null,
-                    mailing_type: (fc.mailingType as AddressType) || null,
-                    work_company_name: fc.workCompanyName || null,
-                    work_company_name_kana: fc.workCompanyNameKana || null,
-                    work_address: fc.workAddress || null,
-                    work_phone_number: fc.workPhoneNumber || null,
-                    contact_method: fc.contactMethod || null,
-                    notes: fc.notes || null,
-                  },
-                });
-                await recordEntityCreated(tx, {
-                  entityType: 'FamilyContact',
-                  entityId: created.id,
-                  physicalPlotId,
-                  contractPlotId,
-                  afterRecord: { id: created.id, name: created.name },
-                  req,
-                });
-              }
-            }
-
-            // 4.2 buried persons（ContractPlot紐付け）
-            if (item.buriedPersons && item.buriedPersons.length > 0) {
-              for (const bp of item.buriedPersons) {
-                if (!bp.name) continue;
-                const created = await tx.buriedPerson.create({
-                  data: {
-                    contract_plot_id: contractPlotId,
-                    name: bp.name,
-                    name_kana: bp.nameKana || null,
-                    relationship: bp.relationship || null,
-                    birth_date: bp.birthDate ? new Date(bp.birthDate) : null,
-                    death_date: bp.deathDate ? new Date(bp.deathDate) : null,
-                    age: bp.age ?? null,
-                    gender:
-                      bp.gender === 'male' || bp.gender === 'female' ? (bp.gender as Gender) : null,
-                    burial_date: bp.burialDate ? new Date(bp.burialDate) : null,
-                    posthumous_name: bp.posthumousName || null,
-                    report_date: bp.reportDate ? new Date(bp.reportDate) : null,
-                    religion: bp.religion || null,
-                    notes: bp.notes || null,
-                  },
-                });
-                await recordEntityCreated(tx, {
-                  entityType: 'BuriedPerson',
-                  entityId: created.id,
-                  physicalPlotId,
-                  contractPlotId,
-                  afterRecord: { id: created.id, name: created.name },
-                  req,
-                });
-              }
-            }
-
-            // 4.3 construction infos（ContractPlot紐付け）
-            if (item.constructionInfos && item.constructionInfos.length > 0) {
-              for (const ci of item.constructionInfos) {
-                const created = await tx.constructionInfo.create({
-                  data: {
-                    contract_plot_id: contractPlotId,
-                    construction_type: ci.constructionType || null,
-                    start_date: ci.startDate ? new Date(ci.startDate) : null,
-                    completion_date: ci.completionDate ? new Date(ci.completionDate) : null,
-                    contractor: ci.contractor || null,
-                    supervisor: ci.supervisor || null,
-                    progress: ci.progress || null,
-                    work_item_1: ci.workItem1 || null,
-                    work_date_1: ci.workDate1 ? new Date(ci.workDate1) : null,
-                    work_amount_1: ci.workAmount1 ?? null,
-                    work_status_1: ci.workStatus1 || null,
-                    work_item_2: ci.workItem2 || null,
-                    work_date_2: ci.workDate2 ? new Date(ci.workDate2) : null,
-                    work_amount_2: ci.workAmount2 ?? null,
-                    work_status_2: ci.workStatus2 || null,
-                    permit_number: ci.permitNumber || null,
-                    application_date: ci.applicationDate ? new Date(ci.applicationDate) : null,
-                    permit_date: ci.permitDate ? new Date(ci.permitDate) : null,
-                    permit_status: ci.permitStatus || null,
-                    payment_type_1: ci.paymentType1 || null,
-                    payment_amount_1: ci.paymentAmount1 ?? null,
-                    payment_date_1: ci.paymentDate1 ? new Date(ci.paymentDate1) : null,
-                    payment_status_1: ci.paymentStatus1 || null,
-                    payment_type_2: ci.paymentType2 || null,
-                    payment_amount_2: ci.paymentAmount2 ?? null,
-                    payment_date_2: ci.paymentScheduledDate2
-                      ? new Date(ci.paymentScheduledDate2)
-                      : null,
-                    payment_status_2: ci.paymentStatus2 || null,
-                    scheduled_end_date: ci.scheduledEndDate ? new Date(ci.scheduledEndDate) : null,
-                    construction_content: ci.constructionContent || null,
-                    notes: ci.notes || null,
-                  },
-                });
-                await recordEntityCreated(tx, {
-                  entityType: 'ConstructionInfo',
-                  entityId: created.id,
-                  physicalPlotId,
-                  contractPlotId,
-                  afterRecord: { id: created.id, construction_type: created.construction_type },
-                  req,
-                });
-              }
-            }
-
-            results.push({
-              row: i,
-              id: contractPlotId,
-              physicalPlotId,
-              plotNumber: item.physicalPlot.plotNumber || null,
-            });
-          } catch (error) {
-            // エラー詳細に行番号を付与して再スロー
-            if (error instanceof ValidationError) {
-              const details = error.details?.length
-                ? error.details.map((d) => ({ ...d, row: i }))
-                : [{ row: i, message: error.message }];
-              throw new ValidationError(`行 ${i} でエラー: ${error.message}`, details);
-            }
-            throw error;
-          }
+      const item = items[i]!;
+      try {
+        const result = await createSingleItem(item, req);
+        successes.push({ row: i, ...result });
+      } catch (error) {
+        const plotNumber = item.physicalPlot.plotNumber || null;
+        if (error instanceof ValidationError) {
+          failures.push({
+            row: i,
+            plotNumber,
+            error: {
+              message: error.message,
+              details: error.details as Array<{ field?: string; message: string }> | undefined,
+            },
+          });
+        } else if (error instanceof Error) {
+          failures.push({
+            row: i,
+            plotNumber,
+            error: { message: error.message },
+          });
+        } else {
+          failures.push({
+            row: i,
+            plotNumber,
+            error: { message: '不明なエラーが発生しました' },
+          });
         }
-
-        return results;
-      },
-      {
-        maxWait: 10000,
-        timeout: 60000,
       }
-    );
+    }
 
+    // 5. レスポンス（部分成功許容）
+    // 全件失敗時も 201 ではなく 207 相当にしたいところだが、Phase 1 では 201 固定
     res.status(201).json({
       success: true,
       data: {
         totalRequested: items.length,
-        created: createdPlots.length,
-        results: createdPlots,
+        succeeded: successes.length,
+        failed: failures,
+        results: successes,
       },
     });
   } catch (error) {

--- a/src/plots/controllers/bulkUpdatePlots.ts
+++ b/src/plots/controllers/bulkUpdatePlots.ts
@@ -4,7 +4,12 @@
  *
  * 既存の ContractPlot を plotNumber でマッチングして一括更新します。
  * 未指定フィールド = 変更しない、null 明示 = クリア（updatePlotCore 仕様）。
- * トランザクションによる all-or-nothing 処理。
+ *
+ * Phase 1 対応 (issue #76):
+ * - 全件 1 トランザクション → 1 件ごとの独立トランザクション
+ * - 存在しない plotNumber / 契約なしは「リクエスト全体エラー」から
+ *   「該当行のみ failed」に変更
+ * - 部分成功レスポンス { totalRequested, succeeded, failed[], results[] }
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -35,6 +40,40 @@ const bulkUpdateRequestSchema = z.object({
 
 export type BulkUpdateItem = z.infer<typeof bulkUpdateItemSchema>;
 
+type BulkFailure = {
+  row: number;
+  plotNumber?: string | null;
+  error: {
+    message: string;
+    details?: Array<{ field?: string; message: string }>;
+  };
+};
+
+type BulkSuccess = {
+  row: number;
+  id: string;
+  plotNumber: string;
+};
+
+/**
+ * 1件分の更新処理（独立トランザクション）
+ */
+async function updateSingleItem(
+  item: BulkUpdateItem,
+  contractPlotId: string,
+  req: Request
+): Promise<void> {
+  const { plotNumber, ...updateInput } = item;
+  void plotNumber;
+
+  await prisma.$transaction(
+    async (tx) => {
+      await updatePlotCore(tx, contractPlotId, updateInput as UpdatePlotRequest, req);
+    },
+    { maxWait: 10000, timeout: 30000 }
+  );
+}
+
 /**
  * 区画一括編集
  * PUT /api/v1/plots/bulk
@@ -63,30 +102,30 @@ export const bulkUpdatePlots = async (
 
     const { items } = parseResult.data;
 
-    // 2. バッチ内の plotNumber 重複チェック
-    const plotNumbers = items.map((item) => item.plotNumber);
-    const duplicatesInBatch = plotNumbers.filter(
-      (num, index) => plotNumbers.indexOf(num) !== index
-    );
+    const failures: BulkFailure[] = [];
+    const skipRows = new Set<number>();
 
-    if (duplicatesInBatch.length > 0) {
-      const uniqueDuplicates = [...new Set(duplicatesInBatch)];
-      const details = uniqueDuplicates.map((plotNumber) => {
-        const rows = items
-          .map((item, index) => (item.plotNumber === plotNumber ? index : -1))
-          .filter((index) => index !== -1);
-        return {
-          row: rows[1],
-          field: 'plotNumber',
-          message: `区画番号「${plotNumber}」がバッチ内で重複しています（行 ${rows.join(', ')}）`,
-        };
-      });
-
-      throw new ValidationError('一括編集でエラーが発生しました', details);
+    // 2. バッチ内の plotNumber 重複 — 後続出現は failed に
+    const seenPlotNumbers = new Map<string, number>();
+    for (let i = 0; i < items.length; i++) {
+      const pn = items[i]!.plotNumber;
+      if (seenPlotNumbers.has(pn)) {
+        failures.push({
+          row: i,
+          plotNumber: pn,
+          error: {
+            message: `区画番号「${pn}」がバッチ内で重複しています（行 ${seenPlotNumbers.get(pn)} と同じ）`,
+            details: [{ field: 'plotNumber', message: `行 ${seenPlotNumbers.get(pn)} と重複` }],
+          },
+        });
+        skipRows.add(i);
+      } else {
+        seenPlotNumbers.set(pn, i);
+      }
     }
 
     // 3. DB 上で plotNumber → 最新 ContractPlot.id をマッピング
-    //   1つの PhysicalPlot に複数契約がある場合は最新（created_at DESC）を選択
+    const plotNumbers = Array.from(seenPlotNumbers.keys());
     const existingPlots = await prisma.physicalPlot.findMany({
       where: {
         plot_number: { in: plotNumbers },
@@ -103,87 +142,89 @@ export const bulkUpdatePlots = async (
     });
 
     const plotNumberToContractId = new Map<string, string>();
-    const plotNumbersWithoutContract: string[] = [];
+    const plotNumbersWithoutContract = new Set<string>();
     for (const pp of existingPlots) {
       const contract = pp.contractPlots[0];
       if (contract) {
         plotNumberToContractId.set(pp.plot_number, contract.id);
       } else {
-        plotNumbersWithoutContract.push(pp.plot_number);
+        plotNumbersWithoutContract.add(pp.plot_number);
       }
     }
 
-    const missingPlotNumbers = plotNumbers.filter(
-      (num) => !plotNumberToContractId.has(num) && !plotNumbersWithoutContract.includes(num)
-    );
+    // 該当する ContractPlot が引けない行を failed に
+    for (let i = 0; i < items.length; i++) {
+      if (skipRows.has(i)) continue;
+      const pn = items[i]!.plotNumber;
+      if (plotNumberToContractId.has(pn)) continue;
 
-    if (missingPlotNumbers.length > 0 || plotNumbersWithoutContract.length > 0) {
-      const details: Array<{ row?: number; field: string; message: string }> = [];
-      for (const num of missingPlotNumbers) {
-        const row = items.findIndex((item) => item.plotNumber === num);
-        details.push({
-          row,
-          field: 'plotNumber',
-          message: `区画番号「${num}」はデータベースに存在しません`,
+      if (plotNumbersWithoutContract.has(pn)) {
+        failures.push({
+          row: i,
+          plotNumber: pn,
+          error: {
+            message: `区画番号「${pn}」に有効な契約区画が存在しません`,
+            details: [{ field: 'plotNumber', message: '契約区画なし' }],
+          },
+        });
+      } else {
+        failures.push({
+          row: i,
+          plotNumber: pn,
+          error: {
+            message: `区画番号「${pn}」はデータベースに存在しません`,
+            details: [{ field: 'plotNumber', message: '区画が見つかりません' }],
+          },
         });
       }
-      for (const num of plotNumbersWithoutContract) {
-        const row = items.findIndex((item) => item.plotNumber === num);
-        details.push({
-          row,
-          field: 'plotNumber',
-          message: `区画番号「${num}」に有効な契約区画が存在しません`,
-        });
-      }
-      throw new ValidationError('一括編集でエラーが発生しました', details);
+      skipRows.add(i);
     }
 
-    // 4. トランザクションで一括更新
-    const updatedPlots = await prisma.$transaction(
-      async (tx) => {
-        const results: Array<{ row: number; id: string; plotNumber: string }> = [];
+    // 4. 1件ずつ独立 tx で処理
+    const successes: BulkSuccess[] = [];
 
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i]!;
-          const contractPlotId = plotNumberToContractId.get(item.plotNumber)!;
+    for (let i = 0; i < items.length; i++) {
+      if (skipRows.has(i)) continue;
 
-          // plotNumber を分離して updatePlotSchema 準拠の input にする
-          const { plotNumber, ...updateInput } = item;
-          void plotNumber;
+      const item = items[i]!;
+      const contractPlotId = plotNumberToContractId.get(item.plotNumber)!;
 
-          try {
-            await updatePlotCore(tx, contractPlotId, updateInput as UpdatePlotRequest, req);
-
-            results.push({
-              row: i,
-              id: contractPlotId,
-              plotNumber: item.plotNumber,
-            });
-          } catch (error) {
-            if (error instanceof ValidationError) {
-              const details = error.details?.length
-                ? error.details.map((d) => ({ ...d, row: i }))
-                : [{ row: i, message: error.message }];
-              throw new ValidationError(`行 ${i} でエラー: ${error.message}`, details);
-            }
-            throw error;
-          }
+      try {
+        await updateSingleItem(item, contractPlotId, req);
+        successes.push({ row: i, id: contractPlotId, plotNumber: item.plotNumber });
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          failures.push({
+            row: i,
+            plotNumber: item.plotNumber,
+            error: {
+              message: error.message,
+              details: error.details as Array<{ field?: string; message: string }> | undefined,
+            },
+          });
+        } else if (error instanceof Error) {
+          failures.push({
+            row: i,
+            plotNumber: item.plotNumber,
+            error: { message: error.message },
+          });
+        } else {
+          failures.push({
+            row: i,
+            plotNumber: item.plotNumber,
+            error: { message: '不明なエラーが発生しました' },
+          });
         }
-
-        return results;
-      },
-      {
-        maxWait: 10000,
-        timeout: 60000,
       }
-    );
+    }
 
     res.status(200).json({
       success: true,
       data: {
         totalRequested: items.length,
-        updated: updatedPlots.length,
-        results: updatedPlots,
+        succeeded: successes.length,
+        failed: failures,
+        results: successes,
       },
     });
   } catch (error) {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -192,8 +192,9 @@ paths:
       summary: 区画情報一括登録
       description: |
         複数の区画を一括登録します。1件登録（POST /plots）と同等のフィールド構成で、
-        最大500件まで一度に登録できます。全件が1つのトランザクションで実行され、
-        1件でもエラーがあれば全件ロールバックします。
+        最大500件まで一度に登録できます。各行は独立したトランザクションで処理され、
+        1行の失敗が他行に波及しない部分成功モデル（issue #76 Phase 1）。
+        レスポンスの `succeeded` / `failed[]` で成否を判定してください。
         manager または admin 権限が必要です。
       security:
         - bearerAuth: []
@@ -250,7 +251,9 @@ paths:
                         type: object
       responses:
         "201":
-          description: 一括登録成功
+          description: |
+            一括登録処理が完了（部分成功を含む）。
+            全行失敗の場合も 201 を返し、`failed[]` に詳細が入ります。
           content:
             application/json:
               schema:
@@ -264,12 +267,40 @@ paths:
                     properties:
                       totalRequested:
                         type: integer
+                        description: リクエストされた総件数
                         example: 10
-                      created:
+                      succeeded:
                         type: integer
-                        example: 10
+                        description: 成功件数
+                        example: 9
+                      failed:
+                        type: array
+                        description: 失敗行の詳細（バッチ内重複・DB重複・行ごとの処理エラーを含む）
+                        items:
+                          type: object
+                          properties:
+                            row:
+                              type: integer
+                            plotNumber:
+                              type: string
+                              nullable: true
+                            error:
+                              type: object
+                              properties:
+                                message:
+                                  type: string
+                                details:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      field:
+                                        type: string
+                                      message:
+                                        type: string
                       results:
                         type: array
+                        description: 成功行の詳細
                         items:
                           type: object
                           properties:
@@ -285,7 +316,7 @@ paths:
                               type: string
                               nullable: true
         "400":
-          description: バリデーションエラー / バッチ内重複 / 既存区画番号と衝突
+          description: リクエスト自体のスキーマ不正 / 空配列 / 上限超過
           content:
             application/json:
               schema:
@@ -323,7 +354,9 @@ paths:
       description: |
         既存の契約区画を plotNumber（区画番号）でマッチングして一括更新します。
         未指定フィールドは変更されず、null 明示フィールドはクリアされます。
-        最大500件まで一度に編集可能。トランザクションで all-or-nothing 処理。
+        最大500件まで一度に編集可能。各行は独立したトランザクションで処理され、
+        1行の失敗が他行に波及しない部分成功モデル（issue #76 Phase 1）。
+        レスポンスの `succeeded` / `failed[]` で成否を判定してください。
         manager または admin 権限が必要です。
       security:
         - bearerAuth: []
@@ -379,7 +412,9 @@ paths:
                         type: object
       responses:
         "200":
-          description: 一括編集成功
+          description: |
+            一括編集処理が完了（部分成功を含む）。
+            全行失敗の場合も 200 を返し、`failed[]` に詳細が入ります。
           content:
             application/json:
               schema:
@@ -393,8 +428,33 @@ paths:
                     properties:
                       totalRequested:
                         type: integer
-                      updated:
+                      succeeded:
                         type: integer
+                      failed:
+                        type: array
+                        description: 失敗行の詳細（マッチング失敗・行ごとの処理エラーを含む）
+                        items:
+                          type: object
+                          properties:
+                            row:
+                              type: integer
+                            plotNumber:
+                              type: string
+                              nullable: true
+                            error:
+                              type: object
+                              properties:
+                                message:
+                                  type: string
+                                details:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      field:
+                                        type: string
+                                      message:
+                                        type: string
                       results:
                         type: array
                         items:
@@ -408,7 +468,7 @@ paths:
                             plotNumber:
                               type: string
         "400":
-          description: バリデーションエラー / バッチ内重複 / 区画番号が DB に存在しない
+          description: リクエスト自体のスキーマ不正 / 空配列 / 上限超過
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":

--- a/tests/plots/controllers/bulkCreatePlots.test.ts
+++ b/tests/plots/controllers/bulkCreatePlots.test.ts
@@ -1,6 +1,8 @@
 /**
  * 区画一括登録コントローラーのテスト
  * POST /api/v1/plots/bulk
+ *
+ * Phase 1 (issue #76): 1 件ごと独立 tx・部分成功レスポンス対応
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -78,6 +80,19 @@ describe('bulkCreatePlots', () => {
   let jsonMock: jest.Mock;
   let statusMock: jest.Mock;
 
+  const buildTxMock = (extras: Record<string, any> = {}) => ({
+    familyContact: {
+      createManyAndReturn: jest.fn().mockResolvedValue([{ id: 'fc-1', name: 'test' }]),
+    },
+    buriedPerson: {
+      createManyAndReturn: jest.fn().mockResolvedValue([{ id: 'bp-1', name: 'test' }]),
+    },
+    constructionInfo: {
+      createManyAndReturn: jest.fn().mockResolvedValue([{ id: 'ci-1', construction_type: null }]),
+    },
+    ...extras,
+  });
+
   beforeEach(() => {
     jsonMock = jest.fn().mockReturnThis();
     statusMock = jest.fn().mockReturnValue({ json: jsonMock });
@@ -87,16 +102,9 @@ describe('bulkCreatePlots', () => {
 
     mockPhysicalPlotFindMany.mockResolvedValue([]);
 
-    // Default transaction: run the callback with a bare tx mock (child entity mocks added per-test)
+    // 各 item が独立 tx を開くため、tx は複数回呼ばれうる
     mockTransaction.mockImplementation(async (callback: any) => {
-      const txMock = {
-        familyContact: { create: jest.fn().mockResolvedValue({ id: 'fc-1', name: 'test' }) },
-        buriedPerson: { create: jest.fn().mockResolvedValue({ id: 'bp-1', name: 'test' }) },
-        constructionInfo: {
-          create: jest.fn().mockResolvedValue({ id: 'ci-1', construction_type: null }),
-        },
-      };
-      return callback(txMock);
+      return callback(buildTxMock());
     });
 
     // Default: createPlotCore returns IDs
@@ -134,7 +142,8 @@ describe('bulkCreatePlots', () => {
         success: true,
         data: {
           totalRequested: 3,
-          created: 3,
+          succeeded: 3,
+          failed: [],
           results: expect.arrayContaining([
             expect.objectContaining({ row: 0, plotNumber: 'A-1' }),
             expect.objectContaining({ row: 1, plotNumber: 'A-2' }),
@@ -143,20 +152,21 @@ describe('bulkCreatePlots', () => {
         },
       });
       expect(mockCreatePlotCore).toHaveBeenCalledTimes(3);
+      // 1 件ごと独立 tx: transaction が items 数ぶん呼ばれる
+      expect(mockTransaction).toHaveBeenCalledTimes(3);
     });
 
     it('familyContacts / buriedPersons / constructionInfos を含む複合登録ができること', async () => {
-      const fcCreateSpy = jest.fn().mockResolvedValue({ id: 'fc-1', name: '家族' });
-      const bpCreateSpy = jest.fn().mockResolvedValue({ id: 'bp-1', name: '埋葬' });
-      const ciCreateSpy = jest.fn().mockResolvedValue({ id: 'ci-1', construction_type: '工事' });
+      const fcCreateSpy = jest.fn().mockResolvedValue([{ id: 'fc-1', name: '家族' }]);
+      const bpCreateSpy = jest.fn().mockResolvedValue([{ id: 'bp-1', name: '埋葬' }]);
+      const ciCreateSpy = jest.fn().mockResolvedValue([{ id: 'ci-1', construction_type: '工事' }]);
 
       mockTransaction.mockImplementation(async (callback: any) => {
-        const txMock = {
-          familyContact: { create: fcCreateSpy },
-          buriedPerson: { create: bpCreateSpy },
-          constructionInfo: { create: ciCreateSpy },
-        };
-        return callback(txMock);
+        return callback({
+          familyContact: { createManyAndReturn: fcCreateSpy },
+          buriedPerson: { createManyAndReturn: bpCreateSpy },
+          constructionInfo: { createManyAndReturn: ciCreateSpy },
+        });
       });
 
       const item = buildValidItem('A-1', {
@@ -177,20 +187,16 @@ describe('bulkCreatePlots', () => {
 
       expect(mockNext).not.toHaveBeenCalled();
       expect(statusMock).toHaveBeenCalledWith(201);
+      // createManyAndReturn は 1 件でも呼ばれる（引数に 1 要素の配列）
       expect(fcCreateSpy).toHaveBeenCalledTimes(1);
       expect(bpCreateSpy).toHaveBeenCalledTimes(1);
       expect(ciCreateSpy).toHaveBeenCalledTimes(1);
     });
 
     it('familyContacts で必須フィールド欠如の行はスキップされること', async () => {
-      const fcCreateSpy = jest.fn().mockResolvedValue({ id: 'fc-1', name: '家族' });
+      const fcCreateSpy = jest.fn().mockResolvedValue([{ id: 'fc-1', name: '田中花子' }]);
       mockTransaction.mockImplementation(async (callback: any) => {
-        const txMock = {
-          familyContact: { create: fcCreateSpy },
-          buriedPerson: { create: jest.fn() },
-          constructionInfo: { create: jest.fn() },
-        };
-        return callback(txMock);
+        return callback(buildTxMock({ familyContact: { createManyAndReturn: fcCreateSpy } }));
       });
 
       const item = buildValidItem('A-1', {
@@ -211,7 +217,10 @@ describe('bulkCreatePlots', () => {
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).not.toHaveBeenCalled();
+      // createManyAndReturn は 1 回呼ばれ、data は 1 件のみ
       expect(fcCreateSpy).toHaveBeenCalledTimes(1);
+      const call = fcCreateSpy.mock.calls[0]![0] as { data: unknown[] };
+      expect(call.data).toHaveLength(1);
     });
   });
 
@@ -254,27 +263,32 @@ describe('bulkCreatePlots', () => {
     });
   });
 
-  describe('重複チェック', () => {
-    it('バッチ内で区画番号が重複している場合エラーを返すこと', async () => {
+  describe('部分成功（Phase 1）', () => {
+    it('バッチ内で区画番号が重複している場合、後続出現行が failed に入る', async () => {
       const items = [buildValidItem('A-1'), buildValidItem('A-2'), buildValidItem('A-1')];
       mockRequest = { body: { items } };
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.details).toEqual(
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(201);
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.totalRequested).toBe(3);
+      expect(payload.data.succeeded).toBe(2); // 行0, 行1 成功
+      expect(payload.data.failed).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            field: 'plotNumber',
-            message: expect.stringContaining('A-1'),
+            row: 2,
+            plotNumber: 'A-1',
+            error: expect.objectContaining({ message: expect.stringContaining('A-1') }),
           }),
         ])
       );
-      expect(mockTransaction).not.toHaveBeenCalled();
+      // 1 件目 (A-1), 2 件目 (A-2) のみ tx 実行
+      expect(mockCreatePlotCore).toHaveBeenCalledTimes(2);
     });
 
-    it('DB に既存の区画番号がある場合エラーを返すこと', async () => {
+    it('DB に既存の区画番号がある場合、該当行のみ failed に入る（他行は成功）', async () => {
       const items = ['A-1', 'A-2', 'A-3'].map((pn) => buildValidItem(pn));
       mockRequest = { body: { items } };
 
@@ -282,43 +296,30 @@ describe('bulkCreatePlots', () => {
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            row: 1,
-            field: 'plotNumber',
-            message: expect.stringContaining('A-2'),
-          }),
-        ])
-      );
-      expect(mockTransaction).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('トランザクションエラー', () => {
-    it('DB エラーが発生した場合 next にエラーが渡されること', async () => {
-      mockRequest = { body: { items: [buildValidItem('A-1')] } };
-
-      const dbError = new Error('Database connection lost');
-      mockTransaction.mockRejectedValue(dbError);
-
-      await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(dbError);
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.totalRequested).toBe(3);
+      expect(payload.data.succeeded).toBe(2);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 1,
+          plotNumber: 'A-2',
+          error: expect.objectContaining({ message: expect.stringContaining('A-2') }),
+        }),
+      ]);
+      // A-2 はスキップされるので createPlotCore は 2 回のみ
+      expect(mockCreatePlotCore).toHaveBeenCalledTimes(2);
     });
 
-    it('createPlotCore が ValidationError を投げた場合、行番号付きで再スローされること', async () => {
+    it('createPlotCore が ValidationError を投げた場合、該当行のみ failed に入り他行は成功', async () => {
       mockRequest = { body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] } };
 
       const { ValidationError } = jest.requireActual('../../../src/middleware/errorHandler');
       mockCreatePlotCore
-        .mockImplementationOnce(async (_tx: any, item: any) => ({
+        .mockImplementationOnce(async () => ({
           contractPlotId: 'cp-1',
           physicalPlotId: 'pp-1',
           customerId: 'cu-1',
-          _item: item,
         }))
         .mockImplementationOnce(async () => {
           throw new ValidationError('契約面積エラー', [
@@ -328,11 +329,49 @@ describe('bulkCreatePlots', () => {
 
       await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('行 1');
-      expect(error.details).toEqual(expect.arrayContaining([expect.objectContaining({ row: 1 })]));
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.totalRequested).toBe(2);
+      expect(payload.data.succeeded).toBe(1);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 1,
+          plotNumber: 'A-2',
+          error: expect.objectContaining({
+            message: expect.stringContaining('契約面積'),
+            details: expect.arrayContaining([
+              expect.objectContaining({ field: 'contractAreaSqm' }),
+            ]),
+          }),
+        }),
+      ]);
+    });
+
+    it('予期しないランタイムエラーも failed に記録され、他行は継続される', async () => {
+      mockRequest = { body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] } };
+
+      mockCreatePlotCore
+        .mockImplementationOnce(async () => {
+          throw new Error('DB接続喪失');
+        })
+        .mockImplementationOnce(async () => ({
+          contractPlotId: 'cp-2',
+          physicalPlotId: 'pp-2',
+          customerId: 'cu-2',
+        }));
+
+      await bulkCreatePlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.succeeded).toBe(1);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 0,
+          plotNumber: 'A-1',
+          error: expect.objectContaining({ message: 'DB接続喪失' }),
+        }),
+      ]);
     });
   });
 });

--- a/tests/plots/controllers/bulkUpdatePlots.test.ts
+++ b/tests/plots/controllers/bulkUpdatePlots.test.ts
@@ -1,6 +1,8 @@
 /**
  * 区画一括編集コントローラーのテスト
  * PUT /api/v1/plots/bulk
+ *
+ * Phase 1 (issue #76): 1 件ごと独立 tx・部分成功レスポンス対応
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -101,7 +103,8 @@ describe('bulkUpdatePlots', () => {
         success: true,
         data: {
           totalRequested: 2,
-          updated: 2,
+          succeeded: 2,
+          failed: [],
           results: [
             { row: 0, id: 'cp-1', plotNumber: 'A-1' },
             { row: 1, id: 'cp-2', plotNumber: 'A-2' },
@@ -109,6 +112,8 @@ describe('bulkUpdatePlots', () => {
         },
       });
       expect(mockUpdatePlotCore).toHaveBeenCalledTimes(2);
+      // 1 件ごと独立 tx: transaction が items 数ぶん呼ばれる
+      expect(mockTransaction).toHaveBeenCalledTimes(2);
     });
 
     it('未指定フィールドは updatePlotCore に undefined として渡されること（部分更新仕様）', async () => {
@@ -169,28 +174,32 @@ describe('bulkUpdatePlots', () => {
     });
   });
 
-  describe('マッチングエラー', () => {
-    it('バッチ内で plotNumber が重複している場合エラーを返すこと', async () => {
+  describe('部分成功（Phase 1）', () => {
+    it('バッチ内で plotNumber が重複している場合、後続出現行のみ failed に入る', async () => {
+      mockPhysicalPlotFindMany.mockResolvedValue([
+        { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+      ]);
       mockRequest = {
         body: { items: [buildValidItem('A-1'), buildValidItem('A-1')] },
       };
 
       await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            field: 'plotNumber',
-            message: expect.stringContaining('A-1'),
-          }),
-        ])
-      );
-      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.totalRequested).toBe(2);
+      expect(payload.data.succeeded).toBe(1);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 1,
+          plotNumber: 'A-1',
+          error: expect.objectContaining({ message: expect.stringContaining('A-1') }),
+        }),
+      ]);
+      expect(mockUpdatePlotCore).toHaveBeenCalledTimes(1);
     });
 
-    it('DB に plotNumber が存在しない場合エラーを返すこと', async () => {
+    it('DB に plotNumber が存在しない場合、該当行のみ failed に入り他行は成功', async () => {
       mockPhysicalPlotFindMany.mockResolvedValue([
         { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
       ]);
@@ -200,39 +209,41 @@ describe('bulkUpdatePlots', () => {
 
       await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            field: 'plotNumber',
-            message: expect.stringContaining('A-2'),
-          }),
-        ])
-      );
-      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.totalRequested).toBe(2);
+      expect(payload.data.succeeded).toBe(1);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 1,
+          plotNumber: 'A-2',
+          error: expect.objectContaining({ message: expect.stringContaining('A-2') }),
+        }),
+      ]);
     });
 
-    it('PhysicalPlot はあるが有効な契約が無い場合エラーを返すこと', async () => {
+    it('PhysicalPlot はあるが有効な契約が無い場合、該当行のみ failed に入る', async () => {
       mockPhysicalPlotFindMany.mockResolvedValue([{ plot_number: 'A-1', contractPlots: [] }]);
       mockRequest = { body: { items: [buildValidItem('A-1')] } };
 
       await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.details).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.succeeded).toBe(0);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 0,
+          plotNumber: 'A-1',
+          error: expect.objectContaining({
             message: expect.stringContaining('有効な契約区画'),
           }),
-        ])
-      );
+        }),
+      ]);
+      expect(mockUpdatePlotCore).not.toHaveBeenCalled();
     });
-  });
 
-  describe('トランザクションエラー', () => {
-    it('updatePlotCore が ValidationError を投げた場合、行番号付きで再スローされること', async () => {
+    it('updatePlotCore が ValidationError を投げた場合、該当行のみ failed に入り他行は成功', async () => {
       mockPhysicalPlotFindMany.mockResolvedValue([
         { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
         { plot_number: 'A-2', contractPlots: [{ id: 'cp-2' }] },
@@ -250,24 +261,47 @@ describe('bulkUpdatePlots', () => {
 
       await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      const error = mockNext.mock.calls[0]![0] as any;
-      expect(error.name).toBe('ValidationError');
-      expect(error.message).toContain('行 1');
-      expect(error.details).toEqual(expect.arrayContaining([expect.objectContaining({ row: 1 })]));
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.succeeded).toBe(1);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 1,
+          plotNumber: 'A-2',
+          error: expect.objectContaining({
+            message: expect.stringContaining('契約面積'),
+          }),
+        }),
+      ]);
     });
 
-    it('DB エラーが発生した場合 next にエラーが渡されること', async () => {
+    it('予期しないランタイムエラーも failed に記録され、他行は継続される', async () => {
       mockPhysicalPlotFindMany.mockResolvedValue([
         { plot_number: 'A-1', contractPlots: [{ id: 'cp-1' }] },
+        { plot_number: 'A-2', contractPlots: [{ id: 'cp-2' }] },
       ]);
-      mockRequest = { body: { items: [buildValidItem('A-1')] } };
+      mockRequest = {
+        body: { items: [buildValidItem('A-1'), buildValidItem('A-2')] },
+      };
 
-      const dbError = new Error('Database connection lost');
-      mockTransaction.mockRejectedValue(dbError);
+      mockTransaction
+        .mockImplementationOnce(async () => {
+          throw new Error('DB接続喪失');
+        })
+        .mockImplementationOnce(async (callback: any) => callback({}));
 
       await bulkUpdatePlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledWith(dbError);
+      expect(mockNext).not.toHaveBeenCalled();
+      const payload = jsonMock.mock.calls[0]![0];
+      expect(payload.data.succeeded).toBe(1);
+      expect(payload.data.failed).toEqual([
+        expect.objectContaining({
+          row: 0,
+          plotNumber: 'A-1',
+          error: expect.objectContaining({ message: 'DB接続喪失' }),
+        }),
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- 一括登録 / 一括編集を **1件ごと独立トランザクション** に変更（全件1 tx をやめた）
- `familyContacts` / `buriedPersons` / `constructionInfos` を `createManyAndReturn` でバッチINSERT
- レスポンスを **部分成功許容形式** に変更: `{ totalRequested, succeeded, failed: [{row, plotNumber, error}], results[] }`
- バッチ内重複・DB重複・行ごとの処理失敗は全て `failed[]` に記録（旧: 全体ValidationError）
- swagger.yaml 更新

## 背景
issue #76 の Phase 1 対応。詳細は issue 本文参照。
- 破綻ポイント: 500件 × updatePlotCore ~5s = Prisma tx 60s タイムアウト + Render HTTP 100s タイムアウト
- Phase 1 で同期のまま ~100件程度までは耐えられる想定
- Phase 2（bulk_jobs テーブル + pg-boss 非同期化）は別スコープで規模要件が明確化してから判断

## 依存
- [ ] 先にマージ: zaitsu82/komine-types#8 （新レスポンス型を追加）
- フロント側追従: zaitsu82/komine-crm-frontend (別PR)

## Test plan
- [x] バックエンド 756 tests passing
- [x] lint 0 errors / typecheck 0 errors
- [x] swagger:validate パス
- [ ] 手動テスト: 小量バッチ（5件）で部分成功レスポンス確認
- [ ] 手動テスト: 既存 plotNumber 混入時に該当行のみ failed に入ること

Closes #76 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)