### PR TITLE
feat(masters): 標準マスタ7種の seed 機構を追加 (#46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "swagger:build": "node scripts/swagger.js build",
     "billing:generate": "ts-node scripts/generate-collective-burial-invoices.ts",
     "bootstrap:admin": "ts-node --transpile-only prisma/seed.ts",
+    "seed:masters": "ts-node --transpile-only prisma/seedMasters.ts",
     "migrate:legacy": "ts-node --transpile-only scripts/migrate-from-legacy.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/prisma/seedMasters.ts
+++ b/prisma/seedMasters.ts
@@ -1,0 +1,179 @@
+/**
+ * マスタ初期データ投入スクリプト
+ *
+ * 標準マスタ7種の初期データを冪等に投入する。
+ * code を unique キーとした insert-only（`skipDuplicates`）方式のため、
+ * 何度実行しても既存レコードは上書きしない（マスタ管理画面での編集を保護する）。
+ *
+ * 対象マスタ（GitHub issue #46「対象マスタ8種」のうち、別系統で投入されるものを除く）:
+ *   - 墓地区分 (cemetery_type_master)
+ *   - 支払方法 (payment_method_master)
+ *   - 税区分   (tax_type_master)
+ *   - 計算方法 (calc_type_master)
+ *   - 請求方法 (billing_type_master)
+ *   - 宛先区分 (recipient_type_master)
+ *   - 工事種別 (construction_type_master)
+ *
+ * 対象外（投入元が別にあるため、ここでは触らない）:
+ *   - 区画名 (section_name_master) ......... issue #14 で別途対応
+ *   - 続柄   (relationship_master) ......... レガシー移行 scripts/legacy-migration/steps/01-masters.ts
+ *   - 工事業者 (contractor_master) ......... レガシー移行 + migration プレースホルダ
+ *
+ * 値の出典: frontend モック（komine-crm-frontend/src/lib/api/masters.ts）を確定ベースラインとして採用（issue #46 の方針）。
+ *           税率変更やクレジットカード等の追加は、確定後にこのファイルへ追記して再実行すれば冪等に反映される。
+ *
+ * 実行方法:
+ *   npm run seed:masters
+ *
+ * 必須環境変数:
+ *   DATABASE_URL
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+interface MasterSeedRow {
+  code: string;
+  name: string;
+  description?: string | null;
+  sort_order?: number | null;
+}
+
+interface TaxTypeSeedRow extends MasterSeedRow {
+  tax_rate: string | null;
+}
+
+const cemeteryType: MasterSeedRow[] = [
+  { code: 'GENERAL', name: '一般墓地', description: '一般的な墓地', sort_order: 1 },
+  { code: 'MEMORIAL', name: '永代供養墓', description: '永代供養用の墓地', sort_order: 2 },
+  { code: 'TREE', name: '樹木葬', description: '樹木葬用の区画', sort_order: 3 },
+];
+
+const paymentMethod: MasterSeedRow[] = [
+  { code: 'CASH', name: '現金払い', description: '現金での支払い', sort_order: 1 },
+  { code: 'BANK_TRANSFER', name: '銀行振込', description: '銀行口座への振込', sort_order: 2 },
+  { code: 'ACCOUNT_TRANSFER', name: '口座振替', description: '自動口座振替', sort_order: 3 },
+];
+
+const taxType: TaxTypeSeedRow[] = [
+  { code: 'TAX_10', name: '消費税10%', description: '標準税率', sort_order: 1, tax_rate: '0.10' },
+  { code: 'TAX_8', name: '消費税8%', description: '軽減税率', sort_order: 2, tax_rate: '0.08' },
+  { code: 'TAX_FREE', name: '非課税', description: '非課税取引', sort_order: 3, tax_rate: '0' },
+];
+
+const calcType: MasterSeedRow[] = [
+  { code: 'AREA', name: '面積単価', description: '面積に基づく計算', sort_order: 1 },
+  { code: 'FIXED', name: '一律料金', description: '固定料金', sort_order: 2 },
+];
+
+const billingType: MasterSeedRow[] = [
+  { code: 'YEARLY', name: '年次請求', description: '年1回の請求', sort_order: 1 },
+  { code: 'MONTHLY', name: '月次請求', description: '月1回の請求', sort_order: 2 },
+  { code: 'ONETIME', name: '一括請求', description: '契約時のみ', sort_order: 3 },
+];
+
+const recipientType: MasterSeedRow[] = [
+  { code: 'CONTRACTOR', name: '契約者', description: '契約者本人', sort_order: 1 },
+  { code: 'SUCCESSOR', name: '承継者', description: '承継者', sort_order: 2 },
+  { code: 'OTHER', name: 'その他', description: 'その他の受取人', sort_order: 3 },
+];
+
+const constructionType: MasterSeedRow[] = [
+  { code: 'FOUNDATION', name: '基礎工事', description: '墓石の基礎工事', sort_order: 1 },
+  { code: 'TOMBSTONE', name: '墓石設置', description: '墓石の設置工事', sort_order: 2 },
+  { code: 'REMOVAL', name: '墓石撤去', description: '墓石の撤去工事', sort_order: 3 },
+  { code: 'REPAIR', name: '修繕工事', description: '墓石の修繕', sort_order: 4 },
+];
+
+export interface MasterSeedSummary {
+  master: string;
+  inserted: number;
+}
+
+/**
+ * 標準マスタ7種を冪等に投入する。
+ * 既存 code はスキップ（skipDuplicates）するため上書きしない。
+ */
+export async function seedMasters(prisma: PrismaClient): Promise<MasterSeedSummary[]> {
+  const summary: MasterSeedSummary[] = [];
+
+  const cemetery = await prisma.cemeteryTypeMaster.createMany({
+    data: cemeteryType,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'cemetery_type_master', inserted: cemetery.count });
+
+  const payment = await prisma.paymentMethodMaster.createMany({
+    data: paymentMethod,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'payment_method_master', inserted: payment.count });
+
+  const tax = await prisma.taxTypeMaster.createMany({
+    data: taxType,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'tax_type_master', inserted: tax.count });
+
+  const calc = await prisma.calcTypeMaster.createMany({
+    data: calcType,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'calc_type_master', inserted: calc.count });
+
+  const billing = await prisma.billingTypeMaster.createMany({
+    data: billingType,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'billing_type_master', inserted: billing.count });
+
+  const recipient = await prisma.recipientTypeMaster.createMany({
+    data: recipientType,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'recipient_type_master', inserted: recipient.count });
+
+  const construction = await prisma.constructionTypeMaster.createMany({
+    data: constructionType,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'construction_type_master', inserted: construction.count });
+
+  return summary;
+}
+
+function createPrismaClient(): PrismaClient {
+  const adapter = new PrismaPg({
+    connectionString: process.env['DATABASE_URL'],
+  });
+  return new PrismaClient({ adapter });
+}
+
+async function main(): Promise<void> {
+  if (!process.env['DATABASE_URL']) {
+    throw new Error('DATABASE_URL が未設定です。.env を確認してください。');
+  }
+
+  const prisma = createPrismaClient();
+  try {
+    console.log('🌱 マスタ初期データを投入中...');
+    const summary = await seedMasters(prisma);
+
+    const total = summary.reduce((sum, s) => sum + s.inserted, 0);
+    for (const s of summary) {
+      console.log(`  ${s.master}: +${s.inserted} 件`);
+    }
+    console.log(`✅ マスタ投入完了（新規 ${total} 件 / 既存はスキップ）`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// 直接実行されたときのみ main() を走らせる（テストから import しても実行されない）
+if (require.main === module) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`❌ ${message}`);
+    process.exit(1);
+  });
+}

--- a/tests/masters/seedMasters.test.ts
+++ b/tests/masters/seedMasters.test.ts
@@ -1,0 +1,92 @@
+import { PrismaClient } from '@prisma/client';
+import { seedMasters } from '../../prisma/seedMasters';
+
+/**
+ * seedMasters は prisma クライアントを引数で受け取るため、
+ * createMany を spy したフェイクを渡して検証する（実DB不要）。
+ */
+function createFakePrisma() {
+  const makeCreateMany = (count: number) => jest.fn().mockResolvedValue({ count });
+
+  return {
+    cemeteryTypeMaster: { createMany: makeCreateMany(3) },
+    paymentMethodMaster: { createMany: makeCreateMany(3) },
+    taxTypeMaster: { createMany: makeCreateMany(3) },
+    calcTypeMaster: { createMany: makeCreateMany(2) },
+    billingTypeMaster: { createMany: makeCreateMany(3) },
+    recipientTypeMaster: { createMany: makeCreateMany(3) },
+    constructionTypeMaster: { createMany: makeCreateMany(4) },
+  };
+}
+
+describe('seedMasters', () => {
+  it('標準マスタ7種すべてに対して createMany を呼ぶ', async () => {
+    const prisma = createFakePrisma();
+
+    const summary = await seedMasters(prisma as unknown as PrismaClient);
+
+    expect(prisma.cemeteryTypeMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.paymentMethodMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.taxTypeMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.calcTypeMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.billingTypeMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.recipientTypeMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.constructionTypeMaster.createMany).toHaveBeenCalledTimes(1);
+
+    expect(summary).toHaveLength(7);
+  });
+
+  it('冪等性のため skipDuplicates: true で投入する', async () => {
+    const prisma = createFakePrisma();
+
+    await seedMasters(prisma as unknown as PrismaClient);
+
+    for (const model of Object.values(prisma)) {
+      const arg = model.createMany.mock.calls[0][0];
+      expect(arg.skipDuplicates).toBe(true);
+      expect(Array.isArray(arg.data)).toBe(true);
+      expect(arg.data.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('投入された件数を master ごとに集計して返す', async () => {
+    const prisma = createFakePrisma();
+
+    const summary = await seedMasters(prisma as unknown as PrismaClient);
+
+    const total = summary.reduce((sum, s) => sum + s.inserted, 0);
+    expect(total).toBe(3 + 3 + 3 + 2 + 3 + 3 + 4);
+    expect(summary.map((s) => s.master)).toEqual([
+      'cemetery_type_master',
+      'payment_method_master',
+      'tax_type_master',
+      'calc_type_master',
+      'billing_type_master',
+      'recipient_type_master',
+      'construction_type_master',
+    ]);
+  });
+
+  it('各マスタの code は重複しない', async () => {
+    const prisma = createFakePrisma();
+
+    await seedMasters(prisma as unknown as PrismaClient);
+
+    for (const model of Object.values(prisma)) {
+      const rows = model.createMany.mock.calls[0][0].data as Array<{ code: string }>;
+      const codes = rows.map((r) => r.code);
+      expect(new Set(codes).size).toBe(codes.length);
+    }
+  });
+
+  it('税区分には tax_rate が含まれる', async () => {
+    const prisma = createFakePrisma();
+
+    await seedMasters(prisma as unknown as PrismaClient);
+
+    const rows = prisma.taxTypeMaster.createMany.mock.calls[0][0].data as Array<{
+      tax_rate: string | null;
+    }>;
+    expect(rows.every((r) => 'tax_rate' in r)).toBe(true);
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -7,7 +7,8 @@
     "src/**/*",
     "scripts/**/*.ts",
     "prisma/scripts/**/*.ts",
-    "prisma/seed.ts"
+    "prisma/seed.ts",
+    "prisma/seedMasters.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## 概要

GitHub issue #46 のうち「シードスクリプトの作成」部分を実装。標準マスタ7種の初期データを冪等に投入する仕組みを追加する。新規環境（本番含む）でマスタが空のままになる問題を解消する。

## 変更点

- `prisma/seedMasters.ts` を新規追加
  - 対象: 墓地区分 / 支払方法 / 税区分 / 計算方法 / 請求方法 / 宛先区分 / 工事種別
  - `createMany({ skipDuplicates: true })` による **insert-only 冪等投入**（既存レコードは上書きしないため、マスタ管理画面での編集を保護）
  - 値は frontend モック（`masters.ts`）を確定ベースラインとして採用（#46 の「mock と整合させる」方針）
  - `seedMasters(prisma)` を export し、`require.main` ガードで standalone 実行と分離
- `npm run seed:masters` スクリプト追加
- `tsconfig.eslint.json` の include に `prisma/seedMasters.ts` を追加
- ユニットテスト5件追加（`tests/masters/seedMasters.test.ts`）

## 対象外（このPRに含めない）

| 項目 | 理由 |
|---|---|
| section-name マスタ | issue #14 で別途対応 |
| relationship / contractor マスタ | legacy 移行（`steps/01-masters.ts` / migration プレースホルダ）が投入元 |
| fee の legacy int→code remap | 旧DBの値の意味が未特定。別PRで対応（業務側の値分布確認待ち） |
| ReligionMaster | 未実装。配置(#108)・値の確定後に別PR |

## 確認

- [x] `npm run seed:masters` で投入（冪等：再実行でスキップ）
- [x] `npm run lint` 0 errors
- [x] マスタ系テスト 56件パス（うち新規5件）

Refs #46