### PR TITLE
feat(masters): add ContractorMaster table + endpoint (C-4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=fc431c88bf45f385901adaceabc564cc7ccc88fc
+ARG TYPES_REF=94cc47ba099eef4a37bd9d835f70d1233c75b4c1
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/prisma/migrations/20260521031607_add_contractor_master/migration.sql
+++ b/prisma/migrations/20260521031607_add_contractor_master/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "contractor_master" (
+    "id" SERIAL NOT NULL,
+    "code" VARCHAR(20) NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "description" VARCHAR(200),
+    "sort_order" INTEGER,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contractor_master_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "contractor_master_code_key" ON "contractor_master"("code");
+
+-- InsertData: 業者名は業務側に未確認のため暫定の代表値のみ投入。
+-- 実際の業者一覧が確定したら is_active を false にして新規 INSERT する想定。
+INSERT INTO "contractor_master" ("code", "name", "sort_order", "updated_at") VALUES
+('placeholder-1',  '小嶺石材',       1, NOW()),
+('placeholder-2',  '小嶺霊園工事部', 2, NOW()),
+('placeholder-3',  '提携業者A',      3, NOW()),
+('placeholder-4',  '提携業者B',      4, NOW()),
+('placeholder-99', 'その他',         99, NOW());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -216,31 +216,31 @@ model ContractPlot {
 
 // 顧客マスタ: 人物情報を一元管理（役割はSaleContractRoleで管理）
 model Customer {
-  id                 String    @id @default(uuid()) @map("customer_id")
-  name               String    @db.VarChar(100) // 氏名
-  name_kana          String    @db.VarChar(100) // 氏名カナ
-  birth_date         DateTime? @db.Date // 生年月日
-  gender             Gender? // 性別
-  postal_code        String    @db.VarChar(7) // 郵便番号
-  address            String    @db.VarChar(200) // 住所
-  address_line_2     String?   @db.VarChar(200) // 住所2（2行目）
-  registered_postal_code String? @db.VarChar(7) // 本籍郵便番号（レガシー t_danka.honseki_zip）
-  registered_address String?   @db.VarChar(200) // 本籍地
-  phone_number       String?   @db.VarChar(11) // 電話番号（nullable: レガシー実データに欠損あり）
-  fax_number         String?   @db.VarChar(11) // FAX番号
-  email              String?   @db.VarChar(254) // メールアドレス（RFC 5321準拠）
+  id                     String    @id @default(uuid()) @map("customer_id")
+  name                   String    @db.VarChar(100) // 氏名
+  name_kana              String    @db.VarChar(100) // 氏名カナ
+  birth_date             DateTime? @db.Date // 生年月日
+  gender                 Gender? // 性別
+  postal_code            String    @db.VarChar(7) // 郵便番号
+  address                String    @db.VarChar(200) // 住所
+  address_line_2         String?   @db.VarChar(200) // 住所2（2行目）
+  registered_postal_code String?   @db.VarChar(7) // 本籍郵便番号（レガシー t_danka.honseki_zip）
+  registered_address     String?   @db.VarChar(200) // 本籍地
+  phone_number           String?   @db.VarChar(11) // 電話番号（nullable: レガシー実データに欠損あり）
+  fax_number             String?   @db.VarChar(11) // FAX番号
+  email                  String?   @db.VarChar(254) // メールアドレス（RFC 5321準拠）
   // 振込先情報（ゆうちょ自動払込CSV 出力用。レガシーで0件運用、新システムで入力していく）
-  bank_name          String?   @db.VarChar(50) // 銀行名
-  branch_name        String?   @db.VarChar(50) // 支店名
-  account_type       String?   @db.VarChar(10) // 預金種目（ordinary/current/savings）
-  account_number     String?   @db.VarChar(20) // 口座番号
-  account_holder     String?   @db.VarChar(100) // 口座名義
-  notes              String?   @db.Text // 備考
-  staff_id           Int? // 担当スタッフFK（レガシー tancd → matant）
-  legacy_danka_cd    Int? // 移行用（レガシー t_danka.danka_cd）
-  created_at         DateTime  @default(now())
-  updated_at         DateTime  @updatedAt
-  deleted_at         DateTime?
+  bank_name              String?   @db.VarChar(50) // 銀行名
+  branch_name            String?   @db.VarChar(50) // 支店名
+  account_type           String?   @db.VarChar(10) // 預金種目（ordinary/current/savings）
+  account_number         String?   @db.VarChar(20) // 口座番号
+  account_holder         String?   @db.VarChar(100) // 口座名義
+  notes                  String?   @db.Text // 備考
+  staff_id               Int? // 担当スタッフFK（レガシー tancd → matant）
+  legacy_danka_cd        Int? // 移行用（レガシー t_danka.danka_cd）
+  created_at             DateTime  @default(now())
+  updated_at             DateTime  @updatedAt
+  deleted_at             DateTime?
 
   // Relations
   staff             Staff?             @relation(fields: [staff_id], references: [id], onDelete: SetNull)
@@ -705,6 +705,21 @@ model RelationshipMaster {
   updated_at  DateTime @updatedAt // 更新日時
 
   @@map("relationship_master")
+}
+
+// 工事業者マスタ（レガシー t_foundlog.gyousha_cd から派生、
+// `ConstructionInfo.contractor` の select 候補として使う）
+model ContractorMaster {
+  id          Int      @id @default(autoincrement()) // ID
+  code        String   @unique @db.VarChar(20) // 業者コード (e.g. legacy-gyousha-{id})
+  name        String   @db.VarChar(100) // 業者名
+  description String?  @db.VarChar(200) // 説明
+  sort_order  Int? // 表示順序
+  is_active   Boolean  @default(true) // 有効フラグ
+  created_at  DateTime @default(now()) // 作成日時
+  updated_at  DateTime @updatedAt // 更新日時
+
+  @@map("contractor_master")
 }
 
 // =============================================================================

--- a/scripts/legacy-migration/steps/09-construction-info.ts
+++ b/scripts/legacy-migration/steps/09-construction-info.ts
@@ -24,7 +24,10 @@ interface FoundlogRow extends RowDataPacket {
 /**
  * t_foundlog → ConstructionInfo
  *
- * - 業者名（gyousha_cd）は contractor フィールドに int 文字列で保持（後でマスタ参照可）
+ * - 業者名（gyousha_cd）は contractor フィールドに `legacy-gyousha-{id}` 形式で保存。
+ *   同名 code を持つ ContractorMaster エントリを upsert で確保し、frontend の
+ *   select が直接ヒット (= 既存値 fallback ではなく master 値として認識) するようにする。
+ *   実際の業者名は業務側確認後にマスタ画面で rename する想定。
  * - work_amount_1 を price、payment_amount_1 を payment に対応
  */
 export const stepConstructionInfo: MigrationStep = {
@@ -37,6 +40,30 @@ export const stepConstructionInfo: MigrationStep = {
     const rows = await legacyQuery<FoundlogRow>(
       `SELECT * FROM t_foundlog WHERE del_flg = 0 OR del_flg IS NULL`
     );
+
+    // 出現する legacy gyousha_cd の一意集合を ContractorMaster に upsert
+    const distinctGyousha = new Set<number>();
+    for (const row of rows) {
+      if (row.gyousha_cd != null) distinctGyousha.add(row.gyousha_cd);
+    }
+    let mastersUpserted = 0;
+    if (!dryRun) {
+      for (const gyoushaCd of distinctGyousha) {
+        const code = `legacy-gyousha-${gyoushaCd}`;
+        await prisma.contractorMaster.upsert({
+          where: { code },
+          create: {
+            code,
+            name: `業者ID:${gyoushaCd}`, // 業務側確認後にリネーム想定
+            sort_order: gyoushaCd,
+            is_active: true,
+          },
+          update: {}, // 既に存在する場合は何もしない (名前は手動で更新可能)
+        });
+        mastersUpserted++;
+      }
+      logger.info({ mastersUpserted }, 'ContractorMaster upserted from legacy gyousha_cd');
+    }
 
     let inserted = 0;
     let skipped = 0;
@@ -71,6 +98,10 @@ export const stepConstructionInfo: MigrationStep = {
       inserted++;
     }
 
-    return { inserted, skipped, notes: { source_rows: rows.length } };
+    return {
+      inserted,
+      skipped,
+      notes: { source_rows: rows.length, contractor_masters_upserted: mastersUpserted },
+    };
   },
 };

--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -355,6 +355,42 @@ export const getRelationshipMaster = async (_req: Request, res: Response) => {
 };
 
 /**
+ * 工事業者マスタ取得
+ * GET /api/v1/masters/contractor
+ */
+export const getContractorMaster = async (_req: Request, res: Response) => {
+  try {
+    const data = await prisma.contractorMaster.findMany({
+      where: { is_active: true },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    const formatted: MasterData[] = data.map((item) => ({
+      id: item.id,
+      code: item.code,
+      name: item.name,
+      description: item.description,
+      sortOrder: item.sort_order,
+      isActive: item.is_active,
+    }));
+
+    res.status(200).json({
+      success: true,
+      data: formatted,
+    });
+  } catch (error) {
+    getRequestLogger().error({ err: error }, 'Error fetching contractor master');
+    res.status(500).json({
+      success: false,
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: '工事業者マスタの取得に失敗しました',
+      },
+    });
+  }
+};
+
+/**
  * マスタタイプからPrismaモデルデリゲートを取得
  */
 const getMasterDelegate = (masterType: MasterType) => {
@@ -368,6 +404,7 @@ const getMasterDelegate = (masterType: MasterType) => {
     'construction-type': prisma.constructionTypeMaster,
     'section-name': prisma.sectionNameMaster,
     relationship: prisma.relationshipMaster,
+    contractor: prisma.contractorMaster,
   };
   return delegateMap[masterType];
 };
@@ -382,6 +419,7 @@ const masterTypeLabels: Record<MasterType, string> = {
   'construction-type': '工事タイプ',
   'section-name': '区画名',
   relationship: '続柄',
+  contractor: '工事業者',
 };
 
 /**
@@ -702,6 +740,7 @@ export const getAllMasters = async (_req: Request, res: Response) => {
       constructionType,
       sectionName,
       relationship,
+      contractor,
     ] = await Promise.all([
       prisma.cemeteryTypeMaster.findMany({
         where: { is_active: true },
@@ -736,6 +775,10 @@ export const getAllMasters = async (_req: Request, res: Response) => {
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
       prisma.relationshipMaster.findMany({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.contractorMaster.findMany({
         where: { is_active: true },
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
@@ -811,6 +854,14 @@ export const getAllMasters = async (_req: Request, res: Response) => {
           isActive: item.is_active,
         })),
         relationship: relationship.map((item) => ({
+          id: item.id,
+          code: item.code,
+          name: item.name,
+          description: item.description,
+          sortOrder: item.sort_order,
+          isActive: item.is_active,
+        })),
+        contractor: contractor.map((item) => ({
           id: item.id,
           code: item.code,
           name: item.name,

--- a/src/masters/masterRoutes.ts
+++ b/src/masters/masterRoutes.ts
@@ -9,6 +9,7 @@ import {
   getConstructionTypeMaster,
   getSectionNameMaster,
   getRelationshipMaster,
+  getContractorMaster,
   getAllMasters,
   createMaster,
   updateMaster,
@@ -98,6 +99,14 @@ router.get(
   authenticate,
   checkApiPermission(),
   withLogging('Masters', 'getRelationshipMaster', getRelationshipMaster)
+);
+
+// 工事業者マスタ
+router.get(
+  '/contractor',
+  authenticate,
+  checkApiPermission(),
+  withLogging('Masters', 'getContractorMaster', getContractorMaster)
 );
 
 // マスタデータ CRUD（汎用）

--- a/src/validations/masterValidation.ts
+++ b/src/validations/masterValidation.ts
@@ -41,6 +41,7 @@ export const VALID_MASTER_TYPES = [
   'construction-type',
   'section-name',
   'relationship',
+  'contractor',
 ] as const;
 
 export type MasterType = (typeof VALID_MASTER_TYPES)[number];

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1738,6 +1738,32 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v1/masters/contractor:
+    get:
+      tags:
+        - Masters
+      summary: 工事業者マスタ一覧取得
+      description: 有効な工事業者マスタデータを表示順で取得（ConstructionInfo.contractor の select 候補）
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 工事業者マスタ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContractorMaster"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v1/masters/all:
     get:
       tags:
@@ -1768,6 +1794,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/RelationshipMaster"
+                      contractor:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ContractorMaster"
         "401":
           $ref: "#/components/responses/Unauthorized"
 
@@ -2048,6 +2078,30 @@ components:
         name:
           type: string
           example: "配偶者"
+        description:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+          nullable: true
+          example: 1
+        isActive:
+          type: boolean
+          example: true
+
+    ContractorMaster:
+      type: object
+      description: 工事業者マスタ (ConstructionInfo.contractor の select 候補)
+      properties:
+        id:
+          type: integer
+          example: 1
+        code:
+          type: string
+          example: "placeholder-1"
+        name:
+          type: string
+          example: "小嶺石材"
         description:
           type: string
           nullable: true

--- a/tests/masters/masterController.test.ts
+++ b/tests/masters/masterController.test.ts
@@ -109,6 +109,25 @@ const mockRelationshipData = [
   { id: 2, code: 'child', name: '子', description: null, sort_order: 2, is_active: true },
 ];
 
+const mockContractorData = [
+  {
+    id: 1,
+    code: 'placeholder-1',
+    name: '小嶺石材',
+    description: null,
+    sort_order: 1,
+    is_active: true,
+  },
+  {
+    id: 2,
+    code: 'placeholder-99',
+    name: 'その他',
+    description: null,
+    sort_order: 99,
+    is_active: true,
+  },
+];
+
 // モックプリズマインスタンスの作成
 const mockPrisma: any = {
   cemeteryTypeMaster: {
@@ -138,6 +157,9 @@ const mockPrisma: any = {
   relationshipMaster: {
     findMany: jest.fn(),
   },
+  contractorMaster: {
+    findMany: jest.fn(),
+  },
 };
 
 // PrismaClientをモック化
@@ -156,6 +178,7 @@ import {
   getConstructionTypeMaster,
   getSectionNameMaster,
   getRelationshipMaster,
+  getContractorMaster,
   getAllMasters,
 } from '../../src/masters/masterController';
 
@@ -640,6 +663,7 @@ describe('Master Controller', () => {
       mockPrisma.constructionTypeMaster.findMany.mockResolvedValue(mockConstructionTypeData);
       mockPrisma.sectionNameMaster.findMany.mockResolvedValue(mockSectionNameData);
       mockPrisma.relationshipMaster.findMany.mockResolvedValue(mockRelationshipData);
+      mockPrisma.contractorMaster.findMany.mockResolvedValue(mockContractorData);
 
       await getAllMasters(mockRequest as Request, mockResponse as Response);
 
@@ -657,6 +681,7 @@ describe('Master Controller', () => {
       expect(jsonCall.data.constructionType).toHaveLength(2);
       expect(jsonCall.data.sectionName).toHaveLength(2);
       expect(jsonCall.data.relationship).toHaveLength(2);
+      expect(jsonCall.data.contractor).toHaveLength(2);
 
       // 特殊フィールドのテスト（taxRate）
       expect(jsonCall.data.taxType[0].taxRate).toBe('10');
@@ -665,10 +690,23 @@ describe('Master Controller', () => {
       // 続柄
       expect(jsonCall.data.relationship[0].code).toBe('spouse');
       expect(jsonCall.data.relationship[0].name).toBe('配偶者');
+      // 工事業者
+      expect(jsonCall.data.contractor[0].code).toBe('placeholder-1');
+      expect(jsonCall.data.contractor[0].name).toBe('小嶺石材');
     });
 
     it('エラーが発生した場合、500エラーを返すこと', async () => {
       mockPrisma.cemeteryTypeMaster.findMany.mockRejectedValue(new Error('Database error'));
+      // Promise.all で同時に走るので他のマスタは resolved に設定しておく
+      mockPrisma.paymentMethodMaster.findMany.mockResolvedValue([]);
+      mockPrisma.taxTypeMaster.findMany.mockResolvedValue([]);
+      mockPrisma.calcTypeMaster.findMany.mockResolvedValue([]);
+      mockPrisma.billingTypeMaster.findMany.mockResolvedValue([]);
+      mockPrisma.recipientTypeMaster.findMany.mockResolvedValue([]);
+      mockPrisma.constructionTypeMaster.findMany.mockResolvedValue([]);
+      mockPrisma.sectionNameMaster.findMany.mockResolvedValue([]);
+      mockPrisma.relationshipMaster.findMany.mockResolvedValue([]);
+      mockPrisma.contractorMaster.findMany.mockResolvedValue([]);
 
       await getAllMasters(mockRequest as Request, mockResponse as Response);
 
@@ -678,6 +716,56 @@ describe('Master Controller', () => {
         error: {
           code: 'INTERNAL_SERVER_ERROR',
           message: '全マスタデータの取得に失敗しました',
+        },
+      });
+    });
+  });
+
+  describe('getContractorMaster', () => {
+    it('工事業者マスタを取得できること', async () => {
+      mockPrisma.contractorMaster.findMany.mockResolvedValue(mockContractorData);
+
+      await getContractorMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.contractorMaster.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          {
+            id: 1,
+            code: 'placeholder-1',
+            name: '小嶺石材',
+            description: null,
+            sortOrder: 1,
+            isActive: true,
+          },
+          {
+            id: 2,
+            code: 'placeholder-99',
+            name: 'その他',
+            description: null,
+            sortOrder: 99,
+            isActive: true,
+          },
+        ],
+      });
+    });
+
+    it('エラーが発生した場合、500エラーを返すこと', async () => {
+      mockPrisma.contractorMaster.findMany.mockRejectedValue(new Error('Database error'));
+
+      await getContractorMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: false,
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: '工事業者マスタの取得に失敗しました',
         },
       });
     });


### PR DESCRIPTION
## Summary

`ConstructionInfo.contractor` は free-text VARCHAR(100) のまま残しつつ、
master 側のインフラを追加して frontend で select 化できるようにする。

- **Prisma**: ContractorMaster (contractor_master) テーブル追加
- **migration** `20260521031607_add_contractor_master`: CREATE TABLE + 暫定 placeholder 5 件 INSERT
- **API**: `GET /api/v1/masters/contractor` (個別) + `/masters/all` に追加
- **step09 修正**: 出現する `gyousha_cd` を ContractorMaster に upsert (code=`legacy-gyousha-{id}`, name=`業者ID:{id}`) — 既存の `contractor = "legacy-gyousha-{id}"` 文字列がそのまま master 直接ヒットするようコードを揃える
- **swagger.yaml** 更新
- **TYPES_REF bump**: types#20 (94cc47b) — security措置 backend#60 の指示通り

## 設計判断

- `contractor` カラム自体は VARCHAR のまま (FK ではない)。C-1 (RelationshipMaster) と同じ「string ベース master ヒット」パターン。frontend は master に無い値を `(既存値)` として fallback 表示する。
- placeholder 名は仮 — 業務側に確認するまでは暫定値で `is_active=true`。確認後にマスタ画面 (or 直接 SQL) で rename する想定。
- step09 自身の `contractor` 文字列ロジックは変更なし。master 側を後付けで追加するだけ。

## Refs

- `query_result/UI_GAP_HANDOFF.md` Phase 5 C-4
- types side: zaitsu82/komine-types#20 (94cc47b に merge 済み)
- frontend side: 後続 PR で UI を select 化

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 816/816 passed (masters: 22/22 含む)
- [x] `npm run lint` — pre-existing warnings only, 0 errors
- [x] `npm run swagger:validate` — OpenAPI valid
- [x] migration `20260521031607_add_contractor_master` は本番 DB に prisma migrate deploy で適用 (placeholder seed 5 件含む)
- [x] step09 再実行は移行スクリプト側の運用次第 (既存データには影響なし)