### PR TITLE
docs(inventory): 区画残数ロジックの暫定仕様を明文化 (refs #64)

### DIFF
--- a/src/plots/services/inventoryService.ts
+++ b/src/plots/services/inventoryService.ts
@@ -29,17 +29,33 @@ function toNumber(value: unknown): number {
   return isNaN(num) ? 0 : num;
 }
 
-// plot_numberからセクションを抽出
+/**
+ * plot_number からセクション名を抽出する。
+ *
+ * 暫定仕様（業務ヒアリング待ち / issue #64 項目 #1）:
+ *   plot_number は `<section>-<連番>` の単純形式を前提とする。
+ *     例: "A-56" → "A", "吉相-10" → "吉相", "1.5-3" → "1.5",
+ *         "るり庵テラス-1" → "るり庵テラス", "天空K-5" → "天空K"
+ *   区画名一覧（komine-docs/区画名一覧.md）に従い、セクション名自体には
+ *   ハイフンを含めない前提。期名（area_name）は別カラムで管理し、
+ *   plot_number には含めない。
+ *   末尾に `-<連番>` が無いフォーマット（例: "A", "吉相"）は、
+ *   セクション単独表記として扱い、そのまま返す。
+ */
 export function extractSection(plotNumber: string): string {
-  // "A-56" → "A"
-  // "吉相-10" → "吉相"
-  // "るり庵テラス-1" → "るり庵テラス"
-  // "1-5" → "1"
   const match = plotNumber.match(/^(.+)-\d+$/);
   return match && match[1] ? match[1] : plotNumber;
 }
 
-// カテゴリを判定（特殊区画用）
+/**
+ * セクションを特殊区画カテゴリに分類する。
+ *
+ * 暫定仕様（業務ヒアリング待ち / issue #64 項目 #5）:
+ *   区画名一覧（komine-docs/区画名一覧.md）の第3期樹林部のセクション
+ *   （樹林, 天空K）を「樹林・天空」カテゴリに分類する。
+ *   素の "天空" セクションは区画名一覧に存在しないが、将来 "天空-N" のような
+ *   区画が追加された場合に備えて互換で残している。
+ */
 export function categorizeSection(section: string): string | undefined {
   const categoryMap: Record<string, string> = {
     樹林: '樹林・天空',
@@ -49,12 +65,26 @@ export function categorizeSection(section: string): string | undefined {
   return categoryMap[section];
 }
 
-// 区画タイプを判定
+/**
+ * セクション名から区画タイプ（表示用分類）を判定する。
+ *
+ * 暫定仕様（業務ヒアリング待ち / issue #64 項目 #6）:
+ *   区画名一覧（komine-docs/区画名一覧.md）に準拠する。
+ *     - 吉相 → "吉相"
+ *     - 樹林 → "樹林"
+ *     - "天空" を含む（天空K等） → "天空"
+ *     - "るり庵" を含む（るり庵テラス, るり庵テラスⅡ等） → "るり庵"
+ *     - 想 → "るり庵"（区画名一覧の備考より、もり庵テラス関連の区画として暫定で "るり庵" 扱い）
+ *     - 墳墓 → "墳墓"（区画名一覧には無いが将来用に残置）
+ *     - 憩 / 恵 → "特別区"
+ *     - その他（A〜P, 1〜8, 1.5, 2.4, 3, 4, 5, 8.4 等） → "自由"
+ */
 export function determinePlotType(section: string, _areaSqm: number): string {
   if (section === '吉相') return '吉相';
   if (section === '樹林') return '樹林';
   if (section.includes('天空')) return '天空';
   if (section.includes('るり庵')) return 'るり庵';
+  if (section === '想') return 'るり庵';
   if (section === '墳墓') return '墳墓';
   if (section === '憩' || section === '恵') return '特別区';
   return '自由';
@@ -126,6 +156,7 @@ export async function getOverallSummary(prisma: DbClient): Promise<InventorySumm
     usageRate: Math.round(usageRate * 10) / 10,
     totalAreaSqm: Math.round(totalAreaSqm * 100) / 100,
     remainingAreaSqm: Math.round(remainingAreaSqm * 100) / 100,
+    // issue #64 項目 #3: API は常に ISO8601 (UTC) で返す。表示整形はフロント責務。
     lastUpdated: new Date().toISOString(),
   };
 }

--- a/tests/plots/services/inventoryService.test.ts
+++ b/tests/plots/services/inventoryService.test.ts
@@ -35,6 +35,13 @@ describe('inventoryService', () => {
       expect(extractSection('10-2')).toBe('10');
     });
 
+    // issue #64 項目 #1 暫定仕様: 第4期の小数点セクションも想定
+    it('小数点を含むセクション名を抽出できること', () => {
+      expect(extractSection('1.5-3')).toBe('1.5');
+      expect(extractSection('2.4-12')).toBe('2.4');
+      expect(extractSection('8.4-1')).toBe('8.4');
+    });
+
     it('ハイフンがない場合はそのまま返すこと', () => {
       expect(extractSection('A')).toBe('A');
       expect(extractSection('吉相')).toBe('吉相');
@@ -69,6 +76,12 @@ describe('inventoryService', () => {
     it('特別区を正しく判定すること', () => {
       expect(determinePlotType('憩', 3.6)).toBe('特別区');
       expect(determinePlotType('恵', 1.8)).toBe('特別区');
+    });
+
+    // issue #64 項目 #6 暫定仕様: 第4期「想」は「るり庵」カテゴリに分類
+    it('「想」はるり庵として分類されること', () => {
+      expect(determinePlotType('想', 3.6)).toBe('るり庵');
+      expect(determinePlotType('想', 1.8)).toBe('るり庵');
     });
 
     it('通常区画は自由タイプを返すこと', () => {


### PR DESCRIPTION
## Summary

区画残数管理ロジック (issue #64) のうち、業務ヒアリング待ちだった項目について **暫定仕様** を決定し、コード上に明文化した。

区画名一覧（`komine-docs/区画名一覧.md`）を一次情報として採用。

### 対象項目

| # | 項目 | 対応 |
|---|------|------|
| #1 | `extractSection()` 命名規則 | JSDocで前提条件を明文化 (`<section>-<連番>` 形式、セクション名内にハイフン不可、期名は別カラム)。小数点セクションのテスト追加 |
| #3 | `lastUpdated` フォーマット | API は ISO8601 固定である旨をコメントで明示（表示整形はフロント責務） |
| #5 | `categorizeSection()` 対象範囲 | 区画名一覧準拠 (`樹林` / `天空K`) を明文化。`天空` は将来 `天空-N` 形式が出た場合の互換で残置 |
| #6 | `determinePlotType()` 業務妥当性 | 第4期「想」を `'るり庵'` カテゴリに暫定追加（区画名一覧の備考で「もり庵テラス」関連と推定） |

### 動作上の変更

`determinePlotType('想', _) → 'るり庵'` のみ。他はドキュメント強化。

### 保留

- #4 `totalAreaSqm` の3.6㎡固定問題 → フロントモック側の問題のため本PR対象外
- 最終確定は業務ヒアリング完了後、本PRの内容をベースに再調整する前提

## Test plan

- [x] `npm test` 全通過（38 suites / 758 tests）
- [x] `npm run lint` 0 errors
- [x] `extractSection` 新テスト（小数点セクション）通過
- [x] `determinePlotType('想')` → `'るり庵'` のテスト通過

refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)