### PR TITLE
fix(test-data): physical_plot.area_name を期名（第N期）形式に修正

### DIFF
--- a/scripts/insert-test-data.js
+++ b/scripts/insert-test-data.js
@@ -91,7 +91,7 @@ async function insertTestData() {
     const physicalPlot1 = await prisma.physicalPlot.create({
       data: {
         plot_number: 'A-001',
-        area_name: '東区1期',
+        area_name: '第1期',
         area_sqm: 3.6,
         status: 'sold_out',
         notes: '墓石建立済み、定期メンテナンス対象',
@@ -102,7 +102,7 @@ async function insertTestData() {
     const physicalPlot2 = await prisma.physicalPlot.create({
       data: {
         plot_number: 'B-056',
-        area_name: '西区2期',
+        area_name: '第2期',
         area_sqm: 3.6,
         status: 'available',
         notes: null,
@@ -113,7 +113,7 @@ async function insertTestData() {
     const physicalPlot3 = await prisma.physicalPlot.create({
       data: {
         plot_number: 'C-102',
-        area_name: '南区3期',
+        area_name: '第3期',
         area_sqm: 5.0,
         status: 'sold_out',
         notes: '2025年春より利用開始予定',
@@ -124,7 +124,7 @@ async function insertTestData() {
     const physicalPlot4 = await prisma.physicalPlot.create({
       data: {
         plot_number: 'D-200',
-        area_name: '北区4期',
+        area_name: '第4期',
         area_sqm: 7.2,
         status: 'partially_sold',
         notes: '分割販売中の区画',


### PR DESCRIPTION
## Summary

- `scripts/insert-test-data.js` の `physical_plot.area_name` を `東区1期`/`西区2期`/`南区3期`/`北区4期` から `第1期`/`第2期`/`第3期`/`第4期` に修正
- 実DB（Supabase）上の 5 レコードも同規約に手動 UPDATE 済み（A-001/B-056/C-102/D-201/D-555）

## 背景

`physical_plots.area_name` は schema.prisma のコメント（`例: 1期、2期`）、`SectionNameMaster.period`、`inventoryService.ts` の `PERIODS` 定数（いずれも `第1期`/`第2期`/`第3期`/`第3期樹林部`/`第4期`）に揃える前提だが、シードデータが方角＋期名の独自形式で投入されていた。

このため区画残数管理画面で:
- 「期」欄に `東区1期` 等の不正値が表示される
- 期別サマリー（`getPeriodSummaries`）が `area_name IN ['第1期', ...]` 絞り込みでヒットせず、全期 0件になる

## 修正後 distinct 値

| | 値 |
|---|---|
| `physical_plots.area_name` | `第1期`, `第2期`, `第3期`, `第4期`, `第3期樹林部` |
| `section_name_master.period` | `第1期`, `第2期`, `第3期`, `第3期樹林部`, `第4期` |

完全一致を確認済み。

## Test plan

- [ ] `npm run dev` 起動 → `/plot-availability` で期別サマリーが正しく集計されることを目視確認
- [ ] 「期」列に `第1期` 等の正しい値が表示される
- [ ] `inventoryService` の既存テストが通る（`npm test`）

refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)