### PR TITLE
feat(master): 方角/位置マスタの追加と墓石 direction/position の名称解決 (#147)

### DIFF
--- a/prisma/migrations/20260526120000_add_direction_position_master/migration.sql
+++ b/prisma/migrations/20260526120000_add_direction_position_master/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE "direction_master" (
+    "id" SERIAL NOT NULL,
+    "code" VARCHAR(10) NOT NULL,
+    "name" VARCHAR(50) NOT NULL,
+    "description" VARCHAR(200),
+    "sort_order" INTEGER,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "direction_master_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "position_master" (
+    "id" SERIAL NOT NULL,
+    "code" VARCHAR(10) NOT NULL,
+    "name" VARCHAR(50) NOT NULL,
+    "description" VARCHAR(200),
+    "sort_order" INTEGER,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "position_master_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "direction_master_code_key" ON "direction_master"("code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "position_master_code_key" ON "position_master"("code");
+
+-- InsertData: 方角 (レガシー sykbnn KBNNO=2024)。code はレガシー houi_id の文字列。
+INSERT INTO "direction_master" ("code", "name", "sort_order", "updated_at") VALUES
+('1', '東',   1, NOW()),
+('2', '西',   2, NOW()),
+('3', '南',   3, NOW()),
+('4', '北',   4, NOW()),
+('5', '北東', 5, NOW()),
+('6', '南東', 6, NOW()),
+('7', '北西', 7, NOW()),
+('8', '南西', 8, NOW());
+
+-- InsertData: 位置 (レガシー sykbnn KBNNO=2025)。code はレガシー ichi_id の文字列。
+INSERT INTO "position_master" ("code", "name", "sort_order", "updated_at") VALUES
+('1', '角', 1, NOW()),
+('2', '端', 2, NOW()),
+('3', '中', 3, NOW());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -724,6 +724,38 @@ model ContractorMaster {
   @@map("contractor_master")
 }
 
+// 方角マスタ（レガシー sykbnn KBNNO=2024 の8方角）
+// code はレガシー houi_id の int をそのまま文字列化した値（"1".."8"）。
+// GravestoneInfo.direction_id は int を保持し、code === String(direction_id) で名称解決する。
+model DirectionMaster {
+  id          Int      @id @default(autoincrement()) // ID
+  code        String   @unique @db.VarChar(10) // 方角コード（レガシー houi_id の文字列: "1".."8"）
+  name        String   @db.VarChar(50) // 方角名称（東/西/南/北/北東/南東/北西/南西）
+  description String?  @db.VarChar(200) // 説明
+  sort_order  Int? // 表示順序
+  is_active   Boolean  @default(true) // 有効フラグ
+  created_at  DateTime @default(now()) // 作成日時
+  updated_at  DateTime @updatedAt // 更新日時
+
+  @@map("direction_master")
+}
+
+// 位置マスタ（レガシー sykbnn KBNNO=2025 の角/端/中）
+// code はレガシー ichi_id の int をそのまま文字列化した値（"1".."3"）。
+// GravestoneInfo.position_id は int を保持し、code === String(position_id) で名称解決する。
+model PositionMaster {
+  id          Int      @id @default(autoincrement()) // ID
+  code        String   @unique @db.VarChar(10) // 位置コード（レガシー ichi_id の文字列: "1".."3"）
+  name        String   @db.VarChar(50) // 位置名称（角/端/中）
+  description String?  @db.VarChar(200) // 説明
+  sort_order  Int? // 表示順序
+  is_active   Boolean  @default(true) // 有効フラグ
+  created_at  DateTime @default(now()) // 作成日時
+  updated_at  DateTime @updatedAt // 更新日時
+
+  @@map("position_master")
+}
+
 // =============================================================================
 // 請求・入金管理
 // =============================================================================

--- a/prisma/seedMasters.ts
+++ b/prisma/seedMasters.ts
@@ -1,7 +1,7 @@
 /**
  * マスタ初期データ投入スクリプト
  *
- * 標準マスタ7種の初期データを冪等に投入する。
+ * 標準マスタ9種の初期データを冪等に投入する。
  * code を unique キーとした insert-only（`skipDuplicates`）方式のため、
  * 何度実行しても既存レコードは上書きしない（マスタ管理画面での編集を保護する）。
  *
@@ -13,6 +13,8 @@
  *   - 請求方法 (billing_type_master)
  *   - 宛先区分 (recipient_type_master)
  *   - 工事種別 (construction_type_master)
+ *   - 方角     (direction_master) ......... 旧 sykbnn KBNNO=2024（issue #147）
+ *   - 位置     (position_master) ......... 旧 sykbnn KBNNO=2025（issue #147）
  *
  * 対象外（投入元が別にあるため、ここでは触らない）:
  *   - 区画名 (section_name_master) ......... issue #14 で別途対応
@@ -92,6 +94,27 @@ const constructionType: MasterSeedRow[] = [
   { code: 'REPAIR', name: '修繕工事', description: '墓石の修繕', sort_order: 4 },
 ];
 
+// 方角: 旧 sykbnn KBNNO=2024。code はレガシー houi_id の int 文字列（"1".."8"）。
+// GravestoneInfo.direction_id（int）を code === String(direction_id) で解決するため、
+// 移行データの remap は不要。
+const direction: MasterSeedRow[] = [
+  { code: '1', name: '東', sort_order: 1 },
+  { code: '2', name: '西', sort_order: 2 },
+  { code: '3', name: '南', sort_order: 3 },
+  { code: '4', name: '北', sort_order: 4 },
+  { code: '5', name: '北東', sort_order: 5 },
+  { code: '6', name: '南東', sort_order: 6 },
+  { code: '7', name: '北西', sort_order: 7 },
+  { code: '8', name: '南西', sort_order: 8 },
+];
+
+// 位置: 旧 sykbnn KBNNO=2025。code はレガシー ichi_id の int 文字列（"1".."3"）。
+const position: MasterSeedRow[] = [
+  { code: '1', name: '角', sort_order: 1 },
+  { code: '2', name: '端', sort_order: 2 },
+  { code: '3', name: '中', sort_order: 3 },
+];
+
 export interface MasterSeedSummary {
   master: string;
   inserted: number;
@@ -145,6 +168,18 @@ export async function seedMasters(prisma: PrismaClient): Promise<MasterSeedSumma
     skipDuplicates: true,
   });
   summary.push({ master: 'construction_type_master', inserted: construction.count });
+
+  const dir = await prisma.directionMaster.createMany({
+    data: direction,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'direction_master', inserted: dir.count });
+
+  const pos = await prisma.positionMaster.createMany({
+    data: position,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'position_master', inserted: pos.count });
 
   return summary;
 }

--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -391,6 +391,78 @@ export const getContractorMaster = async (_req: Request, res: Response) => {
 };
 
 /**
+ * 方角マスタ取得
+ * GET /api/v1/masters/direction
+ */
+export const getDirectionMaster = async (_req: Request, res: Response) => {
+  try {
+    const data = await prisma.directionMaster.findMany({
+      where: { is_active: true },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    const formatted: MasterData[] = data.map((item) => ({
+      id: item.id,
+      code: item.code,
+      name: item.name,
+      description: item.description,
+      sortOrder: item.sort_order,
+      isActive: item.is_active,
+    }));
+
+    res.status(200).json({
+      success: true,
+      data: formatted,
+    });
+  } catch (error) {
+    getRequestLogger().error({ err: error }, 'Error fetching direction master');
+    res.status(500).json({
+      success: false,
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: '方角マスタの取得に失敗しました',
+      },
+    });
+  }
+};
+
+/**
+ * 位置マスタ取得
+ * GET /api/v1/masters/position
+ */
+export const getPositionMaster = async (_req: Request, res: Response) => {
+  try {
+    const data = await prisma.positionMaster.findMany({
+      where: { is_active: true },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    const formatted: MasterData[] = data.map((item) => ({
+      id: item.id,
+      code: item.code,
+      name: item.name,
+      description: item.description,
+      sortOrder: item.sort_order,
+      isActive: item.is_active,
+    }));
+
+    res.status(200).json({
+      success: true,
+      data: formatted,
+    });
+  } catch (error) {
+    getRequestLogger().error({ err: error }, 'Error fetching position master');
+    res.status(500).json({
+      success: false,
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: '位置マスタの取得に失敗しました',
+      },
+    });
+  }
+};
+
+/**
  * マスタタイプからPrismaモデルデリゲートを取得
  */
 const getMasterDelegate = (masterType: MasterType) => {
@@ -405,6 +477,8 @@ const getMasterDelegate = (masterType: MasterType) => {
     'section-name': prisma.sectionNameMaster,
     relationship: prisma.relationshipMaster,
     contractor: prisma.contractorMaster,
+    direction: prisma.directionMaster,
+    position: prisma.positionMaster,
   };
   return delegateMap[masterType];
 };
@@ -420,6 +494,8 @@ const masterTypeLabels: Record<MasterType, string> = {
   'section-name': '区画名',
   relationship: '続柄',
   contractor: '工事業者',
+  direction: '方角',
+  position: '位置',
 };
 
 /**
@@ -741,6 +817,8 @@ export const getAllMasters = async (_req: Request, res: Response) => {
       sectionName,
       relationship,
       contractor,
+      direction,
+      position,
     ] = await Promise.all([
       prisma.cemeteryTypeMaster.findMany({
         where: { is_active: true },
@@ -779,6 +857,14 @@ export const getAllMasters = async (_req: Request, res: Response) => {
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
       prisma.contractorMaster.findMany({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.directionMaster.findMany({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.positionMaster.findMany({
         where: { is_active: true },
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
@@ -862,6 +948,22 @@ export const getAllMasters = async (_req: Request, res: Response) => {
           isActive: item.is_active,
         })),
         contractor: contractor.map((item) => ({
+          id: item.id,
+          code: item.code,
+          name: item.name,
+          description: item.description,
+          sortOrder: item.sort_order,
+          isActive: item.is_active,
+        })),
+        direction: direction.map((item) => ({
+          id: item.id,
+          code: item.code,
+          name: item.name,
+          description: item.description,
+          sortOrder: item.sort_order,
+          isActive: item.is_active,
+        })),
+        position: position.map((item) => ({
           id: item.id,
           code: item.code,
           name: item.name,

--- a/src/masters/masterRoutes.ts
+++ b/src/masters/masterRoutes.ts
@@ -10,6 +10,8 @@ import {
   getSectionNameMaster,
   getRelationshipMaster,
   getContractorMaster,
+  getDirectionMaster,
+  getPositionMaster,
   getAllMasters,
   createMaster,
   updateMaster,
@@ -107,6 +109,22 @@ router.get(
   authenticate,
   checkApiPermission(),
   withLogging('Masters', 'getContractorMaster', getContractorMaster)
+);
+
+// 方角マスタ
+router.get(
+  '/direction',
+  authenticate,
+  checkApiPermission(),
+  withLogging('Masters', 'getDirectionMaster', getDirectionMaster)
+);
+
+// 位置マスタ
+router.get(
+  '/position',
+  authenticate,
+  checkApiPermission(),
+  withLogging('Masters', 'getPositionMaster', getPositionMaster)
 );
 
 // マスタデータ CRUD（汎用）

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -195,6 +195,9 @@ export const getPlotById = async (
             gravestoneType: contractPlot.gravestoneInfo.gravestone_type,
             surroundingArea: contractPlot.gravestoneInfo.surrounding_area,
             gravestoneCost: contractPlot.gravestoneInfo.gravestone_cost,
+            gravestoneInscription: contractPlot.gravestoneInfo.gravestone_inscription,
+            directionId: contractPlot.gravestoneInfo.direction_id,
+            positionId: contractPlot.gravestoneInfo.position_id,
             establishmentDeadline: contractPlot.gravestoneInfo.establishment_deadline,
             establishmentDate: contractPlot.gravestoneInfo.establishment_date,
           }

--- a/src/validations/masterValidation.ts
+++ b/src/validations/masterValidation.ts
@@ -42,6 +42,8 @@ export const VALID_MASTER_TYPES = [
   'section-name',
   'relationship',
   'contractor',
+  'direction',
+  'position',
 ] as const;
 
 export type MasterType = (typeof VALID_MASTER_TYPES)[number];

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1821,6 +1821,58 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v1/masters/direction:
+    get:
+      tags:
+        - Masters
+      summary: 方角マスタ一覧取得
+      description: 有効な方角マスタデータを表示順で取得（レガシー sykbnn KBNNO=2024 由来）。code は GravestoneInfo.direction_id の int 文字列。
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 方角マスタ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DirectionMaster"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v1/masters/position:
+    get:
+      tags:
+        - Masters
+      summary: 位置マスタ一覧取得
+      description: 有効な位置マスタデータを表示順で取得（レガシー sykbnn KBNNO=2025 由来）。code は GravestoneInfo.position_id の int 文字列。
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 位置マスタ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/PositionMaster"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v1/masters/all:
     get:
       tags:
@@ -2159,6 +2211,54 @@ components:
         name:
           type: string
           example: "小嶺石材"
+        description:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+          nullable: true
+          example: 1
+        isActive:
+          type: boolean
+          example: true
+
+    DirectionMaster:
+      type: object
+      description: 方角マスタ。code は GravestoneInfo.direction_id (レガシー houi_id) の int 文字列。
+      properties:
+        id:
+          type: integer
+          example: 1
+        code:
+          type: string
+          example: "1"
+        name:
+          type: string
+          example: "東"
+        description:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+          nullable: true
+          example: 1
+        isActive:
+          type: boolean
+          example: true
+
+    PositionMaster:
+      type: object
+      description: 位置マスタ。code は GravestoneInfo.position_id (レガシー ichi_id) の int 文字列。
+      properties:
+        id:
+          type: integer
+          example: 1
+        code:
+          type: string
+          example: "1"
+        name:
+          type: string
+          example: "角"
         description:
           type: string
           nullable: true

--- a/tests/masters/masterController.test.ts
+++ b/tests/masters/masterController.test.ts
@@ -128,6 +128,16 @@ const mockContractorData = [
   },
 ];
 
+const mockDirectionData = [
+  { id: 1, code: '1', name: '東', description: null, sort_order: 1, is_active: true },
+  { id: 2, code: '2', name: '西', description: null, sort_order: 2, is_active: true },
+];
+
+const mockPositionData = [
+  { id: 1, code: '1', name: '角', description: null, sort_order: 1, is_active: true },
+  { id: 2, code: '2', name: '端', description: null, sort_order: 2, is_active: true },
+];
+
 // モックプリズマインスタンスの作成
 const mockPrisma: any = {
   cemeteryTypeMaster: {
@@ -160,6 +170,12 @@ const mockPrisma: any = {
   contractorMaster: {
     findMany: jest.fn(),
   },
+  directionMaster: {
+    findMany: jest.fn(),
+  },
+  positionMaster: {
+    findMany: jest.fn(),
+  },
 };
 
 // PrismaClientをモック化
@@ -179,6 +195,8 @@ import {
   getSectionNameMaster,
   getRelationshipMaster,
   getContractorMaster,
+  getDirectionMaster,
+  getPositionMaster,
   getAllMasters,
 } from '../../src/masters/masterController';
 
@@ -664,6 +682,8 @@ describe('Master Controller', () => {
       mockPrisma.sectionNameMaster.findMany.mockResolvedValue(mockSectionNameData);
       mockPrisma.relationshipMaster.findMany.mockResolvedValue(mockRelationshipData);
       mockPrisma.contractorMaster.findMany.mockResolvedValue(mockContractorData);
+      mockPrisma.directionMaster.findMany.mockResolvedValue(mockDirectionData);
+      mockPrisma.positionMaster.findMany.mockResolvedValue(mockPositionData);
 
       await getAllMasters(mockRequest as Request, mockResponse as Response);
 
@@ -693,6 +713,14 @@ describe('Master Controller', () => {
       // 工事業者
       expect(jsonCall.data.contractor[0].code).toBe('placeholder-1');
       expect(jsonCall.data.contractor[0].name).toBe('小嶺石材');
+      // 方角
+      expect(jsonCall.data.direction).toHaveLength(2);
+      expect(jsonCall.data.direction[0].code).toBe('1');
+      expect(jsonCall.data.direction[0].name).toBe('東');
+      // 位置
+      expect(jsonCall.data.position).toHaveLength(2);
+      expect(jsonCall.data.position[0].code).toBe('1');
+      expect(jsonCall.data.position[0].name).toBe('角');
     });
 
     it('エラーが発生した場合、500エラーを返すこと', async () => {
@@ -707,6 +735,8 @@ describe('Master Controller', () => {
       mockPrisma.sectionNameMaster.findMany.mockResolvedValue([]);
       mockPrisma.relationshipMaster.findMany.mockResolvedValue([]);
       mockPrisma.contractorMaster.findMany.mockResolvedValue([]);
+      mockPrisma.directionMaster.findMany.mockResolvedValue([]);
+      mockPrisma.positionMaster.findMany.mockResolvedValue([]);
 
       await getAllMasters(mockRequest as Request, mockResponse as Response);
 
@@ -766,6 +796,78 @@ describe('Master Controller', () => {
         error: {
           code: 'INTERNAL_SERVER_ERROR',
           message: '工事業者マスタの取得に失敗しました',
+        },
+      });
+    });
+  });
+
+  describe('getDirectionMaster', () => {
+    it('方角マスタを取得できること', async () => {
+      mockPrisma.directionMaster.findMany.mockResolvedValue(mockDirectionData);
+
+      await getDirectionMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.directionMaster.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          { id: 1, code: '1', name: '東', description: null, sortOrder: 1, isActive: true },
+          { id: 2, code: '2', name: '西', description: null, sortOrder: 2, isActive: true },
+        ],
+      });
+    });
+
+    it('エラーが発生した場合、500エラーを返すこと', async () => {
+      mockPrisma.directionMaster.findMany.mockRejectedValue(new Error('Database error'));
+
+      await getDirectionMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: false,
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: '方角マスタの取得に失敗しました',
+        },
+      });
+    });
+  });
+
+  describe('getPositionMaster', () => {
+    it('位置マスタを取得できること', async () => {
+      mockPrisma.positionMaster.findMany.mockResolvedValue(mockPositionData);
+
+      await getPositionMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.positionMaster.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          { id: 1, code: '1', name: '角', description: null, sortOrder: 1, isActive: true },
+          { id: 2, code: '2', name: '端', description: null, sortOrder: 2, isActive: true },
+        ],
+      });
+    });
+
+    it('エラーが発生した場合、500エラーを返すこと', async () => {
+      mockPrisma.positionMaster.findMany.mockRejectedValue(new Error('Database error'));
+
+      await getPositionMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: false,
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: '位置マスタの取得に失敗しました',
         },
       });
     });

--- a/tests/masters/seedMasters.test.ts
+++ b/tests/masters/seedMasters.test.ts
@@ -16,11 +16,13 @@ function createFakePrisma() {
     billingTypeMaster: { createMany: makeCreateMany(3) },
     recipientTypeMaster: { createMany: makeCreateMany(3) },
     constructionTypeMaster: { createMany: makeCreateMany(4) },
+    directionMaster: { createMany: makeCreateMany(8) },
+    positionMaster: { createMany: makeCreateMany(3) },
   };
 }
 
 describe('seedMasters', () => {
-  it('標準マスタ7種すべてに対して createMany を呼ぶ', async () => {
+  it('標準マスタ9種すべてに対して createMany を呼ぶ', async () => {
     const prisma = createFakePrisma();
 
     const summary = await seedMasters(prisma as unknown as PrismaClient);
@@ -32,8 +34,10 @@ describe('seedMasters', () => {
     expect(prisma.billingTypeMaster.createMany).toHaveBeenCalledTimes(1);
     expect(prisma.recipientTypeMaster.createMany).toHaveBeenCalledTimes(1);
     expect(prisma.constructionTypeMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.directionMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.positionMaster.createMany).toHaveBeenCalledTimes(1);
 
-    expect(summary).toHaveLength(7);
+    expect(summary).toHaveLength(9);
   });
 
   it('冪等性のため skipDuplicates: true で投入する', async () => {
@@ -55,7 +59,7 @@ describe('seedMasters', () => {
     const summary = await seedMasters(prisma as unknown as PrismaClient);
 
     const total = summary.reduce((sum, s) => sum + s.inserted, 0);
-    expect(total).toBe(3 + 3 + 2 + 2 + 3 + 3 + 4);
+    expect(total).toBe(3 + 3 + 2 + 2 + 3 + 3 + 4 + 8 + 3);
     expect(summary.map((s) => s.master)).toEqual([
       'cemetery_type_master',
       'payment_method_master',
@@ -64,6 +68,8 @@ describe('seedMasters', () => {
       'billing_type_master',
       'recipient_type_master',
       'construction_type_master',
+      'direction_master',
+      'position_master',
     ]);
   });
 


### PR DESCRIPTION
## 概要
`GravestoneInfo.direction_id/position_id` がマスタ未対応で、詳細画面で名称解決できていなかった（実際には API が値を返しておらず空表示）問題に対応。

## 変更
- **schema/migration**: `DirectionMaster`/`PositionMaster`（旧 sykbnn KBNNO=2024/2025）
  - `code` はレガシー `houi_id`/`ichi_id` の int 文字列（`"1".."8"` / `"1".."3"`）。`direction_id`(Int) を `code === String(direction_id)` で解決するため **移行データの remap が不要**。
  - migration に INSERT 同梱（`migrate deploy` で投入済みを確認: 8方角/3位置）
- **seedMasters**: 8方角/3位置を冪等投入（`skipDuplicates`）
- **masters API**: `getDirectionMaster`/`getPositionMaster` + `/direction` `/position` ルート、`getAllMasters` に追加、`VALID_MASTER_TYPES` 拡張
- **getPlotById**: `directionId`/`positionId`/`gravestoneInscription` をシリアライズ（従来フロントが参照していたが backend が返していなかった）
- **swagger**: path/schema 追加（`swagger:validate` OK）
- **tests**: masterController/seedMasters のテスト拡張 — **全 847 件 pass**

## ⚠️ スコープ外（フォロー必要）
単一プロットの `createPlot`/`updatePlot` は **`GravestoneInfo` を一切永続化していない既存ギャップ**がある（frontend `plots.ts` も `gravestoneInfo: null` をハードコード）。そのため墓石フォームの方角/位置 select 化は本PRでは行わず、表示・マスタ公開までを対象とした。墓石情報の保存経路の end-to-end 対応は別issue推奨。

## 依存
- 型は komine-types#27 に依存。**types を先にマージ → 本repoの Dockerfile `TYPES_REF` を bump** すること。

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)