### PR TITLE
feat(plots): add grave classification filter + distinct endpoint (B11)

### DIFF
--- a/src/plots/controllers/getGraveClassifications.ts
+++ b/src/plots/controllers/getGraveClassifications.ts
@@ -1,0 +1,47 @@
+/**
+ * 区画区分の distinct 値取得コントローラー
+ * GET /api/v1/plots/grave-classifications
+ *
+ * ContractPlot に存在する grave_kind / grave_kubun / grave_type の
+ * 一意な値の一覧を返す。区画一覧画面のフィルタ select 用。
+ * master 化されるまでの暫定エンドポイント。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import prisma from '../../db/prisma';
+
+export const getGraveClassifications = async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const [kinds, kubuns, types] = await Promise.all([
+      prisma.contractPlot.findMany({
+        where: { deleted_at: null, grave_kind: { not: null } },
+        select: { grave_kind: true },
+        distinct: ['grave_kind'],
+        orderBy: { grave_kind: 'asc' },
+      }),
+      prisma.contractPlot.findMany({
+        where: { deleted_at: null, grave_kubun: { not: null } },
+        select: { grave_kubun: true },
+        distinct: ['grave_kubun'],
+        orderBy: { grave_kubun: 'asc' },
+      }),
+      prisma.contractPlot.findMany({
+        where: { deleted_at: null, grave_type: { not: null } },
+        select: { grave_type: true },
+        distinct: ['grave_type'],
+        orderBy: { grave_type: 'asc' },
+      }),
+    ]);
+
+    res.status(200).json({
+      success: true,
+      data: {
+        graveKinds: kinds.map((r) => r.grave_kind).filter((v): v is number => v !== null),
+        graveKubuns: kubuns.map((r) => r.grave_kubun).filter((v): v is number => v !== null),
+        graveTypes: types.map((r) => r.grave_type).filter((v): v is number => v !== null),
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -25,6 +25,9 @@ interface PlotSearchQuery {
     | 'createdAt';
   sortOrder?: 'asc' | 'desc';
   nameKanaPrefix?: string;
+  graveKind?: number;
+  graveKubun?: number;
+  graveType?: number;
 }
 
 /**
@@ -43,6 +46,9 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
       sortBy,
       sortOrder = 'asc',
       nameKanaPrefix,
+      graveKind,
+      graveKubun,
+      graveType,
     } = req.query as unknown as PlotSearchQuery;
 
     // ページネーション計算
@@ -110,6 +116,17 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
     // 入金ステータスフィルター
     if (paymentStatus) {
       whereCondition.payment_status = paymentStatus;
+    }
+
+    // 区分フィルター（grave_kind / grave_kubun / grave_type）
+    if (graveKind !== undefined) {
+      whereCondition.grave_kind = graveKind;
+    }
+    if (graveKubun !== undefined) {
+      whereCondition.grave_kubun = graveKubun;
+    }
+    if (graveType !== undefined) {
+      whereCondition.grave_type = graveType;
     }
 
     // フリガナ先頭文字フィルター（あいうえおタブ用）

--- a/src/plots/controllers/index.ts
+++ b/src/plots/controllers/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { getPlots } from './getPlots';
+export { getGraveClassifications } from './getGraveClassifications';
 export { getPlotById } from './getPlotById';
 export { createPlot } from './createPlot';
 export { bulkCreatePlots } from './bulkCreatePlots';

--- a/src/plots/plotRoutes.ts
+++ b/src/plots/plotRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   getPlots,
+  getGraveClassifications,
   getPlotById,
   createPlot,
   bulkCreatePlots,
@@ -45,6 +46,14 @@ router.get(
   requirePermission(['viewer', 'operator', 'manager', 'admin']),
   validate({ query: plotSearchQuerySchema }),
   withLogging('Plots', 'getPlots', getPlots)
+);
+
+// 区画区分（grave_kind/kubun/type）の distinct 値取得（フィルタ select 用）
+router.get(
+  '/grave-classifications',
+  authenticate,
+  requirePermission(['viewer', 'operator', 'manager', 'admin']),
+  withLogging('Plots', 'getGraveClassifications', getGraveClassifications)
 );
 
 // ==========================================

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -23,6 +23,15 @@ import {
 /**
  * Plot検索クエリのバリデーションスキーマ
  */
+const graveClassificationParam = z
+  .string()
+  .optional()
+  .transform((val) => {
+    if (val === undefined || val === '') return undefined;
+    const n = parseInt(val, 10);
+    return Number.isNaN(n) ? undefined : n;
+  });
+
 export const plotSearchQuerySchema = paginationSchema.extend({
   search: z.string().optional(),
   status: z.enum(['available', 'partially_sold', 'sold_out']).optional(), // PhysicalPlotStatus ENUM
@@ -42,6 +51,9 @@ export const plotSearchQuerySchema = paginationSchema.extend({
     .optional(),
   sortOrder: z.enum(['asc', 'desc']).optional(),
   nameKanaPrefix: z.string().max(5).optional(),
+  graveKind: graveClassificationParam,
+  graveKubun: graveClassificationParam,
+  graveType: graveClassificationParam,
 });
 
 /**

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -122,6 +122,21 @@ paths:
           description: 墓地タイプフィルタ
           schema:
             type: string
+        - name: graveKind
+          in: query
+          description: 区画区分フィルタ（grave_kind、レガシー tinyint 値）
+          schema:
+            type: integer
+        - name: graveKubun
+          in: query
+          description: 区画区分フィルタ（grave_kubun、レガシー tinyint 値）
+          schema:
+            type: integer
+        - name: graveType
+          in: query
+          description: 区画区分フィルタ（grave_type、レガシー tinyint 値）
+          schema:
+            type: integer
       responses:
         "200":
           description: 取得成功
@@ -184,6 +199,48 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "409":
           $ref: "#/components/responses/Conflict"
+
+  /api/v1/plots/grave-classifications:
+    get:
+      tags:
+        - Plots
+      summary: 区画区分 distinct 値取得
+      description: |
+        ContractPlot に存在する grave_kind / grave_kubun / grave_type の
+        一意な値の一覧を返します。区画一覧画面のフィルタ select 用。
+        master 化されるまでの暫定エンドポイントです。
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      graveKinds:
+                        type: array
+                        items:
+                          type: integer
+                      graveKubuns:
+                        type: array
+                        items:
+                          type: integer
+                      graveTypes:
+                        type: array
+                        items:
+                          type: integer
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 
   /api/v1/plots/bulk:
     post:

--- a/tests/plots/getGraveClassifications.test.ts
+++ b/tests/plots/getGraveClassifications.test.ts
@@ -1,0 +1,96 @@
+/**
+ * getGraveClassifications コントローラーのテスト
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+// モックプリズマインスタンス
+const mockPrisma: any = {
+  contractPlot: {
+    findMany: jest.fn(),
+  },
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+}));
+
+import { getGraveClassifications } from '../../src/plots/controllers/getGraveClassifications';
+
+describe('getGraveClassifications', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseJson: jest.Mock;
+  let responseStatus: jest.Mock;
+  let mockNext: jest.Mock;
+
+  beforeEach(() => {
+    responseJson = jest.fn().mockReturnThis();
+    responseStatus = jest.fn().mockReturnThis();
+    mockRequest = {};
+    mockResponse = {
+      status: responseStatus,
+      json: responseJson,
+    };
+    mockNext = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it('should return distinct grave classification values', async () => {
+    mockPrisma.contractPlot.findMany
+      .mockResolvedValueOnce([{ grave_kind: 1 }, { grave_kind: 2 }])
+      .mockResolvedValueOnce([{ grave_kubun: 3 }, { grave_kubun: 5 }, { grave_kubun: 9 }])
+      .mockResolvedValueOnce([{ grave_type: 1 }]);
+
+    await getGraveClassifications(
+      mockRequest as Request,
+      mockResponse as Response,
+      mockNext as NextFunction
+    );
+
+    expect(responseStatus).toHaveBeenCalledWith(200);
+    expect(responseJson).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        graveKinds: [1, 2],
+        graveKubuns: [3, 5, 9],
+        graveTypes: [1],
+      },
+    });
+  });
+
+  it('should filter out null values returned by Prisma', async () => {
+    mockPrisma.contractPlot.findMany
+      .mockResolvedValueOnce([{ grave_kind: 1 }, { grave_kind: null }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ grave_type: null }, { grave_type: 7 }]);
+
+    await getGraveClassifications(
+      mockRequest as Request,
+      mockResponse as Response,
+      mockNext as NextFunction
+    );
+
+    expect(responseJson).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        graveKinds: [1],
+        graveKubuns: [],
+        graveTypes: [7],
+      },
+    });
+  });
+
+  it('should pass error to next on Prisma failure', async () => {
+    const dbErr = new Error('db boom');
+    mockPrisma.contractPlot.findMany.mockRejectedValueOnce(dbErr);
+
+    await getGraveClassifications(
+      mockRequest as Request,
+      mockResponse as Response,
+      mockNext as NextFunction
+    );
+
+    expect(mockNext).toHaveBeenCalledWith(dbErr);
+  });
+});

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -370,6 +370,45 @@ describe('Plot Controller (ContractPlot Model)', () => {
         })
       );
     });
+
+    it('should apply grave_kind / grave_kubun / grave_type filters when provided', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = {
+        page: 1,
+        limit: 10,
+        graveKind: 1,
+        graveKubun: 3,
+        graveType: 2,
+      } as any;
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.contractPlot.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            grave_kind: 1,
+            grave_kubun: 3,
+            grave_type: 2,
+          }),
+        })
+      );
+    });
+
+    it('should not apply grave classification filters when omitted', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: 1, limit: 10 } as any;
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const whereArg = mockPrisma.contractPlot.findMany.mock.calls[0][0].where;
+      expect(whereArg).not.toHaveProperty('grave_kind');
+      expect(whereArg).not.toHaveProperty('grave_kubun');
+      expect(whereArg).not.toHaveProperty('grave_type');
+    });
   });
 
   describe('getPlotById', () => {

--- a/tests/plots/plotRoutes.test.ts
+++ b/tests/plots/plotRoutes.test.ts
@@ -48,6 +48,12 @@ jest.mock('../../src/middleware/validation', () => {
 // モックコントローラー
 jest.mock('../../src/plots/controllers', () => ({
   getPlots: jest.fn((req, res) => res.status(200).json({ success: true, data: [] })),
+  getGraveClassifications: jest.fn((req, res) =>
+    res.status(200).json({
+      success: true,
+      data: { graveKinds: [], graveKubuns: [], graveTypes: [] },
+    })
+  ),
   getPlotById: jest.fn((req, res) => res.status(200).json({ success: true, data: {} })),
   createPlot: jest.fn((req, res) => res.status(201).json({ success: true, data: {} })),
   bulkCreatePlots: jest.fn((req, res) => res.status(201).json({ success: true, data: {} })),
@@ -75,6 +81,7 @@ jest.mock('../../src/plots/controllers', () => ({
 
 import {
   getPlots,
+  getGraveClassifications,
   getPlotById,
   createPlot,
   updatePlot,
@@ -104,6 +111,17 @@ describe('Plot Routes', () => {
       expect(response.status).toBe(200);
       expect(getPlots).toHaveBeenCalled();
       expect(response.body.success).toBe(true);
+    });
+  });
+
+  describe('GET /api/v1/plots/grave-classifications', () => {
+    it('should call getGraveClassifications controller', async () => {
+      const response = await request(app).get('/api/v1/plots/grave-classifications');
+
+      expect(response.status).toBe(200);
+      expect(getGraveClassifications).toHaveBeenCalled();
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toEqual({ graveKinds: [], graveKubuns: [], graveTypes: [] });
     });
   });
 


### PR DESCRIPTION
## Summary
- `GET /plots` に `graveKind` / `graveKubun` / `graveType` クエリパラメータ追加
- 新規 `GET /plots/grave-classifications` を追加し、ContractPlot 上の distinct な区分値を返す（フィルタ select 用）
- swagger.yaml に新パラメータ・エンドポイント反映、テスト 6 ケース追加（既存 getPlots 2 / 新規 getGraveClassifications 3 / Routes 1）

## Context
画面01「区画一覧（台帳問合せ）」の **B11**（区分フィルタ）の backend 側。
- 関連: types#21、frontend `feature/plot-list-grave-classification-filter`
- 参考: `query_result/UI_GAP_SCREEN_01_PLOT_LIST.md` 「区分（全て）」フィルタ
- grave_kind / grave_kubun / grave_type は ContractPlot に Int で保持済み（レガシー由来 tinyint）。master 化までは raw 値で表示・絞り込みする暫定実装

## Notes
- TYPES_REF bump は不要（本 PR は @komine/types からの新 import を含まない）
- Docker Security Scan は現行 TYPES_REF のままで通る想定

## Test plan
- [x] backend 822 件のテストが全 pass
- [x] swagger validate green
- [ ] CI green（Build / Lint / Test / Docker Security Scan / E2E）
- [ ] frontend PR と合わせて画面01 でフィルタ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)