### PR TITLE
chore(scripts): legacy migration の運用スクリプトを git 管理に整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pids
 *.pid
 *.seed
 *.pid.lock
+*-pid.txt
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/scripts/check-legacy-data.ts
+++ b/scripts/check-legacy-data.ts
@@ -1,0 +1,82 @@
+/// <reference types="node" />
+/**
+ * dev DB のレガシー由来データを確認する一時スクリプト
+ */
+
+import 'dotenv/config';
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+async function main(): Promise<void> {
+  const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const [
+      totalCustomers,
+      legacyCustomers,
+      totalStaff,
+      legacyStaff,
+      totalPhysicalPlots,
+      legacyPlotNumberPattern,
+      totalContractPlots,
+      legacyContractPlots,
+      totalRelationshipMaster,
+      legacyRelationshipMaster,
+      totalBuriedPerson,
+      totalFamilyContact,
+      totalBilling,
+      totalPayment,
+    ] = await Promise.all([
+      prisma.customer.count(),
+      prisma.customer.count({ where: { legacy_danka_cd: { not: null } } }),
+      prisma.staff.count(),
+      prisma.staff.count({ where: { supabase_uid: { startsWith: 'legacy-tancd-' } } }),
+      prisma.physicalPlot.count(),
+      prisma.physicalPlot.count({ where: { plot_number: { startsWith: 'legacy-' } } }),
+      prisma.contractPlot.count(),
+      prisma.contractPlot.count({ where: { legacy_grave_cd: { not: null } } }),
+      prisma.relationshipMaster.count(),
+      prisma.relationshipMaster.count({ where: { code: { startsWith: '2009-' } } }),
+      prisma.buriedPerson.count(),
+      prisma.familyContact.count(),
+      prisma.billing.count(),
+      prisma.payment.count(),
+    ]);
+
+    // eslint-disable-next-line no-console
+    console.log('=== 全件 vs レガシー由来件数 ===');
+    // eslint-disable-next-line no-console
+    console.table({
+      Customer: { total: totalCustomers, legacy: legacyCustomers },
+      Staff: { total: totalStaff, legacy: legacyStaff },
+      PhysicalPlot: { total: totalPhysicalPlots, legacy: legacyPlotNumberPattern },
+      ContractPlot: { total: totalContractPlots, legacy: legacyContractPlots },
+      RelationshipMaster: { total: totalRelationshipMaster, legacy: legacyRelationshipMaster },
+      BuriedPerson: { total: totalBuriedPerson, legacy: '(legacy_* なし、全件で判別)' },
+      FamilyContact: { total: totalFamilyContact, legacy: '(legacy_* なし、全件で判別)' },
+      Billing: { total: totalBilling, legacy: '(legacy_seikyu_cd で判別可)' },
+      Payment: { total: totalPayment, legacy: '(legacy_nyukin_cd で判別可)' },
+    });
+
+    if (legacyPlotNumberPattern > 0) {
+      const leftover = await prisma.physicalPlot.findMany({
+        where: { plot_number: { startsWith: 'legacy-' } },
+        select: { id: true, plot_number: true, area_name: true, created_at: true },
+      });
+      // eslint-disable-next-line no-console
+      console.log('\n=== legacy-* で始まる残り PhysicalPlot ===');
+      // eslint-disable-next-line no-console
+      console.table(leftover);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cleanup-legacy-data.ts
+++ b/scripts/cleanup-legacy-data.ts
@@ -1,0 +1,153 @@
+/// <reference types="node" />
+/**
+ * dev DB から「レガシー由来データ」だけを安全に削除するスクリプト
+ *
+ * Phase 2 のクリーンスタート用。手動投入分（legacy_*_cd が NULL、または
+ * supabase_uid / plot_number / code に legacy プレフィクスがない行）は残す。
+ *
+ * 削除対象（依存関係を考慮した順序、すべて legacy フィルタ付き）:
+ *   1. Payment           : legacy_nyukin_cd IS NOT NULL
+ *   2. Billing           : legacy_seikyu_cd IS NOT NULL
+ *   3. ContractPlot      : legacy_grave_cd IS NOT NULL
+ *      → Cascade で SaleContractRole / FamilyContact / BuriedPerson /
+ *        ConstructionInfo / UsageFee / ManagementFee / GravestoneInfo /
+ *        CollectiveBurial も自動削除
+ *   4. Customer          : legacy_danka_cd IS NOT NULL
+ *      → Cascade で WorkInfo 自動削除、FamilyContact.customer_id は SetNull
+ *   5. PhysicalPlot      : plot_number LIKE 'legacy-%'
+ *   6. Staff             : supabase_uid LIKE 'legacy-tancd-%'
+ *   7. RelationshipMaster: code LIKE '2009-%'
+ *
+ * 使い方:
+ *   npx ts-node --transpile-only scripts/cleanup-legacy-data.ts          # 件数表示のみ (dry-run)
+ *   npx ts-node --transpile-only scripts/cleanup-legacy-data.ts --apply  # 実行
+ */
+
+import 'dotenv/config';
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const paymentWhere = { legacy_nyukin_cd: { not: null } } as const;
+    const billingWhere = { legacy_seikyu_cd: { not: null } } as const;
+    const contractPlotWhere = { legacy_grave_cd: { not: null } } as const;
+    const customerWhere = { legacy_danka_cd: { not: null } } as const;
+    const physicalPlotWhere = { plot_number: { startsWith: 'legacy-' } } as const;
+    const staffWhere = { supabase_uid: { startsWith: 'legacy-tancd-' } } as const;
+    const relationshipMasterWhere = { code: { startsWith: '2009-' } } as const;
+
+    // Cascade で消えるサブ要素も件数を見せる（参考表示用）
+    const legacyContractPlotIds = await prisma.contractPlot.findMany({
+      where: contractPlotWhere,
+      select: { id: true },
+    });
+    const cpIdList = legacyContractPlotIds.map((r) => r.id);
+
+    const before = {
+      payment: await prisma.payment.count({ where: paymentWhere }),
+      billing: await prisma.billing.count({ where: billingWhere }),
+      saleContractRole_cascade: await prisma.saleContractRole.count({
+        where: { contract_plot_id: { in: cpIdList } },
+      }),
+      familyContact_cascade: await prisma.familyContact.count({
+        where: { contract_plot_id: { in: cpIdList } },
+      }),
+      buriedPerson_cascade: await prisma.buriedPerson.count({
+        where: { contract_plot_id: { in: cpIdList } },
+      }),
+      constructionInfo_cascade: await prisma.constructionInfo.count({
+        where: { contract_plot_id: { in: cpIdList } },
+      }),
+      contractPlot: await prisma.contractPlot.count({ where: contractPlotWhere }),
+      customer: await prisma.customer.count({ where: customerWhere }),
+      physicalPlot: await prisma.physicalPlot.count({ where: physicalPlotWhere }),
+      staff: await prisma.staff.count({ where: staffWhere }),
+      relationshipMaster: await prisma.relationshipMaster.count({ where: relationshipMasterWhere }),
+    };
+
+    // eslint-disable-next-line no-console
+    console.log('=== 削除対象件数 (before) ===');
+    // eslint-disable-next-line no-console
+    console.table(before);
+    // eslint-disable-next-line no-console
+    console.log(
+      '*_cascade は ContractPlot 削除時に Cascade で連動削除される件数（明示削除はしない）'
+    );
+
+    if (!apply) {
+      // eslint-disable-next-line no-console
+      console.log('\n--apply フラグがないので削除せず終了。実行するには --apply を付けて再度。');
+      return;
+    }
+
+    // 依存関係を考慮した削除順序:
+    //   Payment → Billing → ContractPlot (Cascade) → Customer → PhysicalPlot → Staff → RelationshipMaster
+    // ContractPlot 削除で SaleContractRole/FamilyContact/BuriedPerson/ConstructionInfo/
+    // UsageFee/ManagementFee/GravestoneInfo/CollectiveBurial は自動削除される（onDelete: Cascade）
+    const result = await prisma.$transaction(
+      async (tx) => {
+        const payment = await tx.payment.deleteMany({ where: paymentWhere });
+        const billing = await tx.billing.deleteMany({ where: billingWhere });
+        const contractPlot = await tx.contractPlot.deleteMany({ where: contractPlotWhere });
+        const customer = await tx.customer.deleteMany({ where: customerWhere });
+        const physicalPlot = await tx.physicalPlot.deleteMany({ where: physicalPlotWhere });
+        const staff = await tx.staff.deleteMany({ where: staffWhere });
+        const relationshipMaster = await tx.relationshipMaster.deleteMany({
+          where: relationshipMasterWhere,
+        });
+        return {
+          payment,
+          billing,
+          contractPlot,
+          customer,
+          physicalPlot,
+          staff,
+          relationshipMaster,
+        };
+      },
+      { timeout: 120_000 }
+    );
+
+    // eslint-disable-next-line no-console
+    console.log('\n=== 削除結果 ===');
+    // eslint-disable-next-line no-console
+    console.table({
+      payment: { deleted: result.payment.count },
+      billing: { deleted: result.billing.count },
+      contractPlot: { deleted: result.contractPlot.count },
+      customer: { deleted: result.customer.count },
+      physicalPlot: { deleted: result.physicalPlot.count },
+      staff: { deleted: result.staff.count },
+      relationshipMaster: { deleted: result.relationshipMaster.count },
+    });
+
+    const after = {
+      payment: await prisma.payment.count({ where: paymentWhere }),
+      billing: await prisma.billing.count({ where: billingWhere }),
+      contractPlot: await prisma.contractPlot.count({ where: contractPlotWhere }),
+      customer: await prisma.customer.count({ where: customerWhere }),
+      physicalPlot: await prisma.physicalPlot.count({ where: physicalPlotWhere }),
+      staff: await prisma.staff.count({ where: staffWhere }),
+      relationshipMaster: await prisma.relationshipMaster.count({ where: relationshipMasterWhere }),
+    };
+
+    // eslint-disable-next-line no-console
+    console.log('\n=== 削除後の残件数 (after) ===');
+    // eslint-disable-next-line no-console
+    console.table(after);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/investigate-payment.ts
+++ b/scripts/investigate-payment.ts
@@ -1,0 +1,91 @@
+/// <reference types="node" />
+import 'dotenv/config';
+
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+async function main(): Promise<void> {
+  const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+  const prisma = new PrismaClient({ adapter });
+
+  try {
+    const total = await prisma.payment.count();
+    const withLegacy = await prisma.payment.count({
+      where: { legacy_nyukin_cd: { not: null } },
+    });
+    const withBilling = await prisma.payment.count({
+      where: { billing_id: { not: null } },
+    });
+    const withCustomer = await prisma.payment.count({
+      where: { customer_id: { not: null } },
+    });
+    const withContractPlot = await prisma.payment.count({
+      where: { contract_plot_id: { not: null } },
+    });
+    const noBillingNoContractPlot = await prisma.payment.count({
+      where: { billing_id: null, contract_plot_id: null },
+    });
+
+    // eslint-disable-next-line no-console
+    console.log('=== Payment 概況 ===');
+    // eslint-disable-next-line no-console
+    console.table({
+      total,
+      withLegacyNyukinCd: withLegacy,
+      withBillingId: withBilling,
+      withCustomerId: withCustomer,
+      withContractPlotId: withContractPlot,
+      'billing=null AND contract_plot=null': noBillingNoContractPlot,
+    });
+
+    // 作成日時の範囲
+    const oldest = await prisma.payment.findFirst({
+      orderBy: { created_at: 'asc' },
+      select: { created_at: true, legacy_nyukin_cd: true },
+    });
+    const newest = await prisma.payment.findFirst({
+      orderBy: { created_at: 'desc' },
+      select: { created_at: true, legacy_nyukin_cd: true },
+    });
+    // eslint-disable-next-line no-console
+    console.log('\n=== 作成日時範囲 ===');
+    // eslint-disable-next-line no-console
+    console.table({ oldest, newest });
+
+    // 日時バケットで分布
+    const sample = await prisma.payment.findMany({
+      select: { created_at: true },
+      orderBy: { created_at: 'asc' },
+    });
+    const buckets = new Map<string, number>();
+    for (const r of sample) {
+      const d = r.created_at;
+      if (!d) continue;
+      const key = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')} ${String(d.getUTCHours()).padStart(2, '0')}`;
+      buckets.set(key, (buckets.get(key) ?? 0) + 1);
+    }
+    // eslint-disable-next-line no-console
+    console.log('\n=== 作成日時 hour バケット (UTC) ===');
+    for (const [k, v] of [...buckets.entries()].sort()) {
+      // eslint-disable-next-line no-console
+      console.log(`${k}h  ${v}`);
+    }
+
+    // legacy_nyukin_cd の値の範囲
+    const minMax = (await prisma.$queryRawUnsafe(
+      'SELECT MIN(legacy_nyukin_cd) as min, MAX(legacy_nyukin_cd) as max FROM "Payment" WHERE legacy_nyukin_cd IS NOT NULL'
+    )) as Array<{ min: number | bigint | null; max: number | bigint | null }>;
+    // eslint-disable-next-line no-console
+    console.log('\n=== legacy_nyukin_cd の範囲 ===');
+    // eslint-disable-next-line no-console
+    console.table(minMax[0]);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Phase 1〜4 完了後の untracked files 棚卸し（2026-05-18, ユーザー判断付き）。運用上必要な 3 スクリプトを git 管理に追加し、一回限り作業用・ランタイム生成ファイルを除外する。

### git 管理に追加（3 files）

| ファイル | 用途 |
|---|---|
| `scripts/check-legacy-data.ts` | レガシー由来件数の確認（`query_result/RECOVERY_PLAN.md` 公式記載） |
| `scripts/cleanup-legacy-data.ts` | レガシーデータ wipe (`--apply` フラグ付き、Cascade も件数表示) |
| `scripts/investigate-payment.ts` | Payment 概況・作成日時バケット分布調査（運用 debug ツール） |

### 削除（user 確認 2026-05-18）

| ファイル | 削除理由 |
|---|---|
| `scripts/auto-run-remaining-steps.ps1` | Windows パス固定 (`C:\Users\zaits\...`)、Phase 1 ハードニング前の旧運用、用済み |
| `scripts/delete-orphan-payments.ts` | 2026-05-14 偽孤児 1,588 件事故対応の一回限り、対象既に削除済、Phase 1 invariant で再発不可 |

### .gitignore 追加

- `*-pid.txt`: `migrate-pid.txt` 等のランタイム生成ファイル（既存の `*.pid` パターンは拡張子違いで捕まらなかった）

## 副次効果: lint error 解消

- PR #131 時点: 1192 warnings / **3 errors**（すべて未管理の `cleanup-legacy-data.ts` の prettier 違反）
- 本 PR 後: 1192 warnings / **0 errors**（prettier --write で fix 済み）

## Test plan

- [x] `npm test` 45 suites / 814 tests グリーン
- [x] `npm run lint` 0 errors（warnings は pre-existing 1192 件）
- [ ] マージ後、`RECOVERY_PLAN.md` の「関連ファイル」表に `investigate-payment.ts` を追記（別途ドキュメント更新で実施）

## 文脈

Phase 4 PR #131 (`chore/migration-script-phase3-followup`) のレビュー時に発覚した「untracked files の方針未確定」項目のフォロー。Phase 4 の完了記録 (`query_result/RECOVERY_PHASE4_FOLLOWUP.md`) でも「別 issue 候補」として明記していた件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)