### PR TITLE
fix(errors): handle P2002 meta shape change in Prisma v7

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -152,13 +152,63 @@ export const errorHandler = (error: any, req: Request, res: Response, _next: Nex
 };
 
 /**
+ * P2002 (unique 制約違反) の field 名を抽出する。
+ * Prisma v6 までは meta.target に入っていたが、v7 + @prisma/adapter-pg では
+ * meta.driverAdapterError.cause.constraint.fields に入る。どちらも取れない
+ * 場合は error.message ("Unique constraint failed on the fields: (`xxx`)")
+ * を正規表現でパースしてフォールバックする。
+ */
+const extractP2002Fields = (error: Prisma.PrismaClientKnownRequestError): string[] => {
+  const meta = error.meta as Record<string, unknown> | undefined;
+
+  const target = meta?.['target'];
+  if (Array.isArray(target)) return target.filter((f): f is string => typeof f === 'string');
+  if (typeof target === 'string')
+    return target
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+  const driverAdapterError = meta?.['driverAdapterError'] as
+    | { cause?: { constraint?: { fields?: unknown } } }
+    | undefined;
+  const adapterFields = driverAdapterError?.cause?.constraint?.fields;
+  if (Array.isArray(adapterFields)) {
+    const fields = adapterFields.filter((f): f is string => typeof f === 'string');
+    if (fields.length > 0) return fields;
+  }
+
+  const match = error.message.match(/fields:\s*\(([^)]+)\)/);
+  if (match) {
+    return match[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^`|`$/g, ''))
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+const FIELD_LABEL_MAP: Record<string, string> = {
+  plot_number: '区画番号',
+  email: 'メールアドレス',
+  supabase_uid: 'Supabaseユーザー',
+  contract_plot_id: '契約区画',
+  customer_id: '顧客',
+  code: 'コード',
+};
+
+const toFieldLabel = (field: string): string => FIELD_LABEL_MAP[field] ?? field;
+
+/**
  * Prismaエラーハンドラー
  */
 const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Response) => {
   switch (error.code) {
     case 'P2002': {
-      // Unique constraint violation
-      const target = error.meta?.['target'] as string[];
+      const fields = extractP2002Fields(error);
+      const fieldKey = fields.join(', ');
+      const fieldLabel = fields.length > 0 ? fields.map(toFieldLabel).join(', ') : 'データ';
       return res.status(409).json({
         success: false,
         error: {
@@ -166,8 +216,8 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
           message: '重複するデータが存在します',
           details: [
             {
-              field: target?.join(', '),
-              message: `${target?.join(', ')} は既に使用されています`,
+              field: fieldKey || undefined,
+              message: `${fieldLabel} は既に使用されています`,
             },
           ],
         },

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -178,9 +178,9 @@ const extractP2002Fields = (error: Prisma.PrismaClientKnownRequestError): string
     if (fields.length > 0) return fields;
   }
 
-  const match = error.message.match(/fields:\s*\(([^)]+)\)/);
-  if (match) {
-    return match[1]
+  const captured = error.message.match(/fields:\s*\(([^)]+)\)/)?.[1];
+  if (captured) {
+    return captured
       .split(',')
       .map((s) => s.trim().replace(/^`|`$/g, ''))
       .filter(Boolean);

--- a/tests/middleware/errorHandler.test.ts
+++ b/tests/middleware/errorHandler.test.ts
@@ -71,7 +71,7 @@ describe('Error Handler Middleware', () => {
 
   describe('errorHandler', () => {
     describe('Prismaエラー処理', () => {
-      it('P2002（重複エラー）を正しく処理すること', () => {
+      it('P2002（重複エラー、v6 meta.target=array）を正しく処理すること', () => {
         const error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
           code: 'P2002',
           clientVersion: '5.0.0',
@@ -89,7 +89,150 @@ describe('Error Handler Middleware', () => {
             details: [
               {
                 field: 'email',
-                message: 'email は既に使用されています',
+                message: 'メールアドレス は既に使用されています',
+              },
+            ],
+          },
+        });
+      });
+
+      it('P2002（v6 meta.target=string カンマ区切り）を正しく処理すること', () => {
+        const error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+          meta: { target: 'email,supabase_uid' },
+        });
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(409);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'CONFLICT',
+            message: '重複するデータが存在します',
+            details: [
+              {
+                field: 'email, supabase_uid',
+                message: 'メールアドレス, Supabaseユーザー は既に使用されています',
+              },
+            ],
+          },
+        });
+      });
+
+      it('P2002（v7 adapter-pg, driverAdapterError から field を抽出）を正しく処理すること', () => {
+        // Prisma v7 + @prisma/adapter-pg では meta.target が無く、
+        // meta.driverAdapterError.cause.constraint.fields に入る
+        const error = new Prisma.PrismaClientKnownRequestError(
+          '\nInvalid `prisma.physicalPlot.create()` invocation:\n\n\nUnique constraint failed on the fields: (`plot_number`)',
+          {
+            code: 'P2002',
+            clientVersion: '7.8.0',
+            meta: {
+              modelName: 'PhysicalPlot',
+              driverAdapterError: {
+                name: 'DriverAdapterError',
+                cause: {
+                  originalCode: '23505',
+                  originalMessage:
+                    'duplicate key value violates unique constraint "physical_plots_plot_number_key"',
+                  kind: 'UniqueConstraintViolation',
+                  constraint: { fields: ['plot_number'] },
+                },
+              },
+            },
+          }
+        );
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(409);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'CONFLICT',
+            message: '重複するデータが存在します',
+            details: [
+              {
+                field: 'plot_number',
+                message: '区画番号 は既に使用されています',
+              },
+            ],
+          },
+        });
+      });
+
+      it('P2002（meta 不在、error.message からフォールバック抽出）を正しく処理すること', () => {
+        const error = new Prisma.PrismaClientKnownRequestError(
+          'Unique constraint failed on the fields: (`plot_number`)',
+          {
+            code: 'P2002',
+            clientVersion: '7.8.0',
+          }
+        );
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(409);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'CONFLICT',
+            message: '重複するデータが存在します',
+            details: [
+              {
+                field: 'plot_number',
+                message: '区画番号 は既に使用されています',
+              },
+            ],
+          },
+        });
+      });
+
+      it('P2002（field 完全に取れない場合）でも undefined を出さないこと', () => {
+        const error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '7.8.0',
+        });
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(409);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'CONFLICT',
+            message: '重複するデータが存在します',
+            details: [
+              {
+                field: undefined,
+                message: 'データ は既に使用されています',
+              },
+            ],
+          },
+        });
+      });
+
+      it('P2002（未知の field 名はそのまま表示）', () => {
+        const error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '7.8.0',
+          meta: { target: ['unknown_field_xyz'] },
+        });
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(409);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'CONFLICT',
+            message: '重複するデータが存在します',
+            details: [
+              {
+                field: 'unknown_field_xyz',
+                message: 'unknown_field_xyz は既に使用されています',
               },
             ],
           },


### PR DESCRIPTION
## Summary

- Prisma v7 + \`@prisma/adapter-pg\` で P2002 (unique 制約違反) の field 名が \`meta.target\` から \`meta.driverAdapterError.cause.constraint.fields\` に移ったため、`/plots/new` 登録時に「**重複するデータが存在します undefined は既に使用されています**」が表示されていた問題を修正。
- 3 段フォールバック (v6 \`meta.target\` → v7 \`driverAdapterError\` → \`error.message\` パース) で field 名を確実に抽出。
- field 名 → 日本語ラベル (例: \`plot_number\` → 区画番号) のマップを追加。UX 向上。

## 再現ログ (修正前)

\`\`\`
"err": "Invalid \`prisma.physicalPlot.create()\` invocation:
Unique constraint failed on the fields: (\`plot_number\`)"
"prismaCode": "P2002"
"prismaMeta": {
  "driverAdapterError": {
    "cause": { "constraint": { "fields": ["plot_number"] } }
  }
}
\`\`\`

clientVersion 7.8.0 では \`meta.target\` が存在しないため、\`target?.join(', ')\` が \`undefined\` を返していた。

## 修正前後の出力

| ケース | 修正前 | 修正後 |
|---|---|---|
| v7 (driverAdapterError) | \`undefined は既に使用されています\` | \`区画番号 は既に使用されています\` |
| v6 (meta.target) | \`email は既に使用されています\` | \`メールアドレス は既に使用されています\` |
| meta なし (message のみ) | \`undefined は既に使用されています\` | \`区画番号 は既に使用されています\` |
| field 完全不明 | \`undefined は既に使用されています\` | \`データ は既に使用されています\` |

## Test plan

- [x] \`npm test -- tests/middleware/errorHandler.test.ts\` — 36 件 green (うち 6 件が今回の追加 / 修正ケース)
- [x] \`npm test\` 全体 — 831 件 green
- [x] \`npm run lint\` — 0 error
- [ ] frontend (\`#147\` マージ後 or ローカル) で \`/plots/new\` を同じ区画番号で 2 回登録 → 「区画番号 は既に使用されています」と表示されること
- [ ] 別の区画番号で登録 → 正常に成功すること

## 関連

- Prisma v7 / adapter-pg 移行: \`af018c7\`, \`879871a\`
- frontend B2: \`zaitsu82/komine-crm-frontend#147\` (動作確認はこの PR マージ後に再開)

🤖 Generated with [Claude Code](https://claude.com/claude-code)