### PR TITLE
test(documents): 書類モジュールにユニットテストを追加 (#100)

### DIFF
--- a/src/documents/documentService.ts
+++ b/src/documents/documentService.ts
@@ -65,7 +65,26 @@ function loadAndRenderTemplate(templateType: TemplateType, data: Record<string, 
     throw new Error(`テンプレートが見つかりません: ${templateType}`);
   }
 
-  let html = fs.readFileSync(templatePath, 'utf-8');
+  const templateHtml = fs.readFileSync(templatePath, 'utf-8');
+  return renderTemplateHtml(templateHtml, templateType, data);
+}
+
+/**
+ * テンプレートHTML文字列にデータを埋め込む（ファイルI/O を伴わない純粋関数）。
+ *
+ * - プレースホルダ `{{ key }}` をデータ値で置換（ユーザー入力は HTMLエスケープ）
+ * - `RAW_HTML_KEYS`（サーバー生成の属性のみ）は素通し
+ * - payment-guide は未入力に既定値、invoice は金額整形・季節挨拶フォールバックを補完
+ * - 未解決プレースホルダは空文字に置換
+ *
+ * `loadAndRenderTemplate` から分離し、レンダリングロジックを単体テスト可能にする。
+ */
+export function renderTemplateHtml(
+  templateHtml: string,
+  templateType: TemplateType,
+  data: Record<string, unknown>
+): string {
+  let html = templateHtml;
 
   const preset = normalizePdfTextStylePreset(data['textStylePreset']);
   const dataForTemplate: Record<string, unknown> = {

--- a/tests/documents/documentService.test.ts
+++ b/tests/documents/documentService.test.ts
@@ -1,0 +1,132 @@
+/**
+ * documentService.renderTemplateHtml の単体テスト
+ *
+ * テンプレート文字列へのデータ埋め込み（プレースホルダ置換・HTMLエスケープ・
+ * 既定値補完）を、ファイルI/O なしで検証する。
+ */
+
+// PDF 生成系はテスト不要なのでモック（ブラウザ起動・pdf-lib 読み込みを回避）
+jest.mock('puppeteer', () => ({ launch: jest.fn() }));
+
+import { renderTemplateHtml } from '../../src/documents/documentService';
+
+describe('renderTemplateHtml', () => {
+  describe('プレースホルダ置換', () => {
+    it('{{ key }} をデータ値で置換する', () => {
+      const html = renderTemplateHtml('<p>{{ name }}</p>', 'permit', { name: '山田太郎' });
+      expect(html).toBe('<p>山田太郎</p>');
+    });
+
+    it('空白ありのプレースホルダ {{  key  }} も置換する', () => {
+      const html = renderTemplateHtml('<p>{{  name  }}</p>', 'permit', { name: 'A' });
+      expect(html).toBe('<p>A</p>');
+    });
+
+    it('同じプレースホルダが複数あっても全て置換する', () => {
+      const html = renderTemplateHtml('{{ x }}-{{ x }}', 'permit', { x: 'Z' });
+      expect(html).toBe('Z-Z');
+    });
+
+    it('未解決のプレースホルダは空文字に置換する', () => {
+      const html = renderTemplateHtml('<p>{{ missing }}</p>', 'permit', {});
+      expect(html).toBe('<p></p>');
+    });
+
+    it('ネストしたオブジェクトは . 連結キーで置換する', () => {
+      const html = renderTemplateHtml('{{ a.b }}', 'permit', { a: { b: 'nested' } });
+      expect(html).toBe('nested');
+    });
+  });
+
+  describe('HTMLエスケープ（XSS対策）', () => {
+    it('<script> をエスケープする', () => {
+      const html = renderTemplateHtml('{{ v }}', 'permit', { v: '<script>alert(1)</script>' });
+      expect(html).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    it('& < > " \' をすべてエスケープする', () => {
+      const html = renderTemplateHtml('{{ v }}', 'permit', { v: `&<>"'` });
+      expect(html).toBe('&amp;&lt;&gt;&quot;&#039;');
+    });
+
+    it('置換値内の $& などの正規表現特殊文字をリテラル挿入する', () => {
+      const html = renderTemplateHtml('{{ v }}', 'permit', { v: '$& $1 $`' });
+      expect(html).toBe('$&amp; $1 $`');
+    });
+  });
+
+  describe('textStyleBodyAttr (RAW_HTML_KEYS 素通し)', () => {
+    it('preset=default では空文字', () => {
+      const html = renderTemplateHtml('<body{{ textStyleBodyAttr }}>', 'permit', {
+        textStylePreset: 'default',
+      });
+      expect(html).toBe('<body>');
+    });
+
+    it('preset 指定時は HTML 属性をエスケープせず挿入する', () => {
+      const html = renderTemplateHtml('<body{{ textStyleBodyAttr }}>', 'permit', {
+        textStylePreset: 'mincho',
+      });
+      expect(html).toBe('<body class="doc-preset-mincho">');
+    });
+
+    it('未知の preset は default 扱い', () => {
+      const html = renderTemplateHtml('<body{{ textStyleBodyAttr }}>', 'permit', {
+        textStylePreset: 'bogus',
+      });
+      expect(html).toBe('<body>');
+    });
+  });
+
+  describe('payment-guide の既定値補完', () => {
+    it('未入力フィールドに既定値を補完する', () => {
+      const html = renderTemplateHtml('{{ option1 }}', 'payment-guide', {});
+      expect(html).toContain('当霊園事務所へご持参下さい。');
+    });
+
+    it('入力があれば既定値で上書きしない', () => {
+      const html = renderTemplateHtml('{{ option1 }}', 'payment-guide', { option1: '独自文言' });
+      expect(html).toBe('独自文言');
+    });
+  });
+
+  describe('invoice の金額整形・季節挨拶フォールバック', () => {
+    it('amount を桁区切りした amountFormatted を生成する', () => {
+      const html = renderTemplateHtml('{{ amountFormatted }}', 'invoice', {
+        customerName: 'X',
+        amount: 1234567,
+      });
+      expect(html).toBe('1,234,567');
+    });
+
+    it('amount が無く total があれば total を使う', () => {
+      const html = renderTemplateHtml('{{ amountFormatted }}', 'invoice', {
+        customerName: 'X',
+        total: 5000,
+      });
+      expect(html).toBe('5,000');
+    });
+
+    it('金額が数値でなければ amountFormatted は空文字', () => {
+      const html = renderTemplateHtml('{{ amountFormatted }}', 'invoice', {
+        customerName: 'X',
+        amount: 'abc',
+      });
+      expect(html).toBe('');
+    });
+
+    it('seasonGreeting 未指定なら非空のフォールバックが入る', () => {
+      const html = renderTemplateHtml('{{ seasonGreeting }}', 'invoice', { customerName: 'X' });
+      expect(html.length).toBeGreaterThan(0);
+    });
+
+    it('amountFormatted を明示指定すれば再計算しない', () => {
+      const html = renderTemplateHtml('{{ amountFormatted }}', 'invoice', {
+        customerName: 'X',
+        amount: 100,
+        amountFormatted: '指定済み',
+      });
+      expect(html).toBe('指定済み');
+    });
+  });
+});

--- a/tests/documents/documentValidation.test.ts
+++ b/tests/documents/documentValidation.test.ts
@@ -1,0 +1,81 @@
+/**
+ * documentValidation.parseTemplateData の単体テスト
+ *
+ * regeneratePdf で DB から復元した template_data を、テンプレ種別ごとの
+ * Zod スキーマでパースする。正常系と不正系（ZodError スロー）を検証する。
+ */
+import { parseTemplateData } from '../../src/validations/documentValidation';
+
+const validPostcard = {
+  recipientName: '受取 太郎',
+  recipientAddress: '福岡県北九州市1-2-3',
+  recipientPostalCode: '8000000',
+  senderName: '小嶺霊園',
+  senderAddress: '福岡県北九州市4-5-6',
+  senderPostalCode: '8001111',
+  message: 'お知らせ',
+  date: '2026-05-26',
+};
+
+describe('parseTemplateData', () => {
+  describe('invoice', () => {
+    it('customerName があれば通る', () => {
+      const r = parseTemplateData('invoice', { customerName: '山田', amount: 1000 });
+      expect(r).toMatchObject({ customerName: '山田' });
+    });
+    it('customerName が無いと ZodError', () => {
+      expect(() => parseTemplateData('invoice', {})).toThrow();
+    });
+    it('items の要素型が不正だと ZodError', () => {
+      expect(() =>
+        parseTemplateData('invoice', {
+          customerName: '山田',
+          items: [{ description: 'x', quantity: 'NaN', unitPrice: 1, amount: 1 }],
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('postcard', () => {
+    it('必須フィールドが揃えば通る', () => {
+      const r = parseTemplateData('postcard', validPostcard);
+      expect(r).toMatchObject({ recipientName: '受取 太郎' });
+    });
+    it('必須フィールド欠落で ZodError', () => {
+      const { message, ...missing } = validPostcard;
+      void message;
+      expect(() => parseTemplateData('postcard', missing)).toThrow();
+    });
+    it('型不一致（数値）で ZodError', () => {
+      expect(() =>
+        parseTemplateData('postcard', { ...validPostcard, recipientName: 123 })
+      ).toThrow();
+    });
+  });
+
+  describe('permit / envelope-letter / envelope-base（全フィールド任意）', () => {
+    it.each(['permit', 'envelope-letter', 'envelope-base'] as const)(
+      '%s は空オブジェクトでも通る',
+      (type) => {
+        expect(() => parseTemplateData(type, {})).not.toThrow();
+      }
+    );
+    it('permit は値を保持する', () => {
+      const r = parseTemplateData('permit', { permitNumber: 'P-1', plotNumber: 'A-56' });
+      expect(r).toMatchObject({ permitNumber: 'P-1', plotNumber: 'A-56' });
+    });
+    it('permit の型不一致で ZodError', () => {
+      expect(() => parseTemplateData('permit', { permitNumber: 123 })).toThrow();
+    });
+  });
+
+  describe('payment-guide（全フィールド任意）', () => {
+    it('空オブジェクトでも通る', () => {
+      expect(() => parseTemplateData('payment-guide', {})).not.toThrow();
+    });
+    it('値を保持する', () => {
+      const r = parseTemplateData('payment-guide', { orgName: '小嶺霊園' });
+      expect(r).toMatchObject({ orgName: '小嶺霊園' });
+    });
+  });
+});

--- a/tests/documents/sanitizeDocumentFileName.test.ts
+++ b/tests/documents/sanitizeDocumentFileName.test.ts
@@ -1,0 +1,42 @@
+/**
+ * sanitizeDocumentFileName の単体テスト
+ *
+ * 書類ダウンロード時のファイル名生成（documentController が利用）。
+ * 実体は @komine/types に定義され、backend が依存する共通サニタイザ。
+ */
+import { sanitizeDocumentFileName } from '@komine/types';
+
+describe('sanitizeDocumentFileName', () => {
+  it('OS 不正文字（/ \\ ? % * : | " < >）を _ に置換する', () => {
+    expect(sanitizeDocumentFileName('a/b\\c?d%e*f:g|h"i<j>k')).toBe('a_b_c_d_e_f_g_h_i_j_k.pdf');
+  });
+
+  it('既存の .pdf 拡張子は重複させない', () => {
+    expect(sanitizeDocumentFileName('report.pdf')).toBe('report.pdf');
+  });
+
+  it('.PDF（大文字）も拡張子とみなし重複させない', () => {
+    expect(sanitizeDocumentFileName('REPORT.PDF')).toBe('REPORT.PDF');
+  });
+
+  it('拡張子が無ければ .pdf を付与する', () => {
+    expect(sanitizeDocumentFileName('請求書')).toBe('請求書.pdf');
+  });
+
+  it('前後の空白をトリムする', () => {
+    expect(sanitizeDocumentFileName('  doc  ')).toBe('doc.pdf');
+  });
+
+  it('空文字は document.pdf にフォールバックする', () => {
+    expect(sanitizeDocumentFileName('')).toBe('document.pdf');
+  });
+
+  it('null / undefined は document.pdf にフォールバックする', () => {
+    expect(sanitizeDocumentFileName(null)).toBe('document.pdf');
+    expect(sanitizeDocumentFileName(undefined)).toBe('document.pdf');
+  });
+
+  it('不正文字のみの名前も _ 連結で .pdf 付与', () => {
+    expect(sanitizeDocumentFileName(':::')).toBe('___.pdf');
+  });
+});


### PR DESCRIPTION
## 概要
書類関連モジュールにユニットテストが0件だった問題に対応。テスト可能性のため、`documentService` のレンダリングロジックを純粋関数 `renderTemplateHtml`（ファイルI/Oなし）として分離し、計 **39件** のテストを追加。

## 変更
- **リファクタ**: `loadAndRenderTemplate` → ファイル読込 + `renderTemplateHtml(html, type, data)`（挙動不変）
- **renderTemplateHtml（19件）**: プレースホルダ置換 / **HTMLエスケープ(XSS)** / `$&` 等のリテラル挿入 / `RAW_HTML_KEYS`(textStyleBodyAttr) 素通し / 未解決→空文字 / payment-guide 既定値補完 / invoice の amountFormatted・seasonGreeting フォールバック
- **parseTemplateData（13件）**: invoice/postcard/permit/envelope-letter/envelope-base/payment-guide の正常系・ZodError
- **sanitizeDocumentFileName（8件）**: 不正文字除去 / `.pdf` 重複防止（大文字含む）/ 空・null フォールバック

## 結果
- 39 tests pass、全体 **882 tests pass**、typecheck OK

## スコープ外（フォロー余地）
`generatePdf` / `regeneratePdf` コントローラ、`permitPdfService` の座標描画は prisma / puppeteer / ベースPDF のモックが必要なため本PRでは未カバー。issue の残チェックリストとして別途対応可能。

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)