### PR TITLE
feat(masters): 旧fee区分を faithful に再定義 + migration remap (#46)

### DIFF
--- a/prisma/seedMasters.ts
+++ b/prisma/seedMasters.ts
@@ -19,8 +19,11 @@
  *   - 続柄   (relationship_master) ......... レガシー移行 scripts/legacy-migration/steps/01-masters.ts
  *   - 工事業者 (contractor_master) ......... レガシー移行 + migration プレースホルダ
  *
- * 値の出典: frontend モック（komine-crm-frontend/src/lib/api/masters.ts）を確定ベースラインとして採用（issue #46 の方針）。
- *           税率変更やクレジットカード等の追加は、確定後にこのファイルへ追記して再実行すれば冪等に反映される。
+ * 値の出典:
+ *   - 墓地区分/支払方法/宛先区分/工事種別: frontend モック（masters.ts）を確定ベースラインとして採用（#46 方針）
+ *   - 計算区分/税区分/請求区分: 旧システム sykbnn（KBNNO 2026/2027/2028）の意味に合わせて再定義（旧データ忠実移行）。
+ *     migration step05 は旧int値をこの code に remap する（scripts/legacy-migration/steps/05-contract-plot.ts）。
+ *   業務確定での値追加（クレカ等）は、このファイルへ追記して再実行すれば冪等に反映される。
  *
  * 実行方法:
  *   npm run seed:masters
@@ -55,21 +58,25 @@ const paymentMethod: MasterSeedRow[] = [
   { code: 'ACCOUNT_TRANSFER', name: '口座振替', description: '自動口座振替', sort_order: 3 },
 ];
 
+// 税区分: 旧システム(sykbnn KBNNO=2027 税金区分)の意味に合わせ「内税/外税」。
+// ※新システム初期設計の税率(10%/8%/非課税)ではない。旧データ忠実移行のため再定義。
+//   tax_rate は内税/外税の概念では持たないため null（請求書の税率は document-form 側で別管理）。
 const taxType: TaxTypeSeedRow[] = [
-  { code: 'TAX_10', name: '消費税10%', description: '標準税率', sort_order: 1, tax_rate: '0.10' },
-  { code: 'TAX_8', name: '消費税8%', description: '軽減税率', sort_order: 2, tax_rate: '0.08' },
-  { code: 'TAX_FREE', name: '非課税', description: '非課税取引', sort_order: 3, tax_rate: '0' },
+  { code: 'INCLUSIVE', name: '内税', description: '税込み', sort_order: 1, tax_rate: null },
+  { code: 'EXCLUSIVE', name: '外税', description: '税抜き', sort_order: 2, tax_rate: null },
 ];
 
+// 計算区分: 旧 sykbnn KBNNO=2026（0=面積×単価 / 1=任意設定）。code は既存と互換維持。
 const calcType: MasterSeedRow[] = [
-  { code: 'AREA', name: '面積単価', description: '面積に基づく計算', sort_order: 1 },
-  { code: 'FIXED', name: '一律料金', description: '固定料金', sort_order: 2 },
+  { code: 'AREA', name: '面積×単価', description: '面積×単価で計算', sort_order: 1 },
+  { code: 'FIXED', name: '任意設定', description: '金額を任意設定', sort_order: 2 },
 ];
 
+// 請求区分: 旧 sykbnn KBNNO=2028（0=なし / 1=あり / 2=永代）。
 const billingType: MasterSeedRow[] = [
-  { code: 'YEARLY', name: '年次請求', description: '年1回の請求', sort_order: 1 },
-  { code: 'MONTHLY', name: '月次請求', description: '月1回の請求', sort_order: 2 },
-  { code: 'ONETIME', name: '一括請求', description: '契約時のみ', sort_order: 3 },
+  { code: 'NONE', name: 'なし', description: '請求なし', sort_order: 1 },
+  { code: 'PRESENT', name: 'あり', description: '請求あり', sort_order: 2 },
+  { code: 'PERPETUAL', name: '永代', description: '永代', sort_order: 3 },
 ];
 
 const recipientType: MasterSeedRow[] = [

--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -7,6 +7,30 @@ import { assertIdMapsReady } from '../lib/invariants';
 import { cleanStr, parseLegacyDate } from '../transforms';
 import type { MigrationStep } from '../types';
 
+// 旧 sykbnn 区分コード → 新マスタ code（seedMasters.ts と一致させること）
+//   計算区分 KBNNO=2026 (0=面積×単価 / 1=任意設定)
+//   税区分   KBNNO=2027 (0=内税 / 1=外税)
+//   請求区分 KBNNO=2028 (0=なし / 1=あり / 2=永代)
+const CALC_TYPE_MAP: Record<number, string> = { 0: 'AREA', 1: 'FIXED' };
+const TAX_TYPE_MAP: Record<number, string> = { 0: 'INCLUSIVE', 1: 'EXCLUSIVE' };
+const BILLING_TYPE_MAP: Record<number, string> = { 0: 'NONE', 1: 'PRESENT', 2: 'PERPETUAL' };
+
+// 旧int値をマスタ code に変換。対応表に無い値は誤 resolve 回避のため legacy- prefix で温存する。
+function mapFeeCode(
+  map: Record<number, string>,
+  prefix: string,
+  value: number | null | undefined
+): string | null {
+  if (value == null) return null;
+  return map[value] ?? `legacy-${prefix}-${value}`;
+}
+
+// 支払方法(shiharai)は旧コードの意味が未特定（対応する sykbnn KBNNO 無し）。
+// 業務確認まで legacy- prefix で温存し、マスタ名への誤変換を防ぐ。
+function mapShiharai(value: number | null | undefined): string | null {
+  return value == null ? null : `legacy-shiharai-${value}`;
+}
+
 interface BochiContractRow extends RowDataPacket {
   grave_cd: number;
   danka_cd: number | null;
@@ -170,14 +194,14 @@ export const stepContractPlot: MigrationStep = {
         await prisma.usageFee.create({
           data: {
             contract_plot_id: contractPlot.id,
-            calculation_type: row.shiyouryou_keisan?.toString() ?? null,
-            tax_type: row.shiyouryou_zei?.toString() ?? null,
-            billing_type: row.shiyouryou_seikyu?.toString() ?? null,
+            calculation_type: mapFeeCode(CALC_TYPE_MAP, 'keisan', row.shiyouryou_keisan),
+            tax_type: mapFeeCode(TAX_TYPE_MAP, 'zei', row.shiyouryou_zei),
+            billing_type: mapFeeCode(BILLING_TYPE_MAP, 'seikyu', row.shiyouryou_seikyu),
             billing_years: row.shiyouryou_seikyunen?.toString() ?? null,
             area: cleanStr(row.shiyouryou_menseki),
             unit_price: row.shiyouryou_tanka?.toString() ?? null,
             usage_fee: row.shiyouryou?.toString() ?? null,
-            payment_method: row.shiyouryou_shiharai?.toString() ?? null,
+            payment_method: mapShiharai(row.shiyouryou_shiharai),
           },
         });
         usageFeeInserted++;
@@ -193,16 +217,16 @@ export const stepContractPlot: MigrationStep = {
         await prisma.managementFee.create({
           data: {
             contract_plot_id: contractPlot.id,
-            calculation_type: row.kanriryou_keisan?.toString() ?? null,
-            tax_type: row.kanriryou_zei?.toString() ?? null,
-            billing_type: row.kanriryou_seikyu?.toString() ?? null,
+            calculation_type: mapFeeCode(CALC_TYPE_MAP, 'keisan', row.kanriryou_keisan),
+            tax_type: mapFeeCode(TAX_TYPE_MAP, 'zei', row.kanriryou_zei),
+            billing_type: mapFeeCode(BILLING_TYPE_MAP, 'seikyu', row.kanriryou_seikyu),
             billing_years: row.kanriryou_seikyunen?.toString() ?? null,
             area: cleanStr(row.kanriryou_menseki),
             billing_month: row.kanriryou_seikyutsuki?.toString() ?? null,
             management_fee: row.kanriryou?.toString() ?? null,
             unit_price: row.kanriryou_tanka?.toString() ?? null,
             last_billing_month: row.kanriryou_last_sei_date?.toString() ?? null,
-            payment_method: row.kanriryou_shiharai?.toString() ?? null,
+            payment_method: mapShiharai(row.kanriryou_shiharai),
           },
         });
         managementFeeInserted++;

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -253,7 +253,7 @@ export async function createPlotCore(
         contract_plot_id: contractPlot.id,
         calculation_type: input.usageFee.calculationType || '',
         tax_type: input.usageFee.taxType || '',
-        billing_type: input.usageFee.billingType || 'onetime',
+        billing_type: input.usageFee.billingType || '',
         billing_years: input.usageFee.billingYears || '1',
         usage_fee: String(input.usageFee.usageFee ?? ''),
         area: String(input.usageFee.area ?? ''),

--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -154,7 +154,7 @@ export const createPlotContract = async (req: Request, res: Response): Promise<a
             contract_plot_id: contractPlot.id,
             calculation_type: input.usageFee.calculationType || null,
             tax_type: input.usageFee.taxType || null,
-            billing_type: input.usageFee.billingType || 'onetime',
+            billing_type: input.usageFee.billingType || '',
             billing_years: input.usageFee.billingYears || '1',
             area: input.usageFee.area ? input.usageFee.area.toString() : null,
             unit_price: input.usageFee.unitPrice ? input.usageFee.unitPrice.toString() : null,

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -624,7 +624,7 @@ export async function updatePlotCore(
           const created = await tx.usageFee.create({
             data: {
               contract_plot_id: id,
-              billing_type: 'onetime',
+              billing_type: '',
               billing_years: '1',
               ...usageFeeData,
             },

--- a/tests/masters/seedMasters.test.ts
+++ b/tests/masters/seedMasters.test.ts
@@ -11,7 +11,7 @@ function createFakePrisma() {
   return {
     cemeteryTypeMaster: { createMany: makeCreateMany(3) },
     paymentMethodMaster: { createMany: makeCreateMany(3) },
-    taxTypeMaster: { createMany: makeCreateMany(3) },
+    taxTypeMaster: { createMany: makeCreateMany(2) },
     calcTypeMaster: { createMany: makeCreateMany(2) },
     billingTypeMaster: { createMany: makeCreateMany(3) },
     recipientTypeMaster: { createMany: makeCreateMany(3) },
@@ -55,7 +55,7 @@ describe('seedMasters', () => {
     const summary = await seedMasters(prisma as unknown as PrismaClient);
 
     const total = summary.reduce((sum, s) => sum + s.inserted, 0);
-    expect(total).toBe(3 + 3 + 3 + 2 + 3 + 3 + 4);
+    expect(total).toBe(3 + 3 + 2 + 2 + 3 + 3 + 4);
     expect(summary.map((s) => s.master)).toEqual([
       'cemetery_type_master',
       'payment_method_master',


### PR DESCRIPTION
## 概要

旧DB(reien) `sykbnn` の区分定義を解読した結果、`UsageFee`/`ManagementFee` の区分フィールドが**旧システムと概念がズレていた**ため、旧の意味に合わせて再定義する（旧データ忠実移行）。PR #145（seed機構）の続き。

## 背景（解読結果）

`sykbnn`(名称マスタ) の KBNNO で旧コードの意味が判明:

| 新フィールド | 旧カラム | KBNNO | 旧値の意味 |
|---|---|---|---|
| calculation_type | shiyouryou_keisan | 2026 計算区分 | 0=面積×単価 / 1=任意設定 |
| tax_type | shiyouryou_zei | 2027 税金区分 | 0=内税 / 1=外税 |
| billing_type | shiyouryou_seikyu | 2028 請求区分 | 0=なし / 1=あり / 2=永代 |
| payment_method | shiyouryou_shiharai | 該当KBNNO無し | 0/1（意味未特定） |

旧 `税区分` は内税/外税（≠新設計の税率）、旧 `請求区分` は なし/あり/永代（≠頻度）だった。

## 変更点

- **seedMasters.ts**: 税区分を `内税/外税`、請求区分を `なし/あり/永代`、計算区分名を `面積×単価/任意設定` に再定義（旧 sykbnn 準拠）。税区分の tax_rate は概念上 null
- **step05 (migration)**: 旧int値を新マスタ code に remap（`mapFeeCode`）。対応表に無い値は誤resolve回避のため `legacy-{prefix}-{n}` で温存
- **支払方法(shiharai)**: 対応する KBNNO が無く意味未特定のため `legacy-shiharai-{n}` で温存（マスタ名への誤変換を防止、**業務確認待ち**）
- **billing_type 既定値 `'onetime'`→`''`**: createPlot / createPlotContract / updatePlot（faithful 後は無効code になるため）

## 影響範囲（調査済み）

fee マスタ4種は新システムでは**表示専用**で、金額計算（yucho/billing/invoice）はマスタ値に依存しない（金額は直接保存）。よって本変更は**表示ラベルが正しくなるだけで計算への影響なし**。

> 注: 請求書PDFの税額は `document-form.tsx` がハードコード10%で計算しており、TaxTypeMaster は元々参照していない（本PRの対象外）。

## 確認

- [x] `npm run lint` 0 errors
- [x] masters + plots テスト 257件パス

Refs #46