### PR TITLE
fix(collective-burials): 契約者名を applicant→contractor フォールバック

### DIFF
--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -95,11 +95,10 @@ export const getCollectiveBurialList = async (
             include: {
               physicalPlot: true,
               saleContractRoles: {
-                where: { deleted_at: null, role: 'applicant' },
+                where: { deleted_at: null, role: { in: ['applicant', 'contractor'] } },
                 include: {
                   customer: true,
                 },
-                take: 1,
               },
               buriedPersons: {
                 where: { deleted_at: null },
@@ -114,7 +113,10 @@ export const getCollectiveBurialList = async (
 
     // レスポンス形式に変換
     const formattedItems = items.map((item) => {
-      const applicant = item.contractPlot.saleContractRoles[0]?.customer;
+      const roles = item.contractPlot.saleContractRoles;
+      const applicant = (
+        roles.find((r) => r.role === 'applicant') ?? roles.find((r) => r.role === 'contractor')
+      )?.customer;
       return {
         id: item.id,
         contractPlotId: item.contract_plot_id,
@@ -198,8 +200,9 @@ export const getCollectiveBurialById = async (
       throw new NotFoundError('合祀情報が見つかりません');
     }
 
-    const applicant = collectiveBurial.contractPlot.saleContractRoles.find(
-      (r) => r.role === 'applicant'
+    const roles = collectiveBurial.contractPlot.saleContractRoles;
+    const applicant = (
+      roles.find((r) => r.role === 'applicant') ?? roles.find((r) => r.role === 'contractor')
     )?.customer;
 
     res.status(200).json({

--- a/tests/collective-burials/collectiveBurialController.test.ts
+++ b/tests/collective-burials/collectiveBurialController.test.ts
@@ -1,0 +1,189 @@
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma: any = {
+  collectiveBurial: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    count: jest.fn(),
+  },
+};
+
+jest.mock('../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+jest.mock('@prisma/client', () => ({
+  BillingStatus: { pending: 'pending', billed: 'billed', paid: 'paid' },
+  PrismaClient: jest.fn(),
+}));
+
+import {
+  getCollectiveBurialList,
+  getCollectiveBurialById,
+} from '../../src/collective-burials/collectiveBurialController';
+
+describe('collectiveBurialController — 契約者名フォールバック (issue #50)', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseJson: jest.Mock;
+  let mockNext: jest.Mock;
+
+  function buildBurial(
+    roles: Array<{ role: 'applicant' | 'contractor'; name: string; name_kana: string }>
+  ) {
+    return {
+      id: 'cb1',
+      contract_plot_id: 'cp1',
+      burial_capacity: 10,
+      current_burial_count: 3,
+      capacity_reached_date: null,
+      validity_period_years: 33,
+      billing_scheduled_date: null,
+      billing_status: 'pending',
+      billing_amount: null,
+      notes: null,
+      created_at: new Date('2026-01-01'),
+      updated_at: new Date('2026-01-01'),
+      contractPlot: {
+        contract_date: new Date('2025-04-01'),
+        physicalPlot: {
+          plot_number: 'A-01',
+          area_name: '合祀区画',
+        },
+        saleContractRoles: roles.map((r, idx) => ({
+          role: r.role,
+          customer: {
+            id: `customer-${idx}`,
+            name: r.name,
+            name_kana: r.name_kana,
+            phone_number: null,
+            email: null,
+            postal_code: null,
+            address: null,
+            billingInfo: null,
+          },
+        })),
+        buriedPersons: [],
+      },
+    };
+  }
+
+  beforeEach(() => {
+    responseJson = jest.fn().mockReturnThis();
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: responseJson,
+    };
+    mockRequest = { params: {}, query: {} };
+    mockNext = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  describe('getCollectiveBurialList', () => {
+    it('applicantがいればapplicantの名前を返す', async () => {
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([
+        buildBurial([
+          { role: 'applicant', name: '申込太郎', name_kana: 'モウシコミタロウ' },
+          { role: 'contractor', name: '契約花子', name_kana: 'ケイヤクハナコ' },
+        ]),
+      ]);
+      mockPrisma.collectiveBurial.count.mockResolvedValue(1);
+
+      await getCollectiveBurialList(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.data.items[0].applicantName).toBe('申込太郎');
+      expect(payload.data.items[0].applicantNameKana).toBe('モウシコミタロウ');
+    });
+
+    it('applicantがいなくてもcontractorがいればcontractorの名前を返す', async () => {
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([
+        buildBurial([{ role: 'contractor', name: '契約花子', name_kana: 'ケイヤクハナコ' }]),
+      ]);
+      mockPrisma.collectiveBurial.count.mockResolvedValue(1);
+
+      await getCollectiveBurialList(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.data.items[0].applicantName).toBe('契約花子');
+      expect(payload.data.items[0].applicantNameKana).toBe('ケイヤクハナコ');
+    });
+
+    it('どのロールも無い場合はnullを返す', async () => {
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([buildBurial([])]);
+      mockPrisma.collectiveBurial.count.mockResolvedValue(1);
+
+      await getCollectiveBurialList(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.data.items[0].applicantName).toBeNull();
+      expect(payload.data.items[0].applicantNameKana).toBeNull();
+    });
+  });
+
+  describe('getCollectiveBurialById', () => {
+    it('applicantがいなくてもcontractorをフォールバックに使う', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue(
+        buildBurial([{ role: 'contractor', name: '契約花子', name_kana: 'ケイヤクハナコ' }])
+      );
+      mockRequest.params = { id: 'cb1' };
+
+      await getCollectiveBurialById(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.data.applicant).not.toBeNull();
+      expect(payload.data.applicant.name).toBe('契約花子');
+    });
+
+    it('applicantとcontractorの両方があればapplicantを優先する', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue(
+        buildBurial([
+          { role: 'contractor', name: '契約花子', name_kana: 'ケイヤクハナコ' },
+          { role: 'applicant', name: '申込太郎', name_kana: 'モウシコミタロウ' },
+        ])
+      );
+      mockRequest.params = { id: 'cb1' };
+
+      await getCollectiveBurialById(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.data.applicant.name).toBe('申込太郎');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 合祀管理一覧で applicant ロールのみフィルタしていたため、contractor しか登録されていない区画では「-」表示になっていた
- 案A（applicant 優先 / contractor フォールバック）を採用
- `getCollectiveBurialList` / `getCollectiveBurialById` 両方に適用

## Test plan
- [x] `tests/collective-burials/collectiveBurialController.test.ts` 追加（5ケース全合格）
  - applicant がいれば applicant の名前を返す
  - applicant がいなくても contractor がいればそれを返す
  - 両方ない場合は null
  - 詳細 API でも applicant→contractor フォールバック
  - 両方ある場合は applicant 優先
- [x] ESLint/Prettier 通過
- [ ] デプロイ後に実データで契約者名が出るか確認

## Notes
レスポンスフィールド名は引き続き `applicantName` のまま（既存のAPI契約維持）。

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)