### PR TITLE
chore(tsconfig): module/moduleResolution を node16 に移行 (Closes #81)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "outDir": "./dist",
     "rootDir": "./src",
 
@@ -42,10 +43,7 @@
     "allowJs": false,                                    /* JavaScript ファイルのコンパイルを許可しない */
     "checkJs": false,                                    /* JavaScript ファイルの型チェックを無効化 */
     "isolatedModules": true,                             /* 各ファイルを個別のモジュールとして扱う */
-    "noEmitOnError": true,                               /* エラーがある場合は出力しない */
-
-    /* 一時的な非推奨警告の抑制 — 別途 node16 への移行 issue あり */
-    "ignoreDeprecations": "5.0"
+    "noEmitOnError": true                                /* エラーがある場合は出力しない */
   },
   "include": [
     "src/**/*"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,7 +9,10 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false,
-    "noUncheckedIndexedAccess": false
+    "noUncheckedIndexedAccess": false,
+    /* ts-jest が dynamic import() を require に降格できるよう CJS に戻す */
+    "module": "CommonJS",
+    "moduleResolution": "node10"
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Summary
- `tsconfig.json` の `module` / `moduleResolution` を明示的に `node16` に移行（TypeScript 7.0 で node10 削除予定への対応）
- #85 で追加していた暫定抑制 `ignoreDeprecations: "5.0"` を削除
- `tsconfig.test.json` は `module: CommonJS` / `moduleResolution: node10` に固定（理由は下記）

## tsconfig.test.json を CJS に固定した理由
`tsconfig.json` が `module: Node16` になると `ts-jest` がテスト内の `await import(...)` を native ESM の dynamic import として出力してしまい、以下で落ちる:

```
TypeError: A dynamic import callback was invoked without --experimental-vm-modules
```

ts-jest + Jest + CJS ランタイムの組み合わせを維持するため、テスト専用設定で CJS を明示指定した。本体コードは Node16 解決を使う。

## Test plan
- [x] `npm run build` — tsc エラーなし
- [x] `npm test` — 756/756 pass
- [x] `npm run dev` — 正常起動（ts-node-dev + ts-node 10.9 で Node16 解決動作確認）
- [x] `npm run swagger:validate` — OK
- [x] `npm run lint` — 0 errors（warning 数は変化なし）
- [ ] CI (GitHub Actions) で Node 20.x / 22.x の両方で通ること
- [ ] Docker build（Render デプロイ相当）

## 影響範囲
- ソースコードの変更なし（import 文含む）。CJS のままなので相対 import の `.js` 拡張子追加は不要だった。
- 影響があったのは Jest/ts-jest のテスト実行のみ（上記の通り tsconfig.test.json で対処）。

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)