### PR TITLE
feat: add RelationshipMaster API (Closes #109)

### DIFF
--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -319,6 +319,42 @@ export const getSectionNameMaster = async (_req: Request, res: Response) => {
 };
 
 /**
+ * 続柄マスタ取得
+ * GET /api/v1/masters/relationship
+ */
+export const getRelationshipMaster = async (_req: Request, res: Response) => {
+  try {
+    const data = await prisma.relationshipMaster.findMany({
+      where: { is_active: true },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    const formatted: MasterData[] = data.map((item) => ({
+      id: item.id,
+      code: item.code,
+      name: item.name,
+      description: item.description,
+      sortOrder: item.sort_order,
+      isActive: item.is_active,
+    }));
+
+    res.status(200).json({
+      success: true,
+      data: formatted,
+    });
+  } catch (error) {
+    getRequestLogger().error({ err: error }, 'Error fetching relationship master');
+    res.status(500).json({
+      success: false,
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: '続柄マスタの取得に失敗しました',
+      },
+    });
+  }
+};
+
+/**
  * マスタタイプからPrismaモデルデリゲートを取得
  */
 const getMasterDelegate = (masterType: MasterType) => {
@@ -331,6 +367,7 @@ const getMasterDelegate = (masterType: MasterType) => {
     'recipient-type': prisma.recipientTypeMaster,
     'construction-type': prisma.constructionTypeMaster,
     'section-name': prisma.sectionNameMaster,
+    relationship: prisma.relationshipMaster,
   };
   return delegateMap[masterType];
 };
@@ -344,6 +381,7 @@ const masterTypeLabels: Record<MasterType, string> = {
   'recipient-type': '受取人タイプ',
   'construction-type': '工事タイプ',
   'section-name': '区画名',
+  relationship: '続柄',
 };
 
 /**
@@ -663,6 +701,7 @@ export const getAllMasters = async (_req: Request, res: Response) => {
       recipientType,
       constructionType,
       sectionName,
+      relationship,
     ] = await Promise.all([
       prisma.cemeteryTypeMaster.findMany({
         where: { is_active: true },
@@ -693,6 +732,10 @@ export const getAllMasters = async (_req: Request, res: Response) => {
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
       prisma.sectionNameMaster.findMany({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.relationshipMaster.findMany({
         where: { is_active: true },
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
@@ -763,6 +806,14 @@ export const getAllMasters = async (_req: Request, res: Response) => {
           code: item.code,
           name: item.name,
           period: item.period,
+          description: item.description,
+          sortOrder: item.sort_order,
+          isActive: item.is_active,
+        })),
+        relationship: relationship.map((item) => ({
+          id: item.id,
+          code: item.code,
+          name: item.name,
           description: item.description,
           sortOrder: item.sort_order,
           isActive: item.is_active,

--- a/src/masters/masterRoutes.ts
+++ b/src/masters/masterRoutes.ts
@@ -8,6 +8,7 @@ import {
   getRecipientTypeMaster,
   getConstructionTypeMaster,
   getSectionNameMaster,
+  getRelationshipMaster,
   getAllMasters,
   createMaster,
   updateMaster,
@@ -89,6 +90,14 @@ router.get(
   authenticate,
   checkApiPermission(),
   withLogging('Masters', 'getSectionNameMaster', getSectionNameMaster)
+);
+
+// 続柄マスタ
+router.get(
+  '/relationship',
+  authenticate,
+  checkApiPermission(),
+  withLogging('Masters', 'getRelationshipMaster', getRelationshipMaster)
 );
 
 // マスタデータ CRUD（汎用）

--- a/src/validations/masterValidation.ts
+++ b/src/validations/masterValidation.ts
@@ -40,6 +40,7 @@ export const VALID_MASTER_TYPES = [
   'recipient-type',
   'construction-type',
   'section-name',
+  'relationship',
 ] as const;
 
 export type MasterType = (typeof VALID_MASTER_TYPES)[number];

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1638,6 +1638,32 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v1/masters/relationship:
+    get:
+      tags:
+        - Masters
+      summary: 続柄マスタ一覧取得
+      description: 有効な続柄マスタデータを表示順で取得（レガシー sykbnn KBNNO=2009 由来）
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 続柄マスタ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RelationshipMaster"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v1/masters/all:
     get:
       tags:
@@ -1664,6 +1690,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/SectionNameMaster"
+                      relationship:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/RelationshipMaster"
         "401":
           $ref: "#/components/responses/Unauthorized"
 
@@ -1921,6 +1951,29 @@ components:
         period:
           type: string
           example: "第1期"
+        description:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+          nullable: true
+          example: 1
+        isActive:
+          type: boolean
+          example: true
+
+    RelationshipMaster:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        code:
+          type: string
+          example: "spouse"
+        name:
+          type: string
+          example: "配偶者"
         description:
           type: string
           nullable: true

--- a/tests/masters/masterController.test.ts
+++ b/tests/masters/masterController.test.ts
@@ -104,6 +104,11 @@ const mockUpdateTypeData = [
   { id: 2, code: 'change', name: '変更', description: null, sort_order: 2, is_active: true },
 ];
 
+const mockRelationshipData = [
+  { id: 1, code: 'spouse', name: '配偶者', description: null, sort_order: 1, is_active: true },
+  { id: 2, code: 'child', name: '子', description: null, sort_order: 2, is_active: true },
+];
+
 // モックプリズマインスタンスの作成
 const mockPrisma: any = {
   cemeteryTypeMaster: {
@@ -130,6 +135,9 @@ const mockPrisma: any = {
   sectionNameMaster: {
     findMany: jest.fn(),
   },
+  relationshipMaster: {
+    findMany: jest.fn(),
+  },
 };
 
 // PrismaClientをモック化
@@ -147,6 +155,7 @@ import {
   getRecipientTypeMaster,
   getConstructionTypeMaster,
   getSectionNameMaster,
+  getRelationshipMaster,
   getAllMasters,
 } from '../../src/masters/masterController';
 
@@ -569,6 +578,56 @@ describe('Master Controller', () => {
     });
   });
 
+  describe('getRelationshipMaster', () => {
+    it('続柄マスタデータを正しく取得・フォーマットすること', async () => {
+      mockPrisma.relationshipMaster.findMany.mockResolvedValue(mockRelationshipData);
+
+      await getRelationshipMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.relationshipMaster.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          {
+            id: 1,
+            code: 'spouse',
+            name: '配偶者',
+            description: null,
+            sortOrder: 1,
+            isActive: true,
+          },
+          {
+            id: 2,
+            code: 'child',
+            name: '子',
+            description: null,
+            sortOrder: 2,
+            isActive: true,
+          },
+        ],
+      });
+    });
+
+    it('エラーが発生した場合、500エラーを返すこと', async () => {
+      mockPrisma.relationshipMaster.findMany.mockRejectedValue(new Error('Database error'));
+
+      await getRelationshipMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: false,
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: '続柄マスタの取得に失敗しました',
+        },
+      });
+    });
+  });
+
   describe('getAllMasters', () => {
     it('全マスタデータを一括取得できること', async () => {
       // すべてのマスターテーブルのモックを設定
@@ -580,6 +639,7 @@ describe('Master Controller', () => {
       mockPrisma.recipientTypeMaster.findMany.mockResolvedValue(mockRecipientTypeData);
       mockPrisma.constructionTypeMaster.findMany.mockResolvedValue(mockConstructionTypeData);
       mockPrisma.sectionNameMaster.findMany.mockResolvedValue(mockSectionNameData);
+      mockPrisma.relationshipMaster.findMany.mockResolvedValue(mockRelationshipData);
 
       await getAllMasters(mockRequest as Request, mockResponse as Response);
 
@@ -596,11 +656,15 @@ describe('Master Controller', () => {
       expect(jsonCall.data.recipientType).toHaveLength(2);
       expect(jsonCall.data.constructionType).toHaveLength(2);
       expect(jsonCall.data.sectionName).toHaveLength(2);
+      expect(jsonCall.data.relationship).toHaveLength(2);
 
       // 特殊フィールドのテスト（taxRate）
       expect(jsonCall.data.taxType[0].taxRate).toBe('10');
       // 特殊フィールドのテスト（period）
       expect(jsonCall.data.sectionName[0].period).toBe('第1期');
+      // 続柄
+      expect(jsonCall.data.relationship[0].code).toBe('spouse');
+      expect(jsonCall.data.relationship[0].name).toBe('配偶者');
     });
 
     it('エラーが発生した場合、500エラーを返すこと', async () => {

--- a/tests/masters/masterCrud.test.ts
+++ b/tests/masters/masterCrud.test.ts
@@ -64,6 +64,18 @@ const mockPrisma: any = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+  sectionNameMaster: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  relationshipMaster: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
 };
 
 jest.mock('@prisma/client', () => ({
@@ -125,6 +137,36 @@ describe('Master CRUD Controller', () => {
         },
         message: '墓地タイプマスタを作成しました',
       });
+    });
+
+    it('続柄マスタを正常に作成できること', async () => {
+      mockRequest.params = { masterType: 'relationship' };
+      mockRequest.body = { code: 'sibling', name: '兄弟姉妹', sortOrder: 5 };
+
+      mockPrisma.relationshipMaster.create.mockResolvedValue({
+        id: 5,
+        code: 'sibling',
+        name: '兄弟姉妹',
+        description: null,
+        sort_order: 5,
+        is_active: true,
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+
+      await createMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.relationshipMaster.create).toHaveBeenCalledWith({
+        data: {
+          code: 'sibling',
+          name: '兄弟姉妹',
+          sort_order: 5,
+          is_active: true,
+        },
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      const jsonCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(jsonCall.message).toBe('続柄マスタを作成しました');
     });
 
     it('税タイプマスタでtaxRateを含めて作成できること', async () => {

--- a/tests/masters/masterRoutes.test.ts
+++ b/tests/masters/masterRoutes.test.ts
@@ -28,6 +28,12 @@ jest.mock('../../src/masters/masterController', () => ({
   getConstructionTypeMaster: jest.fn((req, res) =>
     res.status(200).json({ success: true, controller: 'getConstructionTypeMaster' })
   ),
+  getSectionNameMaster: jest.fn((req, res) =>
+    res.status(200).json({ success: true, controller: 'getSectionNameMaster' })
+  ),
+  getRelationshipMaster: jest.fn((req, res) =>
+    res.status(200).json({ success: true, controller: 'getRelationshipMaster' })
+  ),
   getAllMasters: jest.fn((req, res) =>
     res.status(200).json({ success: true, controller: 'getAllMasters' })
   ),
@@ -173,6 +179,20 @@ describe('Master Routes', () => {
       expect(response.body.success).toBe(true);
       expect(response.body.controller).toBe('getConstructionTypeMaster');
       expect(mockMasterController.getConstructionTypeMaster).toHaveBeenCalledTimes(1);
+      expect(mockAuthMiddleware.authenticate).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/v1/masters/relationship', () => {
+    it('should handle getRelationshipMaster request', async () => {
+      const response = await request(app)
+        .get('/api/v1/masters/relationship')
+        .set('Authorization', 'Bearer token');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.controller).toBe('getRelationshipMaster');
+      expect(mockMasterController.getRelationshipMaster).toHaveBeenCalledTimes(1);
       expect(mockAuthMiddleware.authenticate).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
- New endpoint `GET /api/v1/masters/relationship` — returns active 続柄 records ordered by `sort_order`/`id`, formatted like the other simple masters (`{id, code, name, description, sortOrder, isActive}`).
- `'relationship'` added to `VALID_MASTER_TYPES`, so the existing generic CRUD endpoints (`POST/PUT/DELETE /masters/:masterType`) work for it too — admin only via the existing `/masters/*` permission rule.
- `getAllMasters` now includes a `relationship` collection in its response.
- `swagger.yaml`: added the new path and `RelationshipMaster` schema; `/masters/all` documents the new key.
- Tests: `getRelationshipMaster` success/error, route `GET /relationship`, `createMaster` with `'relationship'`. All 779 tests pass.

## Why
Phase 2 added the `RelationshipMaster` model (legacy `sykbnn` KBNNO=2009 — 35 続柄 entries) to back `BuriedPerson.relationship` and `FamilyContact.relationship`. Phase 3 wires the read/CRUD API.

## Out of scope
- **Seed data** for the 35 entries — tracked by #46.
- **Frontend select 化** of relationship fields in `plot-form` and master fetch hook — split out per the issue's "別 issue 化も可" note; backend is shippable on its own.

## Pairs with
- @komine/types `feature/relationship-master-types` — adds `RelationshipMaster` + `MASTER_TYPES`.

## Test plan
- [x] `npm test` — 779 / 779 pass
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm run build` — passes
- [x] `npm run swagger:validate` — valid
- [ ] Verify the new endpoint via `/api-docs` after deploy

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)