### PR TITLE
fix(migration): t_danka.auth_no → ContractPlot.acceptance_number/date

### DIFF
--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -44,6 +44,10 @@ interface BochiContractRow extends RowDataPacket {
   houi_id: number | null;
   ichi_id: number | null;
   note: string | null;
+  // t_danka からの JOIN 結果（承諾番号・承諾日）
+  // m_bochi.danka_cd → t_danka.danka_cd で 1:1（同一 danka_cd が複数 m_bochi に紐づく場合も値は同一）
+  auth_no: number | null;
+  auth_date: number | null;
 }
 
 /**
@@ -74,16 +78,18 @@ export const stepContractPlot: MigrationStep = {
     assertIdMapsReady('contractPlot', idMaps, ['physicalPlot']);
 
     const rows = await legacyQuery<BochiContractRow>(
-      `SELECT grave_cd, danka_cd, status, grave_kind, grave_kubun, grave_type,
-              request_date, contract_start, contract_end, konryu_kigen, konryu_date, reserve_date,
-              shiyouryou, shiyouryou_menseki, shiyouryou_tanka, shiyouryou_keisan, shiyouryou_zei,
-              shiyouryou_shiharai, shiyouryou_seikyu, shiyouryou_seikyunen, shiyouryou_seikyutsuki,
-              kanriryou, kanriryou_menseki, kanriryou_tanka, kanriryou_keisan, kanriryou_zei,
-              kanriryou_shiharai, kanriryou_seikyu, kanriryou_seikyunen, kanriryou_seikyutsuki,
-              kanriryou_last_sei_date,
-              bosekiryou, boshi, houi_id, ichi_id, note
-         FROM m_bochi
-        WHERE del_flg = 0 OR del_flg IS NULL`
+      `SELECT b.grave_cd, b.danka_cd, b.status, b.grave_kind, b.grave_kubun, b.grave_type,
+              b.request_date, b.contract_start, b.contract_end, b.konryu_kigen, b.konryu_date, b.reserve_date,
+              b.shiyouryou, b.shiyouryou_menseki, b.shiyouryou_tanka, b.shiyouryou_keisan, b.shiyouryou_zei,
+              b.shiyouryou_shiharai, b.shiyouryou_seikyu, b.shiyouryou_seikyunen, b.shiyouryou_seikyutsuki,
+              b.kanriryou, b.kanriryou_menseki, b.kanriryou_tanka, b.kanriryou_keisan, b.kanriryou_zei,
+              b.kanriryou_shiharai, b.kanriryou_seikyu, b.kanriryou_seikyunen, b.kanriryou_seikyutsuki,
+              b.kanriryou_last_sei_date,
+              b.bosekiryou, b.boshi, b.houi_id, b.ichi_id, b.note,
+              d.auth_no, d.auth_date
+         FROM m_bochi b
+         LEFT JOIN t_danka d ON d.danka_cd = b.danka_cd AND (d.del_flg = 0 OR d.del_flg IS NULL)
+        WHERE b.del_flg = 0 OR b.del_flg IS NULL`
     );
 
     let inserted = 0;
@@ -139,6 +145,8 @@ export const stepContractPlot: MigrationStep = {
         price: row.shiyouryou ?? null,
         request_date: parseLegacyDate(row.request_date),
         reservation_date: parseLegacyDate(row.reserve_date),
+        acceptance_number: row.auth_no != null ? String(row.auth_no) : null,
+        acceptance_date: parseLegacyDate(row.auth_date),
         permit_date: parseLegacyDate(row.konryu_kigen),
         start_date: parseLegacyDate(row.konryu_date),
         notes: cleanStr(row.note),


### PR DESCRIPTION
## Summary

- legacy migration step05 (`05-contract-plot.ts`) で **`t_danka.auth_no` / `auth_date` → `ContractPlot.acceptance_number` / `acceptance_date`** のマッピングを追加
- 旧画面の「受付番号」「申込日（契約者）」が migration 後の DB で常に NULL になっていた問題を解消
- legacy 上の承諾番号は **`m_bochi` ではなく `t_danka`** に存在するため、`danka_cd` で LEFT JOIN して取得

## 背景

`query_result/UI_GAP_SCREEN_02_BASIC_INFO_1.md` の **A1** 項目。前セッションの UI gap 分析では `m_bochi.auth_no?` と推定マッピングが書かれていたが、実際の legacy schema 確認 (`query_result/Query.csv`) では `auth_no` は `t_danka` テーブル側のカラム。`MIGRATION_PHASE2_SCHEMA_CHANGES.md` に「`auth_no, auth_date | 承諾番号・日付 | ContractPlot | 既存 acceptance_number, acceptance_date でOK`」と明記されており、マッピング先は確定。

## 主要変更

1. `BochiContractRow` interface に `auth_no` / `auth_date` 追加
2. SQL を `m_bochi b LEFT JOIN t_danka d ON d.danka_cd = b.danka_cd AND (d.del_flg = 0 OR d.del_flg IS NULL)` に変更
3. `ContractPlot.create` で
   - `acceptance_number: row.auth_no != null ? String(row.auth_no) : null`
   - `acceptance_date: parseLegacyDate(row.auth_date)`

## 残課題（本 PR スコープ外）

- **`permit_number` (許可番号 / 平成書番号)** の legacy ソースカラムが特定できなかった。`m_bochi` 列一覧 (`Query.csv`) に該当しそうな列なし、ヒアリング doc にも記述なし。別途業務確認 or schema 再調査が必要。
- B / C / D カテゴリの残作業は別 PR (`query_result/UI_GAP_HANDOFF.md` 参照)

## 再投入手順（マージ後・user 側で実施）

WSL から legacy MySQL に届かないため、Windows 側で実施:

\`\`\`powershell
# 例: 該当 step だけ再実行（dry-run で先に確認推奨）
npx ts-node scripts/legacy-migration/run.ts --step contractPlot --dry-run
npx ts-node scripts/legacy-migration/run.ts --step contractPlot
\`\`\`

冪等性チェック (`existing` 判定、step05:120) があるので、既存 ContractPlot 行は重複 insert されず skip される。**ただし既存行の `acceptance_number` / `acceptance_date` は更新されない**（現在の冪等ロジックは「行存在なら skip」のみ）。空フィールドを埋めるには `UPDATE` 用の補助 step か、対象 ContractPlot を一度 soft delete → 再投入が必要。運用判断は user 側で。

## Test plan

- [x] `npx tsc --noEmit` 対象ファイル clean
- [x] `npx eslint scripts/legacy-migration/steps/05-contract-plot.ts` clean
- [x] `parseLegacyDate(null)` が null を返すことを確認（LEFT JOIN 不一致時の安全性）
- [ ] dry-run 実行（user 側、Windows）
- [ ] 本投入後、`ContractPlot.acceptance_number` / `acceptance_date` に値が入っていることを sample 区画で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)