### PR TITLE
chore(tsconfig): suppress node10 moduleResolution deprecation warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,10 @@
     "allowJs": false,                                    /* JavaScript ファイルのコンパイルを許可しない */
     "checkJs": false,                                    /* JavaScript ファイルの型チェックを無効化 */
     "isolatedModules": true,                             /* 各ファイルを個別のモジュールとして扱う */
-    "noEmitOnError": true                                /* エラーがある場合は出力しない */
+    "noEmitOnError": true,                               /* エラーがある場合は出力しない */
+
+    /* 一時的な非推奨警告の抑制 — 別途 node16 への移行 issue あり */
+    "ignoreDeprecations": "5.0"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary
- `tsconfig.json` に `"ignoreDeprecations": "5.0"` を追加
- TypeScript 5.x が暗黙の `moduleResolution=node10` に対して出す非推奨警告を抑制

## 背景
エディタ上で以下の警告が出ていた:
> オプション 'moduleResolution=node10' は非推奨であり、TypeScript 7.0 で機能しなくなります。

プロジェクトの tsc (5.9.3) は `"5.0"` のみ受け付けるため、その値で抑制。
本格的な `node16` への移行は #81 で別途対応予定。

## Test plan
- [x] `npx tsc --noEmit` パス
- [x] VS Code で警告が消えることを目視確認

Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)