### PR TITLE
feat(plot): Customer 振込先口座 5 フィールドを API で出し入れ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=218afb2b43ff66cf6d54f5f7abb9a19ab9060959
+ARG TYPES_REF=acfe23844a5b1b782e8d2e1f2cc1e72735c201d1
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -94,6 +94,12 @@ export async function createPlotCore(
       phone_number: input.customer.phoneNumber,
       fax_number: input.customer.faxNumber || null,
       email: input.customer.email || null,
+      // 振込先情報（ゆうちょ自動払込 CSV 出力用）
+      bank_name: input.customer.bankName || null,
+      branch_name: input.customer.branchName || null,
+      account_type: input.customer.accountType || null,
+      account_number: input.customer.accountNumber || null,
+      account_holder: input.customer.accountHolder || null,
       notes: input.customer.notes || null,
       staff_id: input.customer.staffId ?? null,
       legacy_danka_cd: input.customer.legacyDankaCd ?? null,

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -318,6 +318,12 @@ export const getPlotById = async (
           address: role.customer.address,
           addressLine2: role.customer.address_line_2,
           registeredAddress: role.customer.registered_address,
+          // 振込先情報（ゆうちょ自動払込 CSV 出力用、レガシー t_danka.kikan_name 系から移行）
+          bankName: role.customer.bank_name,
+          branchName: role.customer.branch_name,
+          accountType: role.customer.account_type,
+          accountNumber: role.customer.account_number,
+          accountHolder: role.customer.account_holder,
           notes: role.customer.notes,
           workInfo: role.customer.workInfo
             ? {

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -305,6 +305,17 @@ export async function updatePlotCore(
       if (input.customer.faxNumber !== undefined)
         customerUpdateData.fax_number = input.customer.faxNumber;
       if (input.customer.email !== undefined) customerUpdateData.email = input.customer.email;
+      // 振込先情報（ゆうちょ自動払込 CSV 出力用）
+      if (input.customer.bankName !== undefined)
+        customerUpdateData.bank_name = input.customer.bankName;
+      if (input.customer.branchName !== undefined)
+        customerUpdateData.branch_name = input.customer.branchName;
+      if (input.customer.accountType !== undefined)
+        customerUpdateData.account_type = input.customer.accountType;
+      if (input.customer.accountNumber !== undefined)
+        customerUpdateData.account_number = input.customer.accountNumber;
+      if (input.customer.accountHolder !== undefined)
+        customerUpdateData.account_holder = input.customer.accountHolder;
       if (input.customer.notes !== undefined) customerUpdateData.notes = input.customer.notes;
 
       // issue #66: update 戻り値を保持し section 13 で再取得しないようにする


### PR DESCRIPTION
## Summary

`PlotDetailResponse.roles[].customer` に振込先情報の 5 フィールド（銀行名・支店名・預金種目・口座番号・口座名義）を含めるよう backend controllers を拡張。`createPlot` / `updatePlot` でも入力受け取り。Prisma schema・migration には以前から存在していたが、API レスポンス / リクエストには未公開で UI から触れない状態だった。

## 依存 PR

- **types**: [zaitsu82/komine-types#17](https://github.com/zaitsu82/komine-types/pull/17) — `@komine/types` に bank fields 追加

types PR が merge されてから本 PR の CI が通る (`file:` リンクで取り込んでいるため、main マージ時 npm install 経由)。

## 変更内容

| Controller | 変更 |
|---|---|
| `getPlotById.ts` | `response.roles[].customer` に `bankName/branchName/accountType/accountNumber/accountHolder` を追加（Prisma include はそのまま、レスポンス mapping のみ拡張） |
| `createPlot.ts` | `tx.customer.create` で `input.customer.bankName/branchName/accountType/accountNumber/accountHolder` を `bank_name/branch_name/account_type/account_number/account_holder` に書き込み |
| `updatePlot.ts` | `customerUpdateData` で 5 フィールドの `!== undefined` 判定追加。明示的に `null` 渡された場合は NULL 設定、未指定は touch しない |

## Out of scope

- **history (`recordCustomerUpdated`)** — 5 フィールドの変更履歴追跡は本 PR スコープ外。before/after 構築を変更すると history payload や test mocks に影響が広がるため、必要なら別 PR で対応
- **CreatePlotResponse / UpdatePlotResponse / PlotListItem** の customer は ID + name 中心の minimal 構造のため touch せず（frontend は編集後に getPlotById で再取得）

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` 既存 warnings のみ、新規エラー無し
- [x] `npm test -- --testPathPatterns=plots` 191/191 pass
- [ ] types PR merge 後、実 DB で `GET /plots/:id` が bank fields を返すか確認
- [ ] 後続 frontend PR で UI 経由の round-trip 確認

Refs: `query_result/UI_GAP_SCREEN_03_BASIC_INFO_2.md` (B6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)