### PR TITLE
feat: make FamilyContact.address and phone_number nullable

### DIFF
--- a/prisma/migrations/20260512030437_family_contact_nullable_address_phone/migration.sql
+++ b/prisma/migrations/20260512030437_family_contact_nullable_address_phone/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "family_contacts" ALTER COLUMN "address" DROP NOT NULL,
+ALTER COLUMN "phone_number" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -419,8 +419,8 @@ model FamilyContact {
   birth_date             DateTime?    @db.Date
   relationship           String       @db.VarChar(50)
   postal_code            String?      @db.VarChar(7) // 郵便番号
-  address                String       @db.VarChar(200)
-  phone_number           String       @db.VarChar(11)
+  address                String?      @db.VarChar(200) // レガシーDBで41%欠損のため nullable
+  phone_number           String?      @db.VarChar(11) // レガシーDBで3%欠損のため nullable
   phone_number_2         String?      @db.VarChar(15) // 電話番号2
   fax_number             String?      @db.VarChar(11)
   email                  String?      @db.VarChar(254) // メールアドレス（RFC 5321準拠）


### PR DESCRIPTION
## Summary

- レガシー DB 移行のための schema 修正。`FamilyContact.address` と `phone_number` を nullable 化。
- D-2 SQL（`reien.t_family`、2,744件）で住所 41.1% / 電話 3.1% が欠損していたため、移行スクリプトが空文字埋めなしでそのまま取り込めるようにする。
- Prisma migration `20260512030437_family_contact_nullable_address_phone` を追加。dev DB は適用済み。
- 既存テスト 779 件すべてグリーン。

## Changes

- `prisma/schema.prisma`: `FamilyContact.address` と `phone_number` を `String?` に変更
- `prisma/migrations/...`: `ALTER TABLE family_contacts ALTER COLUMN ... DROP NOT NULL`

## Related Repos

- @komine/types: zaitsu82/komine-types#PR (feature/family-contact-nullable)
- Frontend: zaitsu82/komine-crm-frontend#PR (feature/family-contact-nullable)

## Background

詳細は `query_result/MIGRATION_STATUS.md` の D-2 結果（2026-05-10 取得）参照。Customer / WorkInfo は D-1 で全件埋まっていたため対象外。

## Test plan

- [x] `npm test` グリーン（42 suites / 779 tests）
- [x] `npx prisma migrate dev` で dev DB 適用済み
- [ ] CI が通ること
- [ ] @komine/types と frontend の PR も併せてマージ

Refs #107