### PR TITLE
feat(plots): aggregate per-year billing status in plot list (B10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=913571ce1b87097ebd4c2da1b34014837d883c91
+ARG TYPES_REF=6484a0b1177ed61e6a29ef9c94bdbbcf672a996c
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -31,6 +31,57 @@ interface PlotSearchQuery {
 }
 
 /**
+ * B10: 年度別請求 status サマリ
+ *
+ * 旧画面01 の「受付済 / 09年 / 10年 …」を一覧では 1 列に集約する（サマリ列方式）。
+ * 集計対象は管理料 (management_fee) Billing。各 Billing の対象年度は
+ * `use_end_year ?? use_start_year` で判定する。
+ *
+ * - latestYear / latestYearStatus: 最も新しい対象年度を持つ Billing の年度と status
+ * - unpaidYearCount: 未納（billed / partial_paid / overdue）の Billing 件数
+ *   （pending=請求前、paid/terminated/written_off は未納に含めない）
+ */
+const UNPAID_BILLING_STATUSES = new Set(['billed', 'partial_paid', 'overdue']);
+
+interface BillingForSummary {
+  use_start_year: number | null;
+  use_end_year: number | null;
+  status: string;
+}
+
+interface BillingSummaryResult {
+  hasBilling: boolean;
+  latestYear: number | null;
+  latestYearStatus: string | null;
+  unpaidYearCount: number;
+}
+
+export const buildBillingSummary = (
+  billings: BillingForSummary[] | undefined | null
+): BillingSummaryResult => {
+  if (!billings || billings.length === 0) {
+    return { hasBilling: false, latestYear: null, latestYearStatus: null, unpaidYearCount: 0 };
+  }
+
+  let latestYear: number | null = null;
+  let latestYearStatus: string | null = null;
+  let unpaidYearCount = 0;
+
+  for (const billing of billings) {
+    const year = billing.use_end_year ?? billing.use_start_year ?? null;
+    if (year !== null && (latestYear === null || year > latestYear)) {
+      latestYear = year;
+      latestYearStatus = billing.status;
+    }
+    if (UNPAID_BILLING_STATUSES.has(billing.status)) {
+      unpaidYearCount += 1;
+    }
+  }
+
+  return { hasBilling: true, latestYear, latestYearStatus, unpaidYearCount };
+};
+
+/**
  * 契約区画一覧取得（ContractPlot中心）
  * サーバーサイド検索・ページネーション対応
  */
@@ -223,6 +274,15 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
             },
           },
           managementFee: true,
+          // B10: 年度別請求 status サマリ用。管理料 Billing のみ集計対象
+          billings: {
+            where: { category: 'management_fee', deleted_at: null },
+            select: {
+              use_start_year: true,
+              use_end_year: true,
+              status: true,
+            },
+          },
         },
         orderBy: orderByCondition,
       }),
@@ -299,6 +359,9 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
         nextBillingDate,
         managementFee: contractPlot.managementFee?.management_fee || null,
         uncollectedAmount: contractPlot.uncollected_amount,
+
+        // 請求状況サマリ（B10: 年度別請求 status の集約列）
+        billingSummary: buildBillingSummary(contractPlot.billings),
 
         // メタ情報
         createdAt: contractPlot.created_at,

--- a/tests/plots/controllers/buildBillingSummary.test.ts
+++ b/tests/plots/controllers/buildBillingSummary.test.ts
@@ -1,0 +1,84 @@
+/**
+ * buildBillingSummary（B10: 年度別請求 status サマリ集計）のテスト
+ *
+ * 旧画面01 の「受付済 / 09年 / 10年 …」を一覧で 1 列に集約する際の集計ロジック。
+ */
+
+import { buildBillingSummary } from '../../../src/plots/controllers/getPlots';
+
+describe('buildBillingSummary', () => {
+  it('Billing が無い場合は hasBilling=false で全て空', () => {
+    expect(buildBillingSummary([])).toEqual({
+      hasBilling: false,
+      latestYear: null,
+      latestYearStatus: null,
+      unpaidYearCount: 0,
+    });
+  });
+
+  it('null / undefined も空サマリを返す', () => {
+    const empty = {
+      hasBilling: false,
+      latestYear: null,
+      latestYearStatus: null,
+      unpaidYearCount: 0,
+    };
+    expect(buildBillingSummary(null)).toEqual(empty);
+    expect(buildBillingSummary(undefined)).toEqual(empty);
+  });
+
+  it('完納済み 1 件: 最新年度 status=paid、未納 0', () => {
+    expect(
+      buildBillingSummary([{ use_start_year: 2023, use_end_year: 2023, status: 'paid' }])
+    ).toEqual({
+      hasBilling: true,
+      latestYear: 2023,
+      latestYearStatus: 'paid',
+      unpaidYearCount: 0,
+    });
+  });
+
+  it('最新年度は use_end_year ?? use_start_year の最大値で判定する', () => {
+    const result = buildBillingSummary([
+      { use_start_year: 2020, use_end_year: 2020, status: 'paid' },
+      { use_start_year: 2022, use_end_year: 2024, status: 'billed' },
+      { use_start_year: 2021, use_end_year: 2021, status: 'paid' },
+    ]);
+    expect(result.latestYear).toBe(2024);
+    expect(result.latestYearStatus).toBe('billed');
+  });
+
+  it('未納カウントは billed / partial_paid / overdue のみ', () => {
+    const result = buildBillingSummary([
+      { use_start_year: 2019, use_end_year: 2019, status: 'paid' }, // 除外
+      { use_start_year: 2020, use_end_year: 2020, status: 'billed' }, // ○
+      { use_start_year: 2021, use_end_year: 2021, status: 'partial_paid' }, // ○
+      { use_start_year: 2022, use_end_year: 2022, status: 'overdue' }, // ○
+      { use_start_year: 2023, use_end_year: 2023, status: 'pending' }, // 除外（請求前）
+      { use_start_year: 2024, use_end_year: 2024, status: 'terminated' }, // 除外
+      { use_start_year: 2025, use_end_year: 2025, status: 'written_off' }, // 除外
+    ]);
+    expect(result.unpaidYearCount).toBe(3);
+  });
+
+  it('use_end_year が null なら use_start_year にフォールバックする', () => {
+    const result = buildBillingSummary([
+      { use_start_year: 2021, use_end_year: null, status: 'paid' },
+      { use_start_year: 2023, use_end_year: null, status: 'overdue' },
+    ]);
+    expect(result.latestYear).toBe(2023);
+    expect(result.latestYearStatus).toBe('overdue');
+    expect(result.unpaidYearCount).toBe(1);
+  });
+
+  it('年度が全て null でも hasBilling=true、未納件数は集計する', () => {
+    const result = buildBillingSummary([
+      { use_start_year: null, use_end_year: null, status: 'billed' },
+      { use_start_year: null, use_end_year: null, status: 'paid' },
+    ]);
+    expect(result.hasBilling).toBe(true);
+    expect(result.latestYear).toBeNull();
+    expect(result.latestYearStatus).toBeNull();
+    expect(result.unpaidYearCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要

旧画面01（区画一覧）の年度別請求 status（`受付済 / 09年 / 10年 …`）を、新システムの一覧では **1 列に集約**して表示する（B10、サマリ列方式）。本 PR は backend 側の集計を担当。

## 変更

- `getPlots` の `include` に管理料 (`category=management_fee`) Billing を追加（`use_start_year` / `use_end_year` / `status`）
- `buildBillingSummary` ヘルパーを新規追加・export
  - `hasBilling`: 管理料 Billing が存在するか
  - `latestYear` / `latestYearStatus`: 最新（最も新しい対象年度）の Billing の年度と status。年度は `use_end_year ?? use_start_year` で判定
  - `unpaidYearCount`: 未納（`billed` / `partial_paid` / `overdue`）件数
- 各区画のレスポンスに `billingSummary` を追加
- Dockerfile `TYPES_REF` を types#24 merge commit `6484a0b` に bump（security 措置 #60）

## 「未納」の定義（業務確認余地あり）

請求済だが完納していない status（`billed` / `partial_paid` / `overdue`）を未納としてカウント。`pending`（請求前）と `paid` / `terminated` / `written_off` は除外。業務確認（D カテゴリ）で定義が変わる可能性あり。

## テスト

- `buildBillingSummary` の純関数ユニットテスト 7 ケース追加（空/null、完納、最新年度判定、未納カウント、year フォールバック、全year null）
- 既存の plot list テスト（plotController / plotRoutes 計 37 件）も回帰なし

## 依存

- types#24（`PlotBillingSummary` 型）merged 済み

Refs B10 (`query_result/UI_GAP_HANDOFF.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)