### PR TITLE
feat(plots): support applicant Customer in create/update plot API (B2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=94cc47ba099eef4a37bd9d835f70d1233c75b4c1
+ARG TYPES_REF=913571ce1b87097ebd4c2da1b34014837d883c91
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -207,6 +207,44 @@ export async function createPlotCore(
     createdRoles.push({ id: created.id, role: created.role, customer_id: created.customer_id });
   }
 
+  // 7.5. 申込者（applicant）の作成（任意）
+  // 旧画面は申込者と契約者を並列に持つ。指定された場合は別 Customer +
+  // SaleContractRole(role=applicant) として保存する。
+  if (input.applicant) {
+    const applicantCustomer = await tx.customer.create({
+      data: {
+        name: input.applicant.name,
+        name_kana: input.applicant.nameKana,
+        birth_date: input.applicant.birthDate ? new Date(input.applicant.birthDate) : null,
+        gender: input.applicant.gender || null,
+        postal_code: input.applicant.postalCode || '',
+        address: input.applicant.address || '',
+        address_line_2: input.applicant.addressLine2 || null,
+        registered_postal_code: input.applicant.registeredPostalCode || null,
+        registered_address: input.applicant.registeredAddress || null,
+        phone_number: input.applicant.phoneNumber ?? null,
+        fax_number: input.applicant.faxNumber || null,
+        email: input.applicant.email || null,
+        notes: input.applicant.notes || null,
+        staff_id: input.applicant.staffId ?? null,
+        legacy_danka_cd: input.applicant.legacyDankaCd ?? null,
+      },
+    });
+    const applicantRoleRecord = await tx.saleContractRole.create({
+      data: {
+        contract_plot_id: contractPlot.id,
+        customer_id: applicantCustomer.id,
+        role: ContractRole.applicant,
+      },
+    });
+    createdRoles.push({
+      id: applicantRoleRecord.id,
+      role: applicantRoleRecord.role,
+      customer_id: applicantRoleRecord.customer_id,
+    });
+    await recordCustomerCreated(tx, applicantCustomer, contractPlot.id, physicalPlot.id, req);
+  }
+
   // 8. 使用料情報の作成
   let usageFee: { id: string } | null = null;
   if (input.usageFee) {

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -6,13 +6,14 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { Prisma } from '@prisma/client';
+import { Prisma, ContractRole } from '@prisma/client';
 import { UpdatePlotRequest } from '@komine/types';
 import { updatePhysicalPlotStatus } from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
 import {
   recordContractPlotUpdated,
+  recordCustomerCreated,
   recordCustomerUpdated,
   recordEntityCreated,
   recordEntityUpdated,
@@ -428,6 +429,126 @@ export async function updatePlotCore(
 
       // 6. BillingInfo は新スキーマで廃止された。
       // 振込先情報は今後 Billing/Payment エンティティから扱う予定（Phase 3で実装）。
+    }
+  }
+
+  // 6.5. 申込者（applicant）の upsert / 解除
+  // undefined: 変更なし / null: 既存の applicant role を soft-delete /
+  // object: 既存あれば更新、なければ Customer + role を新規作成。
+  if (input.applicant !== undefined) {
+    const existingApplicantRole = existingContractPlot.saleContractRoles?.find(
+      (r) => r.role === ContractRole.applicant
+    );
+
+    if (input.applicant === null) {
+      if (existingApplicantRole) {
+        await tx.saleContractRole.update({
+          where: { id: existingApplicantRole.id },
+          data: { deleted_at: new Date() },
+        });
+        await recordEntityDeleted(tx, {
+          entityType: 'SaleContractRole',
+          entityId: existingApplicantRole.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: existingApplicantRole.id,
+            role: existingApplicantRole.role,
+            customer_id: existingApplicantRole.customer_id,
+          },
+          req,
+        });
+      }
+    } else if (existingApplicantRole) {
+      // 既存の applicant Customer を部分更新
+      const applicantCustomerId = existingApplicantRole.customer.id;
+      const applicantUpdateData: any = {};
+      if (input.applicant.name !== undefined) applicantUpdateData.name = input.applicant.name;
+      if (input.applicant.nameKana !== undefined)
+        applicantUpdateData.name_kana = input.applicant.nameKana;
+      if (input.applicant.birthDate !== undefined) {
+        applicantUpdateData.birth_date = input.applicant.birthDate
+          ? new Date(input.applicant.birthDate)
+          : null;
+      }
+      if (input.applicant.gender !== undefined) applicantUpdateData.gender = input.applicant.gender;
+      if (input.applicant.postalCode !== undefined)
+        applicantUpdateData.postal_code = input.applicant.postalCode ?? '';
+      if (input.applicant.address !== undefined)
+        applicantUpdateData.address = input.applicant.address ?? '';
+      if (input.applicant.addressLine2 !== undefined)
+        applicantUpdateData.address_line_2 = input.applicant.addressLine2;
+      if (input.applicant.registeredPostalCode !== undefined)
+        applicantUpdateData.registered_postal_code = input.applicant.registeredPostalCode;
+      if (input.applicant.registeredAddress !== undefined)
+        applicantUpdateData.registered_address = input.applicant.registeredAddress;
+      if (input.applicant.phoneNumber !== undefined)
+        applicantUpdateData.phone_number = input.applicant.phoneNumber;
+      if (input.applicant.faxNumber !== undefined)
+        applicantUpdateData.fax_number = input.applicant.faxNumber;
+      if (input.applicant.email !== undefined) applicantUpdateData.email = input.applicant.email;
+      if (input.applicant.notes !== undefined) applicantUpdateData.notes = input.applicant.notes;
+
+      if (Object.keys(applicantUpdateData).length > 0) {
+        const before = existingApplicantRole.customer;
+        const updated = await tx.customer.update({
+          where: { id: applicantCustomerId },
+          data: applicantUpdateData,
+        });
+        await recordCustomerUpdated(
+          tx,
+          before as unknown as Record<string, unknown>,
+          updated as unknown as Record<string, unknown>,
+          applicantCustomerId,
+          id,
+          physicalPlotId,
+          req
+        );
+      }
+    } else {
+      // 新規 Customer + applicant role を作成
+      if (!input.applicant.name || !input.applicant.nameKana) {
+        throw new ValidationError('申込者の氏名・氏名カナは必須です');
+      }
+      const applicantCustomer = await tx.customer.create({
+        data: {
+          name: input.applicant.name,
+          name_kana: input.applicant.nameKana,
+          birth_date: input.applicant.birthDate ? new Date(input.applicant.birthDate) : null,
+          gender: input.applicant.gender || null,
+          postal_code: input.applicant.postalCode || '',
+          address: input.applicant.address || '',
+          address_line_2: input.applicant.addressLine2 || null,
+          registered_postal_code: input.applicant.registeredPostalCode || null,
+          registered_address: input.applicant.registeredAddress || null,
+          phone_number: input.applicant.phoneNumber ?? null,
+          fax_number: input.applicant.faxNumber || null,
+          email: input.applicant.email || null,
+          notes: input.applicant.notes || null,
+          staff_id: input.applicant.staffId ?? null,
+          legacy_danka_cd: input.applicant.legacyDankaCd ?? null,
+        },
+      });
+      const createdRole = await tx.saleContractRole.create({
+        data: {
+          contract_plot_id: id,
+          customer_id: applicantCustomer.id,
+          role: ContractRole.applicant,
+        },
+      });
+      await recordCustomerCreated(tx, applicantCustomer, id, physicalPlotId, req);
+      await recordEntityCreated(tx, {
+        entityType: 'SaleContractRole',
+        entityId: createdRole.id,
+        physicalPlotId,
+        contractPlotId: id,
+        afterRecord: {
+          id: createdRole.id,
+          role: createdRole.role,
+          customer_id: createdRole.customer_id,
+        },
+        req,
+      });
     }
   }
 

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -875,6 +875,90 @@ describe('Plot Controller (ContractPlot Model)', () => {
       expect(responseStatus).toHaveBeenCalledWith(201);
     });
 
+    it('should create applicant as separate customer + role when provided', async () => {
+      const mockInput = {
+        physicalPlot: {
+          plotNumber: 'A-01',
+          areaName: '一般墓地A',
+          areaSqm: 3.6,
+        },
+        contractPlot: {
+          contractAreaSqm: 3.6,
+        },
+        saleContract: {
+          contractDate: '2024-01-01',
+          price: 1000000,
+        },
+        customer: {
+          name: '山田太郎',
+          nameKana: 'ヤマダタロウ',
+          postalCode: '1500001',
+          address: '東京都渋谷区',
+          phoneNumber: '0312345678',
+        },
+        applicant: {
+          name: '山田花子',
+          nameKana: 'ヤマダハナコ',
+          postalCode: '1500001',
+          address: '東京都渋谷区',
+          phoneNumber: '0312345679',
+        },
+      };
+
+      const mockContractor = { id: 'c1', name: '山田太郎' };
+      const mockApplicant = { id: 'c2', name: '山田花子' };
+
+      mockPrisma.physicalPlot.create.mockResolvedValue({
+        id: 'pp1',
+        plot_number: 'A-01',
+        area_name: '一般墓地A',
+        area_sqm: new Prisma.Decimal(3.6),
+        status: 'sold_out',
+      });
+      mockPrisma.customer.create
+        .mockResolvedValueOnce(mockContractor)
+        .mockResolvedValueOnce(mockApplicant);
+      mockPrisma.contractPlot.create.mockResolvedValue({ id: 'cp1' });
+      mockPrisma.saleContractRole.create
+        .mockResolvedValueOnce({ id: 'scr1', role: 'contractor', customer_id: 'c1' })
+        .mockResolvedValueOnce({ id: 'scr2', role: 'applicant', customer_id: 'c2' });
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        contract_date: new Date('2024-01-01'),
+        price: 1000000,
+        payment_status: 'unpaid',
+        created_at: new Date(),
+        updated_at: new Date(),
+        physicalPlot: {
+          id: 'pp1',
+          plot_number: 'A-01',
+          area_name: '一般墓地A',
+          area_sqm: new Prisma.Decimal(3.6),
+          status: 'sold_out',
+        },
+        saleContractRoles: [
+          { id: 'scr1', role: 'contractor', customer: mockContractor },
+          { id: 'scr2', role: 'applicant', customer: mockApplicant },
+        ],
+        usageFee: null,
+        managementFee: null,
+      });
+
+      mockRequest.body = mockInput;
+
+      await createPlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.customer.create).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledTimes(2);
+      const roleCalls = (mockPrisma.saleContractRole.create as jest.Mock).mock.calls.map(
+        (c: any[]) => c[0].data.role
+      );
+      expect(roleCalls).toContain('contractor');
+      expect(roleCalls).toContain('applicant');
+      expect(responseStatus).toHaveBeenCalledWith(201);
+    });
+
     it('should return error when plotNumber and areaName are missing for new physical plot', async () => {
       mockRequest.body = {
         physicalPlot: {
@@ -945,6 +1029,145 @@ describe('Plot Controller (ContractPlot Model)', () => {
       await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(ValidationError));
+    });
+
+    it('should create applicant Customer + role when applicant provided and no existing applicant', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.customer.create.mockResolvedValue({ id: 'c2', name: '山田花子' });
+      mockPrisma.saleContractRole.create.mockResolvedValue({
+        id: 'scr2',
+        role: 'applicant',
+        customer_id: 'c2',
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        applicant: {
+          name: '山田花子',
+          nameKana: 'ヤマダハナコ',
+        },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.customer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ name: '山田花子', name_kana: 'ヤマダハナコ' }),
+        })
+      );
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ role: 'applicant', customer_id: 'c2' }),
+        })
+      );
+    });
+
+    it('should update existing applicant Customer when applicant role already exists', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+          {
+            id: 'scr2',
+            role: 'applicant',
+            customer: { id: 'c2', name: '山田花子' },
+            customer_id: 'c2',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.customer.update.mockResolvedValue({ id: 'c2', name: '山田花江' });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        applicant: { name: '山田花江' },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.customer.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'c2' },
+          data: expect.objectContaining({ name: '山田花江' }),
+        })
+      );
+      expect(mockPrisma.saleContractRole.create).not.toHaveBeenCalled();
+    });
+
+    it('should soft-delete applicant role when applicant=null', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+          {
+            id: 'scr2',
+            role: 'applicant',
+            customer: { id: 'c2', name: '山田花子' },
+            customer_id: 'c2',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.saleContractRole.update.mockResolvedValue({ id: 'scr2' });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = { applicant: null };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.saleContractRole.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'scr2' },
+          data: expect.objectContaining({ deleted_at: expect.any(Date) }),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- `createPlot`: `input.applicant` 指定時は別 Customer + `SaleContractRole(role=applicant)` を作成
- `updatePlot`: `applicant` フィールドで upsert / 解除
  - `undefined` → 変更なし
  - `null` → 既存の applicant role を soft-delete
  - object → 既存あり：Customer 部分更新、なし：Customer + role を新規作成
- 履歴を `recordCustomerCreated/Updated` / `recordEntityCreated/Deleted` で記録
- 関連テスト 4 件追加（createPlot 1 + updatePlot 3）

## Why

旧画面（`02_基本情報①画面.JPG`）は「申込者」と「契約者」を並列に両方表示するが、
これまで新APIは `customer` 1 人だけだった（B1 で詳細View 側は両方表示できたが、
Form 側は片肺）。types PR で追加された `applicant` フィールドを backend で受け付け、
複数 role を扱えるようにする。

UI gap 分析 `UI_GAP_SCREEN_02_BASIC_INFO_1.md` の **B2** に対応。

## Dependencies

- depends-on: https://github.com/zaitsu82/komine-types/pull/23 (types PR)
- types マージ後、follow-up で Dockerfile の `TYPES_REF` を bump 予定

## Test plan

- [x] backend unit tests pass (`npm test` — 830 tests pass, 4 new)
- [x] backend build clean (`npm run build`)
- [x] backend lint clean (`npm run lint` — 0 errors)
- [ ] frontend で動作確認（次の PR で対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)