### PR TITLE
feat(seed): 初期管理者ブートストラップ機構の整備 (Closes #82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,15 @@ SUPABASE_URL="https://your-project-id.supabase.co"
 # Settings > API > Project API keys > service_role からコピー
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key-here"
 
+# 初期管理者ブートストラップ (npm run bootstrap:admin / npx prisma db seed)
+# 顧客環境への初回デプロイ時に1度だけ実行して admin ユーザーを作成します
+# 既に admin が存在する場合は何もしません（冪等）
+# INITIAL_ADMIN_EMAIL="admin@example.com"
+# INITIAL_ADMIN_PASSWORD="<strong-password-8-chars-or-more>"
+# INITIAL_ADMIN_NAME="管理者"
+# NODE_ENV=production で実行する場合のみ以下も設定
+# ALLOW_BOOTSTRAP_IN_PRODUCTION="true"
+
 # Sentry Configuration (Optional - エラートラッキング)
 # Sentryプロジェクトの設定から取得してください
 # https://sentry.io/settings/{your-org}/projects/{your-project}/keys/

--- a/SETUP.md
+++ b/SETUP.md
@@ -7,8 +7,9 @@ Cemetery CRM Backend の環境構築・設定ガイド
 1. [環境変数の設定](#環境変数の設定)
 2. [Dockerセットアップ](#dockerセットアップ)
 3. [Supabase認証](#supabase認証)
-4. [CI/CDセットアップ](#cicdセットアップ)
-5. [本番環境デプロイ](#本番環境デプロイ)
+4. [顧客環境への初回デプロイ手順](#顧客環境への初回デプロイ手順)
+5. [CI/CDセットアップ](#cicdセットアップ)
+6. [本番環境デプロイ](#本番環境デプロイ)
 
 ---
 
@@ -97,7 +98,13 @@ docker compose -f docker-compose.dev.yml exec app npx prisma migrate dev
    - Project URL → `SUPABASE_URL`
    - service_role key → `SUPABASE_SERVICE_ROLE_KEY`
 
-### ユーザー作成
+### 初期 admin の作成
+
+顧客環境への初回デプロイ時は [顧客環境への初回デプロイ手順](#顧客環境への初回デプロイ手順) の bootstrap スクリプトを使用してください。
+
+運用中の追加ユーザー作成は admin アカウントでログインし `POST /api/v1/staff` から行います。
+
+### （参考）手動でユーザーを追加する場合
 
 1. Supabaseダッシュボード → **Authentication** → **Users**
 2. **Add user** でユーザー作成（Auto Confirm: ON）
@@ -120,6 +127,82 @@ fetch('/api/v1/plots', {
   headers: { 'Authorization': `Bearer ${data.session.access_token}` }
 });
 ```
+
+---
+
+## 顧客環境への初回デプロイ手順
+
+新規の顧客環境に CRM を立ち上げる際の標準手順。以下の順番で実施してください。
+
+### 1. Supabaseプロジェクトの作成
+
+1. [Supabase](https://supabase.com/) にログインし、新規プロジェクトを作成
+2. **Settings** → **API** から以下を控える
+   - `Project URL` → `SUPABASE_URL`
+   - `service_role` key → `SUPABASE_SERVICE_ROLE_KEY`
+3. **Settings** → **Database** から接続情報（DATABASE_URL / DIRECT_URL）を取得
+   - Render / Vercel 等の IPv6 非対応環境では Session Pooler（port 5432）を使用
+
+### 2. 環境変数の設定
+
+`.env`（またはデプロイ先のシークレットマネージャ）に以下を設定:
+
+| 変数名 | 必須 | 用途 |
+|--------|------|------|
+| `DATABASE_URL` | ✅ | Prisma / アプリ本体のDB接続 |
+| `DIRECT_URL` | ▲ | マイグレーション用（Supabase Session Pooler 使用時）|
+| `SUPABASE_URL` | ✅ | bootstrap / auth で使用 |
+| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | bootstrap / auth で使用 |
+| `ALLOWED_ORIGINS` | ✅ | 本番フロントエンドのURLを指定 |
+| `NODE_ENV` | ✅ | `production` |
+| `INITIAL_ADMIN_EMAIL` | ✅ | 初期adminのメールアドレス |
+| `INITIAL_ADMIN_PASSWORD` | ✅ | 初期adminのパスワード（8文字以上）|
+| `INITIAL_ADMIN_NAME` | ✅ | 初期adminの表示名 |
+| `ALLOW_BOOTSTRAP_IN_PRODUCTION` | ▲ | `NODE_ENV=production` で bootstrap を実行する場合のみ `true` を指定 |
+
+### 3. マイグレーションの実行
+
+```bash
+npx prisma migrate deploy
+```
+
+### 4. 初期adminの作成（bootstrap）
+
+```bash
+# 本番環境では ALLOW_BOOTSTRAP_IN_PRODUCTION=true が必要
+npm run bootstrap:admin
+# または
+npx prisma db seed
+```
+
+スクリプトの動作:
+
+- Supabase Auth にユーザーを作成（`email_confirm: true` でメール確認スキップ）
+- Staff テーブルに `role=admin` で登録
+- **冪等**: 既に admin が Staff テーブルに存在する場合は skip
+- **atomic**: Staff 登録に失敗した場合は Supabase ユーザーをロールバック
+- Supabase 未設定時は明示的なエラーメッセージで終了
+- `NODE_ENV=production` かつ `ALLOW_BOOTSTRAP_IN_PRODUCTION` が未指定の場合は誤実行防止のためブロック
+
+### 5. ログイン確認
+
+```bash
+curl -X POST https://yourdomain.com/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<INITIAL_ADMIN_EMAIL>","password":"<INITIAL_ADMIN_PASSWORD>"}'
+```
+
+200 が返れば完了。以降、追加ユーザーは admin アカウントでログイン後に `POST /api/v1/staff` から招待できます。
+
+### トラブルシューティング
+
+| エラー | 原因 / 対処 |
+|--------|------------|
+| `Supabase Admin が利用できません` | `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` を確認 |
+| `必須環境変数が未設定です` | `INITIAL_ADMIN_*` 3変数をすべて設定 |
+| `NODE_ENV=production での実行はブロックされました` | `ALLOW_BOOTSTRAP_IN_PRODUCTION=true` を明示的に設定 |
+| `メールアドレス XXX の Staff が既に存在します` | 別のメールアドレスを指定、または既存レコードを確認 |
+| `既に admin が存在するため skip` | 正常動作（冪等性）。追加 admin は API 経由で作成してください |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "swagger:json": "node scripts/swagger.js json",
     "swagger:build": "node scripts/swagger.js build",
     "billing:generate": "ts-node scripts/generate-collective-burial-invoices.ts",
+    "bootstrap:admin": "ts-node --transpile-only prisma/seed.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
     url: process.env['DATABASE_URL'] ?? 'postgresql://',
     directUrl: process.env['DIRECT_URL'],
   },
+  migrations: {
+    seed: 'ts-node --transpile-only prisma/seed.ts',
+  },
 });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,175 @@
+/**
+ * 初期管理者ブートストラップスクリプト
+ *
+ * 顧客環境への初回リリース時に、最初の admin ユーザーを作成する。
+ * Supabase Auth にユーザーを作成し、Staff テーブルに admin レコードを登録する。
+ *
+ * 冪等性: Staff テーブルに admin が1人でも存在すれば skip する。
+ *
+ * 実行方法:
+ *   npm run bootstrap:admin
+ *   または
+ *   npx prisma db seed
+ *
+ * 必須環境変数:
+ *   INITIAL_ADMIN_EMAIL
+ *   INITIAL_ADMIN_PASSWORD
+ *   INITIAL_ADMIN_NAME
+ *   SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *   DATABASE_URL
+ *
+ * オプション:
+ *   ALLOW_BOOTSTRAP_IN_PRODUCTION=true — NODE_ENV=production でも実行を許可
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import {
+  createSupabaseUserWithPassword,
+  deleteSupabaseUser,
+  isSupabaseAdminAvailable,
+} from '../src/config/supabase';
+
+interface BootstrapEnv {
+  email: string;
+  password: string;
+  name: string;
+}
+
+function readEnv(): BootstrapEnv {
+  const email = process.env['INITIAL_ADMIN_EMAIL'];
+  const password = process.env['INITIAL_ADMIN_PASSWORD'];
+  const name = process.env['INITIAL_ADMIN_NAME'];
+
+  const missing: string[] = [];
+  if (!email) missing.push('INITIAL_ADMIN_EMAIL');
+  if (!password) missing.push('INITIAL_ADMIN_PASSWORD');
+  if (!name) missing.push('INITIAL_ADMIN_NAME');
+
+  if (missing.length > 0) {
+    throw new Error(
+      `必須環境変数が未設定です: ${missing.join(', ')}\n` +
+        '.env ファイルに以下を設定してください:\n' +
+        '  INITIAL_ADMIN_EMAIL=admin@example.com\n' +
+        '  INITIAL_ADMIN_PASSWORD=<strong-password>\n' +
+        '  INITIAL_ADMIN_NAME=管理者'
+    );
+  }
+
+  if (password!.length < 8) {
+    throw new Error('INITIAL_ADMIN_PASSWORD は8文字以上にしてください');
+  }
+
+  return { email: email!, password: password!, name: name! };
+}
+
+function ensureProductionAllowed(): void {
+  if (
+    process.env['NODE_ENV'] === 'production' &&
+    process.env['ALLOW_BOOTSTRAP_IN_PRODUCTION'] !== 'true'
+  ) {
+    throw new Error(
+      'NODE_ENV=production での実行はブロックされました。\n' +
+        '意図的に実行する場合は ALLOW_BOOTSTRAP_IN_PRODUCTION=true を設定してください。'
+    );
+  }
+}
+
+function createPrismaClient(): PrismaClient {
+  const adapter = new PrismaPg({
+    connectionString: process.env['DATABASE_URL'],
+  });
+  return new PrismaClient({ adapter });
+}
+
+async function main(): Promise<void> {
+  ensureProductionAllowed();
+
+  if (!isSupabaseAdminAvailable()) {
+    throw new Error(
+      'Supabase Admin が利用できません。\n' +
+        'SUPABASE_URL と SUPABASE_SERVICE_ROLE_KEY を .env に設定してください。'
+    );
+  }
+
+  const env = readEnv();
+  const prisma = createPrismaClient();
+
+  try {
+    const existingAdmin = await prisma.staff.findFirst({
+      where: { role: 'admin', deleted_at: null },
+      select: { id: true, email: true },
+    });
+
+    if (existingAdmin) {
+      console.log(
+        `✅ 既に admin が存在するため skip します (id=${existingAdmin.id}, email=${existingAdmin.email})`
+      );
+      return;
+    }
+
+    const existingStaffByEmail = await prisma.staff.findUnique({
+      where: { email: env.email },
+      select: { id: true, role: true },
+    });
+
+    if (existingStaffByEmail) {
+      throw new Error(
+        `メールアドレス ${env.email} の Staff が既に存在します (id=${existingStaffByEmail.id}, role=${existingStaffByEmail.role})。\n` +
+          '別のメールアドレスを指定するか、既存レコードを確認してください。'
+      );
+    }
+
+    console.log(`🔐 Supabase Auth にユーザーを作成中: ${env.email}`);
+    const supabaseResult = await createSupabaseUserWithPassword(env.email, env.password, {
+      name: env.name,
+      role: 'admin',
+    });
+
+    if (!supabaseResult.success || !supabaseResult.user) {
+      throw new Error(`Supabase ユーザー作成に失敗しました: ${supabaseResult.error}`);
+    }
+
+    const supabaseUid = supabaseResult.user.id;
+    console.log(`✅ Supabase ユーザー作成完了 (uid=${supabaseUid})`);
+
+    try {
+      const staff = await prisma.staff.create({
+        data: {
+          supabase_uid: supabaseUid,
+          email: env.email,
+          name: env.name,
+          role: 'admin',
+          is_active: true,
+        },
+      });
+      console.log(`✅ Staff テーブルに登録しました (id=${staff.id}, role=admin)`);
+    } catch (dbError) {
+      console.error('❌ Staff 登録に失敗したため Supabase ユーザーをロールバックします');
+      const rollback = await deleteSupabaseUser(supabaseUid);
+      if (!rollback.success) {
+        console.error(
+          `⚠️ Supabase ロールバックにも失敗しました。手動削除が必要です (uid=${supabaseUid}): ${rollback.error}`
+        );
+      }
+      throw dbError;
+    }
+
+    console.log('\n🎉 初期管理者ブートストラップが完了しました');
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log(`  Email:    ${env.email}`);
+    console.log(`  Name:     ${env.name}`);
+    console.log(`  Role:     admin`);
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log('フロントエンドからこの認証情報でログインできます。');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`❌ ${message}`);
+  process.exit(1);
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,7 +6,8 @@
   "include": [
     "src/**/*",
     "scripts/**/*.ts",
-    "prisma/scripts/**/*.ts"
+    "prisma/scripts/**/*.ts",
+    "prisma/seed.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

- 顧客環境への初回リリース時、最初の admin ユーザーを 1 コマンドで作成可能にした
- `prisma/seed.ts` が Supabase Auth + Staff テーブルを atomic に作成（失敗時は Supabase ユーザーをロールバック）
- 冪等: 既に admin が存在する場合は skip
- 本番誤実行防止: `NODE_ENV=production` では `ALLOW_BOOTSTRAP_IN_PRODUCTION=true` 必須

## Changes

- **新規**: `prisma/seed.ts`
- **package.json**: `npm run bootstrap:admin` を追加
- **prisma.config.ts**: `migrations.seed` を登録（`npx prisma db seed` で実行可）
- **SETUP.md**: 「顧客環境への初回デプロイ手順」章を追加（Supabase作成→env→migration→bootstrap→ログイン確認）
- **.env.example**: `INITIAL_ADMIN_EMAIL/PASSWORD/NAME` と `ALLOW_BOOTSTRAP_IN_PRODUCTION` を追記
- **tsconfig.eslint.json**: `prisma/seed.ts` を lint 対象に追加

## Issue 確認事項への回答

- **seed script vs 専用 CLI**: seed script + npm script の併用にした。`npx prisma db seed` / `npm run bootstrap:admin` どちらでも実行可能
- **Auto Confirm**: `createSupabaseUserWithPassword` の `email_confirm: true` でメール確認をスキップ
- **プロダクション誤実行防止**: `NODE_ENV=production` かつ `ALLOW_BOOTSTRAP_IN_PRODUCTION` 未指定なら即エラーで停止

## Test plan

- [ ] ローカル: `.env` に `INITIAL_ADMIN_*` を設定し `npm run bootstrap:admin` を実行して Supabase + Staff に admin が作成されること
- [ ] 2回目の実行で skip されること（冪等性）
- [ ] `INITIAL_ADMIN_*` 未設定時に明示的エラーで終了すること
- [ ] `SUPABASE_URL` 未設定時に明示的エラーで終了すること
- [ ] `NODE_ENV=production` 単独では実行ブロックされること
- [ ] 作成した admin でフロントからログインできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)