### PR TITLE
fix: remove broken post-check on NOT NULL contract_plot_id (Phase 1)

### DIFF
--- a/scripts/legacy-migration/steps/06-sale-contract-role.ts
+++ b/scripts/legacy-migration/steps/06-sale-contract-role.ts
@@ -2,7 +2,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
-import { assertIdMapsReady, assertNoOrphanRows } from '../lib/invariants';
+import { assertIdMapsReady } from '../lib/invariants';
 import { cleanPhone, cleanStr, joinName, parseLegacyZip } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -182,16 +182,6 @@ export const stepSaleContractRole: MigrationStep = {
         },
       });
       applicantInserted++;
-    }
-
-    if (!dryRun) {
-      await assertNoOrphanRows(
-        prisma,
-        'saleContractRole',
-        { contract_plot_id: null, deleted_at: null },
-        'saleContractRole',
-        'contract_plot_id IS NULL after insert'
-      );
     }
 
     return {

--- a/scripts/legacy-migration/steps/07-family-contact.ts
+++ b/scripts/legacy-migration/steps/07-family-contact.ts
@@ -2,7 +2,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
-import { assertIdMapsReady, assertNoOrphanRows } from '../lib/invariants';
+import { assertIdMapsReady } from '../lib/invariants';
 import { cleanPhone, cleanStr, joinName, parseLegacyDate, parseLegacyZip } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -131,16 +131,6 @@ export const stepFamilyContact: MigrationStep = {
         },
       });
       inserted++;
-    }
-
-    if (!dryRun) {
-      await assertNoOrphanRows(
-        prisma,
-        'familyContact',
-        { contract_plot_id: null, deleted_at: null },
-        'familyContact',
-        'contract_plot_id IS NULL after insert'
-      );
     }
 
     return {

--- a/scripts/legacy-migration/steps/08-buried-person.ts
+++ b/scripts/legacy-migration/steps/08-buried-person.ts
@@ -2,7 +2,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
-import { assertIdMapsReady, assertNoOrphanRows } from '../lib/invariants';
+import { assertIdMapsReady } from '../lib/invariants';
 import { cleanStr, joinName, parseGender, parseLegacyDate } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -108,16 +108,6 @@ export const stepBuriedPerson: MigrationStep = {
         },
       });
       inserted++;
-    }
-
-    if (!dryRun) {
-      await assertNoOrphanRows(
-        prisma,
-        'buriedPerson',
-        { contract_plot_id: null, deleted_at: null },
-        'buriedPerson',
-        'contract_plot_id IS NULL after insert'
-      );
     }
 
     return {

--- a/scripts/legacy-migration/steps/09-construction-info.ts
+++ b/scripts/legacy-migration/steps/09-construction-info.ts
@@ -2,7 +2,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
-import { assertIdMapsReady, assertNoOrphanRows } from '../lib/invariants';
+import { assertIdMapsReady } from '../lib/invariants';
 import { cleanStr, parseLegacyDate } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -69,16 +69,6 @@ export const stepConstructionInfo: MigrationStep = {
         },
       });
       inserted++;
-    }
-
-    if (!dryRun) {
-      await assertNoOrphanRows(
-        prisma,
-        'constructionInfo',
-        { contract_plot_id: null, deleted_at: null },
-        'constructionInfo',
-        'contract_plot_id IS NULL after insert'
-      );
     }
 
     return { inserted, skipped, notes: { source_rows: rows.length } };

--- a/scripts/legacy-migration/steps/10-billing.ts
+++ b/scripts/legacy-migration/steps/10-billing.ts
@@ -3,7 +3,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
-import { assertIdMapsReady, assertNoOrphanRows } from '../lib/invariants';
+import { assertIdMapsReady } from '../lib/invariants';
 import { cleanStr, parseLegacyDate } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -158,16 +158,6 @@ export const stepBilling: MigrationStep = {
       });
       idMaps.billing.set(row.seikyu_cd, billing.id);
       inserted++;
-    }
-
-    if (!dryRun) {
-      await assertNoOrphanRows(
-        prisma,
-        'billing',
-        { legacy_seikyu_cd: { not: null }, contract_plot_id: null, deleted_at: null },
-        'billing',
-        'legacy_seikyu_cd set but contract_plot_id IS NULL'
-      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Phase 1 (PR #123) で導入した orphan 検出 post-check 5 件が、対象カラム (`contract_plot_id`) が NOT NULL FK のため Prisma v7 で `PrismaClientValidationError` を返す。本投入 (2026-05-16 13:16) で saleContractRole step の post-check 到達時にクラッシュした。

- **影響 step**: 06 saleContractRole / 07 familyContact / 08 buriedPerson / 09 constructionInfo / 10 billing
- **修正**: 当該 post-check は schema の NOT NULL 制約と冗長なので削除（意図は維持）
- **payment (step 11)** は `billing_id` / `contract_plot_id` がともに nullable なので意味のある orphan 検出として残す
- **Phase 1 unit test** は mock Prisma 経由のため type validation を通らず、実 DB でのみ顕在化
- 814/814 tests green

## クラッシュ時のエラー

\`\`\`
Argument \`contract_plot_id\` must not be null.
  at assertNoOrphanRows (invariants.ts:73:17)
  at steps/06-sale-contract-role.ts:188:7
\`\`\`

## Test plan

- [x] \`npm test\` → 45 suites / 814 tests green
- [x] マージ後、Windows 側 \`git pull\` で同期
- [x] migrate-from-legacy.ts 再走 (idempotency で step 01-06 skip、07-11 を投入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)