### PR TITLE
refactor(types): prisma tx 引数の any を排除し ESLint 警告を削減 (#142 段階対応)

### DIFF
--- a/src/plots/utils.ts
+++ b/src/plots/utils.ts
@@ -4,7 +4,7 @@
  * 物理区画の在庫計算と契約可能面積の検証を行います
  */
 
-import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 /**
  * 物理区画の利用可能面積を計算
@@ -13,7 +13,7 @@ import { PrismaClient } from '@prisma/client';
  * @returns 利用可能面積（㎡）
  */
 export async function calculateAvailableArea(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string
 ): Promise<number> {
   const physicalPlot = await prisma.physicalPlot.findUnique({
@@ -39,7 +39,7 @@ export async function calculateAvailableArea(
 
   // 契約済み面積の合計
   const contractedArea = (physicalPlot.contractPlots || []).reduce(
-    (sum: number, contract: any) => sum + contract.contract_area_sqm.toNumber(),
+    (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
     0
   );
 
@@ -58,7 +58,7 @@ export async function calculateAvailableArea(
  * @returns 契約可能かどうか
  */
 export async function validateContractArea(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string,
   requestedArea: number,
   excludeContractPlotId?: string
@@ -92,7 +92,7 @@ export async function validateContractArea(
 
   const totalArea = physicalPlot.area_sqm.toNumber();
   const contractedArea = (physicalPlot.contractPlots || []).reduce(
-    (sum: number, contract: any) => sum + contract.contract_area_sqm.toNumber(),
+    (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
     0
   );
   const availableArea = totalArea - contractedArea;
@@ -127,7 +127,7 @@ export async function validateContractArea(
  * @returns 更新後のステータス
  */
 export async function updatePhysicalPlotStatus(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string
 ): Promise<'available' | 'partially_sold' | 'sold_out'> {
   const availableArea = await calculateAvailableArea(prisma, physicalPlotId);
@@ -168,7 +168,7 @@ export async function updatePhysicalPlotStatus(
  * @returns 完全に利用可能かどうか
  */
 export async function isFullyAvailable(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string
 ): Promise<boolean> {
   const physicalPlot = await prisma.physicalPlot.findUnique({
@@ -194,7 +194,7 @@ export async function isFullyAvailable(
  * @returns 完全に売却済みかどうか
  */
 export async function isFullySold(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string
 ): Promise<boolean> {
   const availableArea = await calculateAvailableArea(prisma, physicalPlotId);
@@ -209,7 +209,7 @@ export async function isFullySold(
  * @returns 契約可能な面積パターン（例: [1.8, 3.6]）
  */
 export async function getAvailableAreaOptions(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string
 ): Promise<number[]> {
   const availableArea = await calculateAvailableArea(prisma, physicalPlotId);

--- a/src/validations/plotBusinessRules.ts
+++ b/src/validations/plotBusinessRules.ts
@@ -6,7 +6,7 @@
  * データベースアクセスを伴うビジネスルールの検証を行います。
  */
 
-import { PrismaClient, ContractRole } from '@prisma/client';
+import { Prisma, ContractRole } from '@prisma/client';
 import { ValidationError } from '../middleware/errorHandler';
 
 /**
@@ -28,7 +28,7 @@ export function validatePlotNumberFormat(plotNumber: string): boolean {
  * @returns 重複しているかどうか
  */
 export async function isPlotNumberDuplicate(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   plotNumber: string,
   excludeId?: string
 ): Promise<boolean> {
@@ -132,7 +132,7 @@ export function isValidAreaDivision(
  * @returns 削除可能かどうか
  */
 export async function canDeletePhysicalPlot(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   physicalPlotId: string
 ): Promise<{
   canDelete: boolean;
@@ -172,7 +172,7 @@ export async function canDeletePhysicalPlot(
  * @returns 削除可能かどうか
  */
 export async function canDeleteContractPlot(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   contractPlotId: string
 ): Promise<{
   canDelete: boolean;
@@ -268,7 +268,7 @@ export function validateCustomerRole(role: string): boolean {
  * @throws ValidationError
  */
 export async function validatePhysicalPlotCreate(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   plotNumber: string,
   areaSqm: number
 ): Promise<void> {
@@ -305,7 +305,7 @@ export async function validatePhysicalPlotCreate(
  * @throws ValidationError
  */
 export async function validatePhysicalPlotUpdate(
-  prisma: PrismaClient | any,
+  prisma: Prisma.TransactionClient,
   id: string,
   plotNumber?: string,
   areaSqm?: number
@@ -347,7 +347,7 @@ export async function validatePhysicalPlotUpdate(
 
     if (physicalPlot) {
       const totalContractedArea = (physicalPlot.contractPlots || []).reduce(
-        (sum: number, contract: any) => sum + contract.contract_area_sqm.toNumber(),
+        (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
         0
       );
 


### PR DESCRIPTION
## 概要
#142（ESLint no-unsafe-* 警告 1,200+ 件の技術的負債）の**段階的削減**の第一歩。

トランザクション対応のため `prisma: PrismaClient | any` と書かれていた引数が `any` 経由で大量の `no-unsafe-assignment` / `no-unsafe-call` / `no-unsafe-member-access` を誘発していた。`Prisma.TransactionClient`（フルクライアントも tx も代入可能）へ置換し、配列 `reduce` の `contract: any` も型推論に委ねて連鎖を解消。

## 効果（計測）
| ファイル | before | after |
|---|---|---|
| `src/validations/plotBusinessRules.ts` | 29 | **0** |
| `src/plots/utils.ts` | 47 | **0** |
| **合計** | 1,203 | **1,129**（-74） |

- 挙動不変（型注釈のみ）。`tsc --noEmit` OK / 全 **882 tests pass**

## 残（フォロー）
- `src/collective-burials/utils.ts` 等にも同パターンが残るが、返り値 `Promise<any[]>` / `updateData: any` 等が絡むため別対応。
- 提案にある「CI で warning 上限（増加防止）」は他PRをブロックしうる方針判断のため本PRには含めず（チーム判断推奨）。

本PRは段階対応のため #142 はクローズしません。

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)