### PR TITLE
feat: contract restoration (terminated→active) — service + API + tests

### DIFF
--- a/src/plots/controllers/index.ts
+++ b/src/plots/controllers/index.ts
@@ -10,6 +10,7 @@ export { bulkCreatePlots } from './bulkCreatePlots';
 export { bulkUpdatePlots } from './bulkUpdatePlots';
 export { updatePlot } from './updatePlot';
 export { deletePlot } from './deletePlot';
+export { restoreContract } from './restoreContract';
 export { getPlotContracts } from './getPlotContracts';
 export { createPlotContract } from './createPlotContract';
 export { getPlotInventory } from './getPlotInventory';

--- a/src/plots/controllers/restoreContract.ts
+++ b/src/plots/controllers/restoreContract.ts
@@ -1,0 +1,75 @@
+/**
+ * 契約復活エンドポイント
+ * POST /api/v1/plots/:id/restore
+ *
+ * terminated 状態の ContractPlot を active に戻す（誤操作リカバリ用）。
+ * reason は履歴に記録するため必須。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { ContractStatus } from '@prisma/client';
+import prisma from '../../db/prisma';
+import { NotFoundError, ConflictError } from '../../middleware/errorHandler';
+import { recordEntityUpdated } from '../services/historyService';
+import { contractStatusService } from '../services/contractStatusService';
+import type { RestoreContractRequest } from '../../validations/plotValidation';
+
+export const restoreContract = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id = (req.params as Record<string, string>)['id'] as string;
+    const { reason } = req.body as RestoreContractRequest;
+
+    const contractPlot = await prisma.contractPlot.findUnique({
+      where: { id, deleted_at: null },
+    });
+
+    if (!contractPlot) {
+      throw new NotFoundError('指定された契約区画が見つかりません');
+    }
+
+    const beforeStatus = contractPlot.contract_status;
+
+    // 復活エンドポイントは terminated 状態のみ受け付ける（vacant→active 等は通常 PUT を使う）
+    if (beforeStatus !== ContractStatus.terminated) {
+      throw new ConflictError(
+        `現在のステータス '${beforeStatus}' から復活はできません（terminated のみ復活可能）`
+      );
+    }
+
+    // 復活遷移＋reason 必須の整合性を保証
+    contractStatusService.validateTransitionWithReason(beforeStatus, ContractStatus.active, reason);
+
+    await prisma.$transaction(async (tx) => {
+      await tx.contractPlot.update({
+        where: { id },
+        data: { contract_status: ContractStatus.active },
+      });
+
+      await recordEntityUpdated(tx, {
+        entityType: 'ContractPlot',
+        entityId: id,
+        physicalPlotId: contractPlot.physical_plot_id,
+        contractPlotId: id,
+        beforeRecord: { contract_status: beforeStatus },
+        afterRecord: { contract_status: ContractStatus.active },
+        changeReason: reason,
+        req,
+      });
+    });
+
+    res.status(200).json({
+      success: true,
+      data: {
+        message: '契約区画を復活しました',
+        id,
+        contractStatus: ContractStatus.active,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/plots/plotRoutes.ts
+++ b/src/plots/plotRoutes.ts
@@ -7,6 +7,7 @@ import {
   bulkUpdatePlots,
   updatePlot,
   deletePlot,
+  restoreContract,
   getPlotContracts,
   createPlotContract,
   getPlotInventory,
@@ -26,6 +27,7 @@ import {
   createPlotSchema,
   updatePlotSchema,
   createPlotContractSchema,
+  restoreContractSchema,
 } from '../validations/plotValidation';
 import {
   inventorySummaryQuerySchema,
@@ -139,6 +141,15 @@ router.delete(
   requirePermission(['manager', 'admin']),
   validate({ params: plotIdParamsSchema }),
   withLogging('Plots', 'deletePlot', deletePlot)
+);
+
+// 契約復活（terminated → active、誤操作リカバリ用）
+router.post(
+  '/:id/restore',
+  authenticate,
+  requirePermission(['operator', 'manager', 'admin']),
+  validate({ params: plotIdParamsSchema, body: restoreContractSchema }),
+  withLogging('Plots', 'restoreContract', restoreContract)
 );
 
 // 物理区画の契約一覧取得

--- a/src/plots/services/contractStatusService.ts
+++ b/src/plots/services/contractStatusService.ts
@@ -8,21 +8,19 @@
  *   active     — 契約有効
  *   terminated — 契約終了（解約・期限切れ・名義変更後など、理由を問わない）
  *
+ * 通常遷移: vacant → active → terminated（一方向）
+ * 例外遷移: terminated → active（復活）— 誤操作リカバリ用、reason 必須
+ *
  * 注: 旧7ステート（draft/reserved/suspended/cancelled/transferred）は廃止。
  *     旧 reserved/draft 相当は active に統合、cancelled/transferred は terminated に統合。
  */
 
 import { ContractStatus, PaymentStatus } from '@prisma/client';
 
-/**
- * 許可される状態遷移のマップ
- * key: 現在のステータス
- * value: 遷移可能なステータスの配列
- */
 const ALLOWED_TRANSITIONS: Record<ContractStatus, ContractStatus[]> = {
   [ContractStatus.vacant]: [ContractStatus.active],
   [ContractStatus.active]: [ContractStatus.terminated],
-  [ContractStatus.terminated]: [],
+  [ContractStatus.terminated]: [ContractStatus.active],
 };
 
 /**
@@ -112,6 +110,17 @@ export class PaymentStatusMismatchError extends Error {
 }
 
 /**
+ * 復活遷移の reason 未指定エラー
+ * terminated → active の遷移時、誰がいつ何の理由で復活させたか追跡するため reason 必須
+ */
+export class RestoreReasonRequiredError extends Error {
+  constructor(message?: string) {
+    super(message || 'Reason is required when restoring a terminated contract to active');
+    this.name = 'RestoreReasonRequiredError';
+  }
+}
+
+/**
  * 契約ステータス遷移サービス
  */
 export const contractStatusService = {
@@ -185,7 +194,40 @@ export const contractStatusService = {
   },
 
   /**
-   * 契約がファイナル状態（変更不可）かどうか
+   * 復活遷移（terminated → active）かどうか判定
+   */
+  isRestoreTransition(from: ContractStatus, to: ContractStatus): boolean {
+    return from === ContractStatus.terminated && to === ContractStatus.active;
+  },
+
+  /**
+   * 復活遷移の reason をバリデート
+   * 空文字 / 空白のみは RestoreReasonRequiredError をスロー
+   */
+  validateRestoreReason(reason: string | null | undefined): void {
+    if (!reason || reason.trim().length === 0) {
+      throw new RestoreReasonRequiredError();
+    }
+  },
+
+  /**
+   * 復活遷移を含めた一括バリデーション
+   * 復活遷移の場合のみ reason 必須をチェックする
+   */
+  validateTransitionWithReason(
+    from: ContractStatus,
+    to: ContractStatus,
+    reason: string | null | undefined
+  ): void {
+    this.validateTransition(from, to);
+    if (this.isRestoreTransition(from, to)) {
+      this.validateRestoreReason(reason);
+    }
+  },
+
+  /**
+   * 契約がファイナル状態（通常運用での終端）かどうか
+   * 注: terminated は通常運用ではファイナルだが、誤操作リカバリで active へ復活可能
    */
   isFinalStatus(status: ContractStatus): boolean {
     return status === ContractStatus.terminated;

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -274,6 +274,20 @@ export const createPlotContractSchema = z.object({
 });
 
 /**
+ * 契約復活リクエストのバリデーションスキーマ
+ * POST /plots/:id/restore
+ * terminated 状態の ContractPlot を active に戻す（誤操作リカバリ用）。
+ * reason は履歴に記録するため必須（空白のみは拒否）。
+ */
+export const restoreContractSchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .min(1, '復活理由は必須です')
+    .max(200, '復活理由は200文字以内で入力してください'),
+});
+
+/**
  * 型エクスポート
  */
 export type PlotSearchQuery = z.infer<typeof plotSearchQuerySchema>;
@@ -281,6 +295,7 @@ export type PlotIdParams = z.infer<typeof plotIdParamsSchema>;
 export type CreatePlotRequest = z.infer<typeof createPlotSchema>;
 export type UpdatePlotRequest = z.infer<typeof updatePlotSchema>;
 export type CreatePlotContractRequest = z.infer<typeof createPlotContractSchema>;
+export type RestoreContractRequest = z.infer<typeof restoreContractSchema>;
 
 // dateSchema も従来通り再エクスポート（他モジュールからの参照互換性維持）
 export { dateSchema };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -603,6 +603,80 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/plots/{id}/restore:
+    post:
+      tags:
+        - Plots
+      summary: 契約区画の復活（terminated → active）
+      description: |
+        terminated 状態の契約区画を active に戻す（誤操作リカバリ用）。
+        reason は履歴に記録するため必須（1〜200文字、空白のみは不可）。
+        現在のステータスが terminated でない場合は 409 を返す。
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: 契約区画ID（UUID）
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 200
+                  description: 復活理由（履歴に記録される）
+                  example: 担当者の入力ミスのため復活
+      responses:
+        "200":
+          description: 復活成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        example: 契約区画を復活しました
+                      id:
+                        type: string
+                        format: uuid
+                      contractStatus:
+                        type: string
+                        enum: [vacant, active, terminated]
+                        example: active
+        "400":
+          description: バリデーションエラー（reason 欠落 / 長すぎ等）
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: 現在のステータスが terminated でないため復活不可
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/v1/plots/{id}/contracts:
     get:
       tags:

--- a/tests/plots/controllers/restoreContract.test.ts
+++ b/tests/plots/controllers/restoreContract.test.ts
@@ -1,0 +1,234 @@
+/**
+ * restoreContract コントローラのテスト
+ * POST /api/v1/plots/:id/restore
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma: any = {
+  contractPlot: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  history: {
+    create: jest.fn(),
+  },
+  $transaction: jest.fn((callback: any) => Promise.resolve(callback(mockPrisma))),
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  ContractStatus: {
+    vacant: 'vacant',
+    active: 'active',
+    terminated: 'terminated',
+  },
+  PaymentStatus: {
+    unpaid: 'unpaid',
+    partial_paid: 'partial_paid',
+    paid: 'paid',
+    overdue: 'overdue',
+    refunded: 'refunded',
+    cancelled: 'cancelled',
+  },
+}));
+
+const mockRecordEntityUpdated = jest.fn();
+jest.mock('../../../src/plots/services/historyService', () => ({
+  recordEntityUpdated: (...args: unknown[]) => mockRecordEntityUpdated(...args),
+}));
+
+import { restoreContract } from '../../../src/plots/controllers/restoreContract';
+import { NotFoundError, ConflictError } from '../../../src/middleware/errorHandler';
+
+const buildRes = (): Response => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  return res;
+};
+
+const buildReq = (overrides: Partial<Request> = {}): Request => {
+  const req = {
+    params: { id: 'cp-1' },
+    body: { reason: '誤って解約したため復活' },
+    user: {
+      id: 1,
+      email: 'staff@example.com',
+      name: 'Test Staff',
+      role: 'operator',
+      is_active: true,
+      supabase_uid: 'sup-1',
+    },
+    ip: '127.0.0.1',
+    get: jest.fn().mockReturnValue(undefined),
+    ...overrides,
+  } as unknown as Request;
+  return req;
+};
+
+describe('restoreContract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('成功ケース', () => {
+    it('terminated → active への復活が成功し、履歴も記録される', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'terminated',
+        deleted_at: null,
+      });
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        id: 'cp-1',
+        contract_status: 'active',
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      expect(mockPrisma.contractPlot.update).toHaveBeenCalledWith({
+        where: { id: 'cp-1' },
+        data: { contract_status: 'active' },
+      });
+      expect(mockRecordEntityUpdated).toHaveBeenCalledTimes(1);
+      const historyCall = mockRecordEntityUpdated.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(historyCall).toMatchObject({
+        entityType: 'ContractPlot',
+        entityId: 'cp-1',
+        physicalPlotId: 'pp-1',
+        contractPlotId: 'cp-1',
+        beforeRecord: { contract_status: 'terminated' },
+        afterRecord: { contract_status: 'active' },
+        changeReason: '誤って解約したため復活',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          message: '契約区画を復活しました',
+          id: 'cp-1',
+          contractStatus: 'active',
+        },
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('失敗ケース', () => {
+    it('存在しない ContractPlot は NotFoundError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(null);
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = (next as jest.Mock).mock.calls[0]?.[0] as Error;
+      expect(err).toBeInstanceOf(NotFoundError);
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+      expect(mockRecordEntityUpdated).not.toHaveBeenCalled();
+    });
+
+    it('active 状態からの復活は ConflictError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'active',
+        deleted_at: null,
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = (next as jest.Mock).mock.calls[0]?.[0] as Error;
+      expect(err).toBeInstanceOf(ConflictError);
+      expect((err as Error).message).toContain('terminated のみ復活可能');
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+      expect(mockRecordEntityUpdated).not.toHaveBeenCalled();
+    });
+
+    it('vacant 状態からの復活も ConflictError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'vacant',
+        deleted_at: null,
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = (next as jest.Mock).mock.calls[0]?.[0] as Error;
+      expect(err).toBeInstanceOf(ConflictError);
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+    });
+
+    it('DB エラーは next に伝播される', async () => {
+      mockPrisma.contractPlot.findUnique.mockRejectedValue(new Error('connection lost'));
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = (next as jest.Mock).mock.calls[0]?.[0] as Error;
+      expect(err.message).toBe('connection lost');
+    });
+  });
+
+  describe('履歴記録の詳細', () => {
+    it('reason がトリム後の値で履歴に記録される（zod schema 前提）', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'terminated',
+        deleted_at: null,
+      });
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        id: 'cp-1',
+        contract_status: 'active',
+      });
+
+      const req = buildReq({ body: { reason: '担当者の入力ミス - リカバリ' } } as Partial<Request>);
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      const historyCall = mockRecordEntityUpdated.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(historyCall['changeReason']).toBe('担当者の入力ミス - リカバリ');
+    });
+  });
+});

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -85,6 +85,11 @@ jest.mock('@prisma/client', () => ({
     partial: 'partial',
     paid: 'paid',
   },
+  ContractStatus: {
+    vacant: 'vacant',
+    active: 'active',
+    terminated: 'terminated',
+  },
   ContractRole: {
     applicant: 'applicant',
     contractor: 'contractor',

--- a/tests/plots/services/contractStatusService.test.ts
+++ b/tests/plots/services/contractStatusService.test.ts
@@ -8,6 +8,7 @@ import {
   ContractStatusTransitionError,
   ContractOperationNotAllowedError,
   PaymentStatusMismatchError,
+  RestoreReasonRequiredError,
   ContractOperation,
 } from '../../../src/plots/services/contractStatusService';
 
@@ -41,11 +42,11 @@ describe('contractStatusService', () => {
       });
     });
 
-    describe('terminated は最終状態', () => {
-      it('terminated → active は許可されない', () => {
+    describe('terminated からの遷移（復活遷移）', () => {
+      it('terminated → active は許可される（誤操作リカバリ用）', () => {
         expect(
           contractStatusService.canTransition(ContractStatus.terminated, ContractStatus.active)
-        ).toBe(false);
+        ).toBe(true);
       });
 
       it('terminated → vacant は許可されない', () => {
@@ -63,9 +64,15 @@ describe('contractStatusService', () => {
       ).not.toThrow();
     });
 
-    it('許可されない遷移は ContractStatusTransitionError を投げる', () => {
+    it('復活遷移（terminated → active）はエラーを投げない', () => {
       expect(() =>
         contractStatusService.validateTransition(ContractStatus.terminated, ContractStatus.active)
+      ).not.toThrow();
+    });
+
+    it('許可されない遷移は ContractStatusTransitionError を投げる', () => {
+      expect(() =>
+        contractStatusService.validateTransition(ContractStatus.terminated, ContractStatus.vacant)
       ).toThrow(ContractStatusTransitionError);
     });
   });
@@ -83,8 +90,104 @@ describe('contractStatusService', () => {
       ]);
     });
 
-    it('terminated は遷移先なし', () => {
-      expect(contractStatusService.getAllowedTransitions(ContractStatus.terminated)).toEqual([]);
+    it('terminated は active のみに遷移可能（復活）', () => {
+      expect(contractStatusService.getAllowedTransitions(ContractStatus.terminated)).toEqual([
+        ContractStatus.active,
+      ]);
+    });
+  });
+
+  describe('isRestoreTransition', () => {
+    it('terminated → active は復活遷移', () => {
+      expect(
+        contractStatusService.isRestoreTransition(ContractStatus.terminated, ContractStatus.active)
+      ).toBe(true);
+    });
+
+    it('vacant → active は復活遷移ではない', () => {
+      expect(
+        contractStatusService.isRestoreTransition(ContractStatus.vacant, ContractStatus.active)
+      ).toBe(false);
+    });
+
+    it('active → terminated は復活遷移ではない', () => {
+      expect(
+        contractStatusService.isRestoreTransition(ContractStatus.active, ContractStatus.terminated)
+      ).toBe(false);
+    });
+  });
+
+  describe('validateRestoreReason', () => {
+    it('非空文字の reason はエラーを投げない', () => {
+      expect(() =>
+        contractStatusService.validateRestoreReason('誤って解約したため復活')
+      ).not.toThrow();
+    });
+
+    it('空文字は RestoreReasonRequiredError を投げる', () => {
+      expect(() => contractStatusService.validateRestoreReason('')).toThrow(
+        RestoreReasonRequiredError
+      );
+    });
+
+    it('null は RestoreReasonRequiredError を投げる', () => {
+      expect(() => contractStatusService.validateRestoreReason(null)).toThrow(
+        RestoreReasonRequiredError
+      );
+    });
+
+    it('undefined は RestoreReasonRequiredError を投げる', () => {
+      expect(() => contractStatusService.validateRestoreReason(undefined)).toThrow(
+        RestoreReasonRequiredError
+      );
+    });
+
+    it('空白のみは RestoreReasonRequiredError を投げる', () => {
+      expect(() => contractStatusService.validateRestoreReason('   ')).toThrow(
+        RestoreReasonRequiredError
+      );
+    });
+  });
+
+  describe('validateTransitionWithReason', () => {
+    it('通常遷移は reason なしでもエラーを投げない', () => {
+      expect(() =>
+        contractStatusService.validateTransitionWithReason(
+          ContractStatus.vacant,
+          ContractStatus.active,
+          null
+        )
+      ).not.toThrow();
+    });
+
+    it('復活遷移で reason ありはエラーを投げない', () => {
+      expect(() =>
+        contractStatusService.validateTransitionWithReason(
+          ContractStatus.terminated,
+          ContractStatus.active,
+          '誤って解約したため復活'
+        )
+      ).not.toThrow();
+    });
+
+    it('復活遷移で reason なしは RestoreReasonRequiredError を投げる', () => {
+      expect(() =>
+        contractStatusService.validateTransitionWithReason(
+          ContractStatus.terminated,
+          ContractStatus.active,
+          null
+        )
+      ).toThrow(RestoreReasonRequiredError);
+    });
+
+    it('許可されない遷移は ContractStatusTransitionError を投げる', () => {
+      expect(() =>
+        contractStatusService.validateTransitionWithReason(
+          ContractStatus.terminated,
+          ContractStatus.vacant,
+          'whatever'
+        )
+      ).toThrow(ContractStatusTransitionError);
     });
   });
 


### PR DESCRIPTION
## Summary

#110 の業務確認結果に基づき、`contractStatusService` に terminated→active の復活遷移を追加し、`POST /api/v1/plots/:id/restore` エンドポイントを実装。reason は履歴に記録（誰がいつ何の理由で復活させたか追跡可能）。

- ✅ サービス層: `ALLOWED_TRANSITIONS[terminated] = [active]`、`RestoreReasonRequiredError`、`validateRestoreReason` / `validateTransitionWithReason` / `isRestoreTransition` を追加
- ✅ API: `POST /api/v1/plots/:id/restore`（operator/manager/admin）、Zod 検証で reason 1〜200 文字必須・空白のみ拒否
- ✅ 履歴記録: `recordEntityUpdated` 経由で ContractPlot の `contract_status` の before/after と `change_reason` を保存
- ✅ swagger.yaml にエンドポイント追加
- ✅ テスト: contractStatusService 25→40 件、restoreContract.test.ts 6 件新規、plotController.test.ts のモック更新
- ✅ 全テスト **798/798 グリーン**、lint 0 errors、format OK、`swagger:validate` 通過

## Background

#110 の業務確認で「terminated 区画の誤操作リカバリ用に復活操作が欲しい」との回答を取得。詳細は [#110 のコメント](https://github.com/zaitsu82/komine-crm-backend/issues/110#issuecomment-4431311094) 参照。

## API spec

```
POST /api/v1/plots/:id/restore
Body: { reason: string }  // 1〜200 文字、空白のみは拒否
```

| status | 条件 |
|---|---|
| 200 | terminated → active 復活成功、`{ message, id, contractStatus: "active" }` |
| 400 | reason 欠落 / 長すぎ / 空白のみ |
| 404 | ContractPlot が存在しない or 論理削除済み |
| 409 | 現在のステータスが terminated でない |

## Design notes

- **復活エンドポイントは terminated 専用**: vacant→active のような通常遷移は `PUT /plots/:id` を使う想定。restoreContract は誤操作リカバリ専用なので「terminated 以外は 409」と明示
- `isFinalStatus(terminated)` / `isEditable(terminated)` は **通常運用での意味を維持**（true / false のまま）。復活は例外操作なので、通常 UI からは編集不可・ファイナル扱いとし、復活専用フローで遷移させる前提
- `validateTransitionWithReason` は通常遷移では reason 不要、復活遷移時のみ reason 必須を強制（呼び出し側を間違えても controller 層で守る）
- 履歴は `recordEntityUpdated` の汎用ヘルパーを使い、entity_type=ContractPlot / action_type=UPDATE / changed_fields=[contract_status] / change_reason=入力 reason で記録

## Out of Scope (別 PR)

- フロントエンドの復活ボタン UI（フロントリポ）
- `@komine/types` への `RestoreContractRequest` 型追加（フロント PR 時に必要なら）

## Test plan

- [x] `npm test -- tests/plots/services/contractStatusService.test.ts` — 40/40 通過
- [x] `npm test -- tests/plots/controllers/restoreContract.test.ts` — 6/6 通過
- [x] `npm test` — 全 798 件通過（既存テストへの影響なし）
- [x] `npm run lint` — 0 errors（既存 warnings 1190 は main 由来）
- [x] `npm run format:check` — pass
- [x] `npm run swagger:validate` — pass

## Refs

- Refs #110（マージで Closes できる状態）
- 業務確認 5 件の回答は [#110 のコメント](https://github.com/zaitsu82/komine-crm-backend/issues/110#issuecomment-4431311094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)