### PR TITLE
feat(documents): 封筒書・封筒台の種別とPDF対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=6484a0b1177ed61e6a29ef9c94bdbbcf672a996c
+ARG TYPES_REF=99414bbf9f6336a316fce8f3149b0b97d3a8bd09
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.3.0",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "postinstall": "prisma generate",
+    "dev": "prisma generate && ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc && npm run build:assets",
     "build:assets": "node scripts/copy-document-assets.js",
     "start": "node dist/index.js",

--- a/prisma/migrations/20260525120000_add_document_types_envelope_letter_base/migration.sql
+++ b/prisma/migrations/20260525120000_add_document_types_envelope_letter_base/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum: 書類タイプに封筒書・封筒台を追加
+ALTER TYPE "DocumentType" ADD VALUE 'envelope_letter';
+ALTER TYPE "DocumentType" ADD VALUE 'envelope_base';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,8 @@ enum DocumentType {
   postcard // はがき
   contract // 契約書
   permit // 許可証
+  envelope_letter // 封筒書
+  envelope_base // 封筒台
   other // その他
 }
 

--- a/src/documents/documentController.ts
+++ b/src/documents/documentController.ts
@@ -9,7 +9,7 @@
  */
 
 import { Request, Response } from 'express';
-import { Prisma } from '@prisma/client';
+import { Prisma, type DocumentType, type DocumentStatus } from '@prisma/client';
 import { ZodError } from 'zod';
 import { getRequestLogger } from '../utils/logger';
 import { generatePdfFromTemplate } from './documentService';
@@ -26,10 +26,6 @@ import {
   recordDocumentUpdated,
   recordDocumentDeleted,
 } from '../plots/services/historyService';
-
-// 型定義
-type DocumentType = 'invoice' | 'postcard' | 'contract' | 'permit' | 'other';
-type DocumentStatus = 'draft' | 'generated' | 'sent' | 'archived';
 
 // リクエスト型定義
 interface CreateDocumentBody {
@@ -69,6 +65,8 @@ const TEMPLATE_TYPE_TO_DOC_TYPE: Record<DocumentTemplateType, DocumentType> = {
   invoice: 'invoice',
   postcard: 'postcard',
   permit: 'permit',
+  'envelope-letter': 'envelope_letter',
+  'envelope-base': 'envelope_base',
   'payment-guide': 'other',
 };
 
@@ -76,6 +74,8 @@ const TEMPLATE_TYPE_TO_NAME: Record<DocumentTemplateType, string> = {
   invoice: '護持費のお知らせ',
   postcard: 'はがき',
   permit: '許可証',
+  'envelope-letter': '封筒書',
+  'envelope-base': '封筒台',
   'payment-guide': 'お支払い方法のご案内',
 };
 

--- a/src/documents/documentService.ts
+++ b/src/documents/documentService.ts
@@ -25,7 +25,11 @@ import {
   getDefaultSeasonGreeting,
 } from '@komine/types';
 import { logger } from '../utils/logger';
-import { generatePermitPdf } from './permitPdfService';
+import {
+  generatePermitPdf,
+  generateEnvelopeLetterPdf,
+  generateEnvelopeBasePdf,
+} from './permitPdfService';
 
 // 後方互換のため既存名で再エクスポート
 export type TemplateType = DocumentTemplateType;
@@ -248,6 +252,12 @@ export async function generatePdfFromTemplate(
     // 許可証は既存のテンプレートPDFに pdf-lib で文字を重ねる
     if (templateType === 'permit') {
       return await generatePermitPdf(data as PermitTemplateData);
+    }
+    if (templateType === 'envelope-letter') {
+      return await generateEnvelopeLetterPdf(data as PermitTemplateData);
+    }
+    if (templateType === 'envelope-base') {
+      return await generateEnvelopeBasePdf(data as PermitTemplateData);
     }
 
     const html = loadAndRenderTemplate(templateType, data as unknown as Record<string, unknown>);

--- a/src/documents/permitPdfService.ts
+++ b/src/documents/permitPdfService.ts
@@ -7,7 +7,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { PDFDocument, rgb, degrees, PDFFont } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
-import { PERMIT_PAGES, PermitField, PermitTemplateData } from '@komine/types';
+import {
+  PERMIT_CERTIFICATE_PAGES,
+  ENVELOPE_LETTER_PAGES,
+  ENVELOPE_BASE_PAGES,
+  type PermitField,
+  type PermitPage,
+  type PermitTemplateData,
+} from '@komine/types';
 import { logger } from '../utils/logger';
 
 const TEMPLATE_DIR = path.join(__dirname, 'templates', 'permit');
@@ -98,25 +105,22 @@ function drawField(
 }
 
 /**
- * 許可証テンプレートPDFにテキストを重ねて、5ページまとめた1つのPDFを返す
+ * 許可証・封筒書・封筒台: 指定ページ定義どおりに PDF を結合して返す
  */
-export async function generatePermitPdf(
+export async function generatePermitPdfFromPages(
+  pages: readonly PermitPage[],
   data: PermitTemplateData
 ): Promise<{ success: boolean; buffer?: Buffer; error?: string }> {
   try {
     const fonts = loadFonts();
     const outDoc = await PDFDocument.create();
     outDoc.registerFontkit(fontkit);
-    // subset=true だと CID マップ不整合で一部文字が描画されない現象があったため、
-    // 全グリフを埋め込む（ファイルサイズは増えるが表示を優先）
     const fontRegular = await outDoc.embedFont(fonts.regular, { subset: false });
     const fontBold = await outDoc.embedFont(fonts.bold, { subset: false });
 
-    for (const pageDef of PERMIT_PAGES) {
+    for (const pageDef of pages) {
       if (!pageDef.enabled) continue;
       const basePath = path.join(TEMPLATE_DIR, pageDef.baseFile);
-      // ベースPDFはリポジトリに同梱されているため、不在なら配布物が壊れている。
-      // silent skip すると空ページの PDF がユーザに渡るので fail fast する。
       if (!fs.existsSync(basePath)) {
         throw new Error(`Permit base PDF が見つかりません: ${pageDef.baseFile}`);
       }
@@ -143,10 +147,29 @@ export async function generatePermitPdf(
     const bytes = await outDoc.save();
     return { success: true, buffer: Buffer.from(bytes) };
   } catch (error) {
-    logger.error({ err: error }, 'Permit PDF generation error');
+    logger.error({ err: error }, 'Permit-style PDF generation error');
     return {
       success: false,
-      error: error instanceof Error ? error.message : '許可証PDFの生成に失敗しました',
+      error: error instanceof Error ? error.message : 'PDFの生成に失敗しました',
     };
   }
+}
+
+/** 許可証は1ページ（許可証書）のみ */
+export async function generatePermitPdf(
+  data: PermitTemplateData
+): Promise<{ success: boolean; buffer?: Buffer; error?: string }> {
+  return generatePermitPdfFromPages(PERMIT_CERTIFICATE_PAGES, data);
+}
+
+export async function generateEnvelopeLetterPdf(
+  data: PermitTemplateData
+): Promise<{ success: boolean; buffer?: Buffer; error?: string }> {
+  return generatePermitPdfFromPages(ENVELOPE_LETTER_PAGES, data);
+}
+
+export async function generateEnvelopeBasePdf(
+  data: PermitTemplateData
+): Promise<{ success: boolean; buffer?: Buffer; error?: string }> {
+  return generatePermitPdfFromPages(ENVELOPE_BASE_PAGES, data);
 }

--- a/src/validations/documentValidation.ts
+++ b/src/validations/documentValidation.ts
@@ -29,6 +29,8 @@ const TEMPLATE_DATA_SCHEMAS = {
   invoice: invoiceTemplateDataSchema,
   postcard: postcardTemplateDataSchema,
   permit: permitTemplateDataSchema,
+  'envelope-letter': permitTemplateDataSchema,
+  'envelope-base': permitTemplateDataSchema,
   'payment-guide': paymentGuideTemplateDataSchema,
 } as const;
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2180,6 +2180,8 @@ components:
         - postcard
         - contract
         - permit
+        - envelope_letter
+        - envelope_base
         - other
       example: invoice
 
@@ -2419,7 +2421,13 @@ components:
       properties:
         templateType:
           type: string
-          enum: [ invoice, postcard ]
+          enum:
+            - invoice
+            - postcard
+            - permit
+            - envelope-letter
+            - envelope-base
+            - payment-guide
           description: テンプレートタイプ
         templateData:
           type: object


### PR DESCRIPTION
## 概要
書類タイプに `envelope_letter`（封筒書）と `envelope_base`（封筒台）を追加し、API・PDF生成・Swagger・Prismaマイグレーションを整合させます。

## 変更内容
- Prisma: `DocumentType` 拡張用マイグレーション
- ドキュメントサービス・許可証PDF・バリデーションの更新
- `postinstall` / `dev` で `prisma generate` を実行

## 関連
フロントエンド: `komine-crm-frontend` の `feature/documents-integration` とセットでレビューしてください。
型パッケージ `komine-types` の変更がローカルの `packages/types` にありますが、別リポジトリへのプッシュは現在のアカウント権限ではできませんでした。権限のある環境から `feature/document-envelope-letter-types` をプッシュしてください。

Made with [Cursor](https://cursor.com)