### PR TITLE
feat(yucho): restore Zengin CSV data row generation via Customer bank account

### DIFF
--- a/prisma/migrations/20260506232005_add_customer_bank_account_fields/migration.sql
+++ b/prisma/migrations/20260506232005_add_customer_bank_account_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "customers" ADD COLUMN     "account_holder" VARCHAR(100),
+ADD COLUMN     "account_number" VARCHAR(20),
+ADD COLUMN     "account_type" VARCHAR(10),
+ADD COLUMN     "bank_name" VARCHAR(50),
+ADD COLUMN     "branch_name" VARCHAR(50);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -228,6 +228,12 @@ model Customer {
   phone_number       String    @db.VarChar(11) // 電話番号
   fax_number         String?   @db.VarChar(11) // FAX番号
   email              String?   @db.VarChar(254) // メールアドレス（RFC 5321準拠）
+  // 振込先情報（ゆうちょ自動払込CSV 出力用。レガシーで0件運用、新システムで入力していく）
+  bank_name          String?   @db.VarChar(50) // 銀行名
+  branch_name        String?   @db.VarChar(50) // 支店名
+  account_type       String?   @db.VarChar(10) // 預金種目（ordinary/current/savings）
+  account_number     String?   @db.VarChar(20) // 口座番号
+  account_holder     String?   @db.VarChar(100) // 口座名義
   notes              String?   @db.Text // 備考
   staff_id           Int? // 担当スタッフFK（レガシー tancd → matant）
   legacy_danka_cd    Int? // 移行用（レガシー t_danka.danka_cd）

--- a/src/yucho/yuchoService.ts
+++ b/src/yucho/yuchoService.ts
@@ -38,26 +38,44 @@ const parseManagementFeeAmount = (value: string | null | undefined): number => {
   return isNaN(num) ? 0 : Math.round(num);
 };
 
+type PayerCustomer = {
+  id: string;
+  name: string;
+  name_kana: string;
+  bank_name: string | null;
+  branch_name: string | null;
+  account_type: string | null;
+  account_number: string | null;
+  account_holder: string | null;
+};
+
 /**
  * 契約者(役割: contractor)を最優先、無ければ申込者(applicant)を返す。
  */
-// NOTE: BillingInfoは新スキーマで廃止された。
-// 振込先情報は今後 Billing/Payment エンティティから取得する想定（Phase 3で実装）。
-// 現状は payer.billingInfo は常に null として扱う。
 const pickPayer = (
-  roles: Array<{
-    role: string;
-    customer: {
-      id: string;
-      name: string;
-      name_kana: string;
-    } | null;
-  }>
-) => {
+  roles: Array<{ role: string; customer: PayerCustomer | null }>
+): PayerCustomer | null => {
   const contractor = roles.find((r) => r.role === 'contractor' && r.customer);
   if (contractor) return contractor.customer;
   const applicant = roles.find((r) => r.role === 'applicant' && r.customer);
   return applicant?.customer ?? null;
+};
+
+/**
+ * Customer の振込先カラムから YuchoBillingItem.billingInfo を組み立てる。
+ * 主要フィールド（bank_name / branch_name / account_number）が全て空の場合は null を返す。
+ * （Zengin CSV のデータ行生成判定に使われる）
+ */
+const buildBillingInfo = (payer: PayerCustomer | null): YuchoBillingItem['billingInfo'] => {
+  if (!payer) return null;
+  if (!payer.bank_name && !payer.branch_name && !payer.account_number) return null;
+  return {
+    bankName: payer.bank_name,
+    branchName: payer.branch_name,
+    accountType: payer.account_type,
+    accountNumber: payer.account_number,
+    accountHolder: payer.account_holder,
+  };
 };
 
 /**
@@ -136,7 +154,7 @@ const fetchManagementBillingItems = async (params: FetchParams): Promise<YuchoBi
       billingStatus: fee.contractPlot.payment_status,
       scheduledDate,
       billingMonth,
-      billingInfo: null,
+      billingInfo: buildBillingInfo(payer),
     });
   }
 
@@ -208,7 +226,7 @@ const fetchCollectiveBillingItems = async (params: FetchParams): Promise<YuchoBi
         billingStatus: b.billing_status,
         scheduledDate,
         billingMonth,
-        billingInfo: null,
+        billingInfo: buildBillingInfo(payer),
       };
     });
 };

--- a/tests/yucho/yuchoController.test.ts
+++ b/tests/yucho/yuchoController.test.ts
@@ -46,13 +46,11 @@ const buildContractPlot = (overrides: Record<string, unknown> = {}) => ({
         id: 'cust-1',
         name: '山田太郎',
         name_kana: 'ヤマダタロウ',
-        billingInfo: {
-          bank_name: 'ゆうちょ銀行',
-          branch_name: '〇一八',
-          account_type: 'ordinary',
-          account_number: '1234567',
-          account_holder: 'ヤマダタロウ',
-        },
+        bank_name: 'ゆうちょ銀行',
+        branch_name: '〇一八',
+        account_type: 'ordinary',
+        account_number: '1234567',
+        account_holder: 'ヤマダタロウ',
       },
     },
   ],
@@ -199,8 +197,6 @@ describe('yuchoController', () => {
     });
 
     it('prefers contractor role over applicant when picking the payer', async () => {
-      // BillingInfoは新スキーマで廃止。Phase 3で Billing/Payment 経由で再実装予定。
-      // ここでは payer 選定（contractor 優先）が正しく行われることのみ検証する。
       mockPrisma.managementFee.findMany.mockResolvedValue([
         {
           id: 'f1',
@@ -215,6 +211,11 @@ describe('yuchoController', () => {
                   id: 'a1',
                   name: '申込太郎',
                   name_kana: 'モウシコミタロウ',
+                  bank_name: '三菱UFJ銀行',
+                  branch_name: '渋谷支店',
+                  account_type: 'ordinary',
+                  account_number: '7654321',
+                  account_holder: 'モウシコミタロウ',
                 },
               },
               {
@@ -223,6 +224,53 @@ describe('yuchoController', () => {
                   id: 'c1',
                   name: '契約花子',
                   name_kana: 'ケイヤクハナコ',
+                  bank_name: 'ゆうちょ銀行',
+                  branch_name: '〇一八',
+                  account_type: 'ordinary',
+                  account_number: '1234567',
+                  account_holder: 'ケイヤクハナコ',
+                },
+              },
+            ],
+          }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data.items[0].customerId).toBe('c1');
+      expect(payload.data.items[0].billingInfo).toEqual({
+        bankName: 'ゆうちょ銀行',
+        branchName: '〇一八',
+        accountType: 'ordinary',
+        accountNumber: '1234567',
+        accountHolder: 'ケイヤクハナコ',
+      });
+    });
+
+    it('returns billingInfo=null when payer has no bank account fields', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '10000',
+          contractPlot: buildContractPlot({
+            saleContractRoles: [
+              {
+                role: 'contractor',
+                customer: {
+                  id: 'c1',
+                  name: '契約花子',
+                  name_kana: 'ケイヤクハナコ',
+                  bank_name: null,
+                  branch_name: null,
+                  account_type: null,
+                  account_number: null,
+                  account_holder: null,
                 },
               },
             ],
@@ -250,9 +298,6 @@ describe('yuchoController', () => {
     };
 
     it('returns text/csv with attachment disposition and Zengin records', async () => {
-      // 注: BillingInfo は新スキーマで廃止されたため、現状はデータ行(2)が生成されない。
-      // Phase 3 で Billing/Payment 経由で振込先情報を取得する実装に切り替えた段階で
-      // データ行の生成を再度検証する。ここではヘッダ/トレーラ/エンドの存在のみ確認。
       mockPrisma.managementFee.findMany.mockResolvedValue([
         {
           id: 'f1',
@@ -276,6 +321,7 @@ describe('yuchoController', () => {
       const sent = (res.send as jest.Mock).mock.calls[0][0] as string;
       const lines = sent.split('\r\n').filter((l) => l.length > 0);
       expect(lines[0]?.[0]).toBe('1');
+      expect(lines.find((l) => l[0] === '2')).toBeDefined();
       expect(lines.find((l) => l[0] === '8')).toBeDefined();
       expect(lines.find((l) => l[0] === '9')).toBeDefined();
     });


### PR DESCRIPTION
Phase 2 で `BillingInfo` モデルを廃止した際、`yuchoService.ts` では振込先情報を常に `null` として扱う暫定対応で `/yucho/export` の Zengin CSV データ行(2)が生成されない状態だった。
振込先情報の置き場所として **Customer に直接振込先 5 カラムを追加する**方針を採択し、yucho の業務影響を解消する。

レガシー DB では自動振替 0 件運用だったため、新システムで顧客毎に 1 つの振込先を入力していく。Issue #106 の中の yucho 復元部分のみを切り出した PR。Billing/Payment API 本体は別 PR で対応する。

## Summary

- Customer に振込先 5 カラム (`bank_name` / `branch_name` / `account_type` / `account_number` / `account_holder`) を nullable で追加
- `yuchoService.pickPayer` を Customer 振込先情報を含めた形にし、`buildBillingInfo` で `YuchoBillingItem.billingInfo` を組み立て直す（振込先全て空なら `null` でデータ行非生成）
- `yuchoController.test.ts` の暫定対応を撤去、`accountNumber` / データ行(2) の存在検証を復活、振込先未入力時の null ケースを新規追加

## Schema

```prisma
model Customer {
  // ... 既存 ...
  bank_name      String? @db.VarChar(50)
  branch_name    String? @db.VarChar(50)
  account_type   String? @db.VarChar(10)  // ordinary/current/savings
  account_number String? @db.VarChar(20)
  account_holder String? @db.VarChar(100)
}
```

Migration: `20260506232005_add_customer_bank_account_fields` (dev DB 適用済み)

## Verification

- `npx prisma generate` / `npx prisma migrate dev` OK
- `npx tsc --noEmit`: 0 errors
- `npm test`: **735 passed / 0 failed**（前回比 +1：振込先空時の null ケース追加分）

## Out of scope（後続で対応）

- Billing / Payment エンティティの API 実装（issue #106 の主要部分）
- `@komine/types` の `Customer` 型に振込先 5 フィールド追加（フロントの振込先入力 UI と合わせて別 PR）
- フロントエンドの振込先入力 UI

## Refs

- issue #106（Phase 3 — Billing/Payment API + yucho 連携復元）— **本 PR で yucho 連携の復元のみ対応**

## Test plan

- [x] CI（lint / format / swagger / test / coverage）グリーン
- [x] 本番 DB に migration `20260506232005_add_customer_bank_account_fields` を `prisma migrate deploy` で適用
- [x] dev 環境で Customer の振込先カラムに値を入れて `/api/v1/yucho/export` を叩き、Zengin CSV のデータ行(2)が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)