### PR TITLE
feat(customer): persist and return registered_postal_code (B5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=acfe23844a5b1b782e8d2e1f2cc1e72735c201d1
+ARG TYPES_REF=fc431c88bf45f385901adaceabc564cc7ccc88fc
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/prisma/migrations/20260520121215_add_customer_registered_postal_code/migration.sql
+++ b/prisma/migrations/20260520121215_add_customer_registered_postal_code/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "customers" ADD COLUMN     "registered_postal_code" VARCHAR(7);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,6 +224,7 @@ model Customer {
   postal_code        String    @db.VarChar(7) // 郵便番号
   address            String    @db.VarChar(200) // 住所
   address_line_2     String?   @db.VarChar(200) // 住所2（2行目）
+  registered_postal_code String? @db.VarChar(7) // 本籍郵便番号（レガシー t_danka.honseki_zip）
   registered_address String?   @db.VarChar(200) // 本籍地
   phone_number       String?   @db.VarChar(11) // 電話番号（nullable: レガシー実データに欠損あり）
   fax_number         String?   @db.VarChar(11) // FAX番号

--- a/scripts/legacy-migration/steps/04-customer.ts
+++ b/scripts/legacy-migration/steps/04-customer.ts
@@ -158,6 +158,7 @@ export const stepCustomer: MigrationStep = {
           gender: parseGender(row.sex_flg),
           postal_code: postalCode,
           address,
+          registered_postal_code: parseLegacyZip(row.honseki_zip),
           registered_address:
             [cleanStr(row.honseki_addr1), cleanStr(row.honseki_addr2)].filter(Boolean).join(' ') ||
             null,

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -90,6 +90,7 @@ export async function createPlotCore(
       postal_code: input.customer.postalCode,
       address: input.customer.address,
       address_line_2: input.customer.addressLine2 || null,
+      registered_postal_code: input.customer.registeredPostalCode || null,
       registered_address: input.customer.registeredAddress || null,
       phone_number: input.customer.phoneNumber,
       fax_number: input.customer.faxNumber || null,

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -317,6 +317,7 @@ export const getPlotById = async (
           postalCode: role.customer.postal_code,
           address: role.customer.address,
           addressLine2: role.customer.address_line_2,
+          registeredPostalCode: role.customer.registered_postal_code,
           registeredAddress: role.customer.registered_address,
           // 振込先情報（ゆうちょ自動払込 CSV 出力用、レガシー t_danka.kikan_name 系から移行）
           bankName: role.customer.bank_name,

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -298,6 +298,8 @@ export async function updatePlotCore(
       if (input.customer.address !== undefined) customerUpdateData.address = input.customer.address;
       if (input.customer.addressLine2 !== undefined)
         customerUpdateData.address_line_2 = input.customer.addressLine2;
+      if (input.customer.registeredPostalCode !== undefined)
+        customerUpdateData.registered_postal_code = input.customer.registeredPostalCode;
       if (input.customer.registeredAddress !== undefined)
         customerUpdateData.registered_address = input.customer.registeredAddress;
       if (input.customer.phoneNumber !== undefined)


### PR DESCRIPTION
## Summary

UI ギャップ B5（本籍郵便番号）の backend 側。types#18 / #19 で揃えたフィールドを Prisma schema・migration・controller・migration step に通す。

- Prisma: \`Customer.registered_postal_code String? @db.VarChar(7)\` を追加
- migration \`20260520121215_add_customer_registered_postal_code\`
- step04-customer.ts: \`t_danka.honseki_zip → parseLegacyZip → registered_postal_code\` をマッピング
- \`createPlot\` / \`updatePlot\` / \`getPlotById\` で registeredPostalCode を扱う
- Dockerfile TYPES_REF を \`fc431c8\` (types#19 merge commit) に bump

## なぜ単独 PR か

types#18 (Customer model) + #19 (API / Zod) と分離した直後の合流地点。frontend PR (B5-3) はこの backend が main 反映後に着手する想定。

## Test plan

- [x] \`npm test\` 全 814 件 pass
- [x] \`npx tsc --noEmit\` 通過
- [ ] Dockerfile build 通過（CI 任せ）
- [ ] \`primary_customer\` レスポンスは型定義無しのため legacy のまま据え置き（後続 PR でレビュー）

Refs: types#18 #19, UI ギャップ B5

🤖 Generated with [Claude Code](https://claude.com/claude-code)