### PR TITLE
fix(plots): 単一/更新/分割契約で GravestoneInfo を永続化 (#154)

### DIFF
--- a/__mocks__/@prisma/client.ts
+++ b/__mocks__/@prisma/client.ts
@@ -81,6 +81,13 @@ export const PrismaClient = jest.fn().mockImplementation(() => ({
     update: jest.fn(),
     delete: jest.fn(),
   },
+  gravestoneInfo: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
   billingAccount: {
     findMany: jest.fn(),
     findUnique: jest.fn(),

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -9,7 +9,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Prisma, PaymentStatus, ContractRole, DmSetting, AddressType } from '@prisma/client';
 import { CreatePlotRequest } from '@komine/types';
-import { validateContractArea, updatePhysicalPlotStatus } from '../utils';
+import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
 import {
@@ -161,6 +161,20 @@ export async function createPlotCore(
       legacy_grave_cd: input.saleContract.legacyGraveCd ?? null,
     },
   });
+
+  // 6. 墓石情報の作成（issue #154: 単一作成・一括作成で永続化されていなかった）
+  let gravestoneInfo: { id: string } | null = null;
+  if (input.gravestoneInfo) {
+    const gravestoneData = buildGravestoneInfoData(input.gravestoneInfo);
+    if (Object.keys(gravestoneData).length > 0) {
+      gravestoneInfo = await tx.gravestoneInfo.create({
+        data: {
+          contract_plot_id: contractPlot.id,
+          ...gravestoneData,
+        },
+      });
+    }
+  }
 
   // 6.5. 合祀情報の作成
   let collectiveBurial: { id: string } | null = null;
@@ -332,6 +346,16 @@ export async function createPlotCore(
       physicalPlotId: physicalPlot.id,
       contractPlotId: contractPlot.id,
       afterRecord: { id: managementFee.id, ...input.managementFee! },
+      req,
+    });
+  }
+  if (gravestoneInfo) {
+    await recordEntityCreated(tx, {
+      entityType: 'GravestoneInfo',
+      entityId: gravestoneInfo.id,
+      physicalPlotId: physicalPlot.id,
+      contractPlotId: contractPlot.id,
+      afterRecord: { id: gravestoneInfo.id, ...buildGravestoneInfoData(input.gravestoneInfo!) },
       req,
     });
   }

--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -7,7 +7,7 @@
 
 import { Request, Response } from 'express';
 import { Prisma, PaymentStatus, ContractRole } from '@prisma/client';
-import { validateContractArea, updatePhysicalPlotStatus } from '../utils';
+import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
 import { getRequestLogger } from '../../utils/logger';
 
@@ -145,6 +145,19 @@ export const createPlotContract = async (req: Request, res: Response): Promise<a
             role: input.saleContract.customerRole || ContractRole.contractor,
           },
         });
+      }
+
+      // 墓石情報作成（オプション・issue #154）
+      if (input.gravestoneInfo) {
+        const gravestoneData = buildGravestoneInfoData(input.gravestoneInfo);
+        if (Object.keys(gravestoneData).length > 0) {
+          await tx.gravestoneInfo.create({
+            data: {
+              contract_plot_id: contractPlot.id,
+              ...gravestoneData,
+            },
+          });
+        }
       }
 
       // UsageFee作成（オプション）

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -8,7 +8,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Prisma, ContractRole } from '@prisma/client';
 import { UpdatePlotRequest } from '@komine/types';
-import { updatePhysicalPlotStatus } from '../utils';
+import { updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
 import {
@@ -53,6 +53,7 @@ export async function updatePlotCore(
       usageFee: true,
       managementFee: true,
       collectiveBurial: true,
+      gravestoneInfo: true,
     },
   });
 
@@ -748,6 +749,101 @@ export async function updatePlotCore(
             afterRecord: {
               id: created.id,
               ...managementFeeData,
+            },
+            req,
+          });
+        }
+      }
+    }
+  }
+
+  // 8.5. GravestoneInfo（issue #154: update で永続化されていなかった）
+  if (input.gravestoneInfo !== undefined) {
+    const existingGravestone = existingContractPlot.gravestoneInfo;
+
+    if (input.gravestoneInfo === null) {
+      if (existingGravestone) {
+        await tx.gravestoneInfo.delete({
+          where: { id: existingGravestone.id },
+        });
+        await recordEntityDeleted(tx, {
+          entityType: 'GravestoneInfo',
+          entityId: existingGravestone.id,
+          physicalPlotId,
+          contractPlotId: id,
+          beforeRecord: {
+            id: existingGravestone.id,
+            gravestone_base: existingGravestone.gravestone_base,
+            gravestone_dealer: existingGravestone.gravestone_dealer,
+            gravestone_type: existingGravestone.gravestone_type,
+            direction_id: existingGravestone.direction_id,
+            position_id: existingGravestone.position_id,
+          },
+          req,
+        });
+      }
+    } else {
+      const gravestoneData = buildGravestoneInfoData(input.gravestoneInfo);
+
+      if (Object.keys(gravestoneData).length > 0) {
+        if (existingGravestone) {
+          const before = existingGravestone;
+          const updated = await tx.gravestoneInfo.update({
+            where: { id: before.id },
+            data: gravestoneData,
+          });
+          await recordEntityUpdated(tx, {
+            entityType: 'GravestoneInfo',
+            entityId: before.id,
+            physicalPlotId,
+            contractPlotId: id,
+            beforeRecord: {
+              gravestone_base: before.gravestone_base,
+              enclosure_position: before.enclosure_position,
+              gravestone_dealer: before.gravestone_dealer,
+              gravestone_type: before.gravestone_type,
+              surrounding_area: before.surrounding_area,
+              gravestone_cost: before.gravestone_cost,
+              establishment_deadline: before.establishment_deadline?.toISOString() ?? null,
+              establishment_date: before.establishment_date?.toISOString() ?? null,
+              gravestone_inscription: before.gravestone_inscription,
+              direction_id: before.direction_id,
+              position_id: before.position_id,
+            },
+            afterRecord: {
+              gravestone_base: updated.gravestone_base,
+              enclosure_position: updated.enclosure_position,
+              gravestone_dealer: updated.gravestone_dealer,
+              gravestone_type: updated.gravestone_type,
+              surrounding_area: updated.surrounding_area,
+              gravestone_cost: updated.gravestone_cost,
+              establishment_deadline: updated.establishment_deadline?.toISOString() ?? null,
+              establishment_date: updated.establishment_date?.toISOString() ?? null,
+              gravestone_inscription: updated.gravestone_inscription,
+              direction_id: updated.direction_id,
+              position_id: updated.position_id,
+            },
+            req,
+          });
+        } else {
+          const created = await tx.gravestoneInfo.create({
+            data: {
+              contract_plot_id: id,
+              ...gravestoneData,
+            },
+          });
+          await recordEntityCreated(tx, {
+            entityType: 'GravestoneInfo',
+            entityId: created.id,
+            physicalPlotId,
+            contractPlotId: id,
+            afterRecord: {
+              id: created.id,
+              gravestone_base: created.gravestone_base,
+              gravestone_dealer: created.gravestone_dealer,
+              gravestone_type: created.gravestone_type,
+              direction_id: created.direction_id,
+              position_id: created.position_id,
             },
             req,
           });

--- a/src/plots/utils.ts
+++ b/src/plots/utils.ts
@@ -7,6 +7,46 @@
 import { Prisma } from '@prisma/client';
 
 /**
+ * フォーム入力（camelCase）から GravestoneInfo の永続化用データ（snake_case）へ変換する。
+ * create / update / createPlotContract / bulk の各経路で共通利用する。
+ * undefined のキーは省略し、null は明示的にクリアとして扱う。
+ */
+export function buildGravestoneInfoData(input: {
+  gravestoneBase?: string | null;
+  enclosurePosition?: string | null;
+  gravestoneDealer?: string | null;
+  gravestoneType?: string | null;
+  surroundingArea?: string | null;
+  gravestoneCost?: number | null;
+  establishmentDeadline?: string | null;
+  establishmentDate?: string | null;
+  gravestoneInscription?: string | null;
+  directionId?: number | null;
+  positionId?: number | null;
+}): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  if (input.gravestoneBase !== undefined) data['gravestone_base'] = input.gravestoneBase || null;
+  if (input.enclosurePosition !== undefined)
+    data['enclosure_position'] = input.enclosurePosition || null;
+  if (input.gravestoneDealer !== undefined)
+    data['gravestone_dealer'] = input.gravestoneDealer || null;
+  if (input.gravestoneType !== undefined) data['gravestone_type'] = input.gravestoneType || null;
+  if (input.surroundingArea !== undefined) data['surrounding_area'] = input.surroundingArea || null;
+  if (input.gravestoneCost !== undefined) data['gravestone_cost'] = input.gravestoneCost ?? null;
+  if (input.establishmentDeadline !== undefined)
+    data['establishment_deadline'] = input.establishmentDeadline
+      ? new Date(input.establishmentDeadline)
+      : null;
+  if (input.establishmentDate !== undefined)
+    data['establishment_date'] = input.establishmentDate ? new Date(input.establishmentDate) : null;
+  if (input.gravestoneInscription !== undefined)
+    data['gravestone_inscription'] = input.gravestoneInscription || null;
+  if (input.directionId !== undefined) data['direction_id'] = input.directionId ?? null;
+  if (input.positionId !== undefined) data['position_id'] = input.positionId ?? null;
+  return data;
+}
+
+/**
  * 物理区画の利用可能面積を計算
  * @param prisma Prismaクライアント（トランザクション対応）
  * @param physicalPlotId 物理区画ID

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -66,6 +66,12 @@ const mockPrisma: any = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+  gravestoneInfo: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
   $transaction: jest.fn((callback: any) => Promise.resolve(callback(mockPrisma))),
 };
 
@@ -96,11 +102,15 @@ jest.mock('@prisma/client', () => ({
   },
 }));
 
-// ユーティリティ関数のモック化
-jest.mock('../../src/plots/utils', () => ({
-  validateContractArea: jest.fn(),
-  updatePhysicalPlotStatus: jest.fn(),
-}));
+// ユーティリティ関数のモック化（buildGravestoneInfoData は実装をそのまま使用）
+jest.mock('../../src/plots/utils', () => {
+  const actual = jest.requireActual('../../src/plots/utils');
+  return {
+    validateContractArea: jest.fn(),
+    updatePhysicalPlotStatus: jest.fn(),
+    buildGravestoneInfoData: actual.buildGravestoneInfoData,
+  };
+});
 
 // 履歴サービスのモック化
 jest.mock('../../src/plots/services/historyService', () => ({
@@ -1166,6 +1176,226 @@ describe('Plot Controller (ContractPlot Model)', () => {
         expect.objectContaining({
           where: { id: 'scr2' },
           data: expect.objectContaining({ deleted_at: expect.any(Date) }),
+        })
+      );
+    });
+  });
+
+  describe('GravestoneInfo persistence (issue #154)', () => {
+    const gravestoneInput = {
+      gravestoneBase: '石基A',
+      enclosurePosition: '北東',
+      gravestoneDealer: '小嶺石材',
+      gravestoneType: '和型',
+      surroundingArea: '0.5㎡',
+      gravestoneCost: 500000,
+      establishmentDeadline: '2025-03-31',
+      establishmentDate: '2025-01-15',
+      gravestoneInscription: '南無阿弥陀仏',
+      directionId: 2,
+      positionId: 3,
+    };
+
+    it('createPlot は gravestoneInfo を snake_case で永続化する', async () => {
+      mockPrisma.physicalPlot.create.mockResolvedValue({
+        id: 'pp1',
+        plot_number: 'A-01',
+        area_name: '一般墓地A',
+        area_sqm: new Prisma.Decimal(3.6),
+        status: 'sold_out',
+      });
+      mockPrisma.customer.create.mockResolvedValue({ id: 'c1', name: '山田太郎' });
+      mockPrisma.contractPlot.create.mockResolvedValue({ id: 'cp1', physical_plot_id: 'pp1' });
+      mockPrisma.saleContractRole.create.mockResolvedValue({ id: 'scr1', customer: { id: 'c1' } });
+      mockPrisma.gravestoneInfo.create.mockResolvedValue({ id: 'g1' });
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: {
+          id: 'pp1',
+          plot_number: 'A-01',
+          area_name: '一般墓地A',
+          area_sqm: new Prisma.Decimal(3.6),
+        },
+        saleContractRoles: [],
+        usageFee: null,
+        managementFee: null,
+        collectiveBurial: null,
+      });
+
+      mockRequest.body = {
+        physicalPlot: { plotNumber: 'A-01', areaName: '一般墓地A', areaSqm: 3.6 },
+        contractPlot: { contractAreaSqm: 3.6 },
+        saleContract: { contractDate: '2024-01-01' },
+        customer: {
+          name: '山田太郎',
+          nameKana: 'ヤマダタロウ',
+          postalCode: '150-0001',
+          address: '東京都渋谷区',
+          phoneNumber: '0312345678',
+        },
+        gravestoneInfo: gravestoneInput,
+      };
+
+      await createPlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.gravestoneInfo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            contract_plot_id: 'cp1',
+            gravestone_base: '石基A',
+            enclosure_position: '北東',
+            gravestone_dealer: '小嶺石材',
+            gravestone_type: '和型',
+            surrounding_area: '0.5㎡',
+            gravestone_cost: 500000,
+            establishment_deadline: new Date('2025-03-31'),
+            establishment_date: new Date('2025-01-15'),
+            gravestone_inscription: '南無阿弥陀仏',
+            direction_id: 2,
+            position_id: 3,
+          }),
+        })
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    const buildExistingPlot = (gravestoneInfo: unknown) => ({
+      id: 'cp1',
+      physical_plot_id: 'pp1',
+      contract_area_sqm: new Prisma.Decimal(3.6),
+      physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+      saleContractRoles: [
+        {
+          id: 'scr1',
+          role: 'contractor',
+          customer: { id: 'c1', workInfo: null },
+          deleted_at: null,
+        },
+      ],
+      usageFee: null,
+      managementFee: null,
+      collectiveBurial: null,
+      gravestoneInfo,
+    });
+
+    it('updatePlot は既存 gravestoneInfo が無い場合に create する', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildExistingPlot(null));
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.gravestoneInfo.create.mockResolvedValue({ id: 'g1' });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = { gravestoneInfo: gravestoneInput };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.gravestoneInfo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ contract_plot_id: 'cp1', gravestone_base: '石基A' }),
+        })
+      );
+      expect(mockPrisma.gravestoneInfo.update).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('updatePlot は既存 gravestoneInfo がある場合に update する', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(
+        buildExistingPlot({
+          id: 'g1',
+          gravestone_base: '旧',
+          enclosure_position: null,
+          gravestone_dealer: null,
+          gravestone_type: null,
+          surrounding_area: null,
+          gravestone_cost: null,
+          establishment_deadline: null,
+          establishment_date: null,
+          gravestone_inscription: null,
+          direction_id: null,
+          position_id: null,
+        })
+      );
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.gravestoneInfo.update.mockResolvedValue({
+        id: 'g1',
+        gravestone_base: '石基A',
+        enclosure_position: '北東',
+        gravestone_dealer: '小嶺石材',
+        gravestone_type: '和型',
+        surrounding_area: '0.5㎡',
+        gravestone_cost: 500000,
+        establishment_deadline: new Date('2025-03-31'),
+        establishment_date: new Date('2025-01-15'),
+        gravestone_inscription: '南無阿弥陀仏',
+        direction_id: 2,
+        position_id: 3,
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = { gravestoneInfo: gravestoneInput };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.gravestoneInfo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'g1' },
+          data: expect.objectContaining({ gravestone_base: '石基A', direction_id: 2 }),
+        })
+      );
+      expect(mockPrisma.gravestoneInfo.create).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('updatePlot は gravestoneInfo: null で既存を削除する', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(
+        buildExistingPlot({
+          id: 'g1',
+          gravestone_base: '旧',
+          gravestone_dealer: null,
+          gravestone_type: null,
+          direction_id: null,
+          position_id: null,
+        })
+      );
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.gravestoneInfo.delete.mockResolvedValue({ id: 'g1' });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = { gravestoneInfo: null };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.gravestoneInfo.delete).toHaveBeenCalledWith({ where: { id: 'g1' } });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('createPlotContract は gravestoneInfo を永続化する', async () => {
+      mockPrisma.physicalPlot.findUnique.mockResolvedValue({ id: 'pp1' });
+      (validateContractArea as jest.Mock).mockResolvedValue({ isValid: true });
+      mockPrisma.customer.create.mockResolvedValue({ id: 'c1' });
+      mockPrisma.contractPlot.create.mockResolvedValue({ id: 'cp1' });
+      mockPrisma.saleContractRole.create.mockResolvedValue({ id: 'scr1' });
+      mockPrisma.gravestoneInfo.create.mockResolvedValue({ id: 'g1' });
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(3.6) },
+        saleContractRoles: [],
+      });
+
+      mockRequest.params = { id: 'pp1' };
+      mockRequest.body = {
+        contractPlot: { contractAreaSqm: 3.6 },
+        saleContract: {},
+        customer: { name: '田中', nameKana: 'タナカ' },
+        gravestoneInfo: gravestoneInput,
+      };
+
+      await createPlotContract(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.gravestoneInfo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ contract_plot_id: 'cp1', gravestone_base: '石基A' }),
         })
       );
     });


### PR DESCRIPTION
## 概要

墓石情報（墓石台・外柵位置・石材店・墓石種類・周辺面積・墓石代・建立期限/日・墓誌・方位/位置）がフォームで入力・編集できるのに **DB へ永続化されず黙って落ちていた** 不具合（#154）を修正。

調査の結果、書き込みは **全経路で欠落** していた（issue 記載の「bulk のみ書込み」も実際には未永続化で、bulk はバリデーションのみ）。frontend は `plot-form.ts` で既に `gravestoneInfo` を送信済みのため、バグは backend 側のみだった。

## 変更内容

- **`utils.ts`**: `buildGravestoneInfoData()` を追加。camelCase→snake_case のマッピングを集約し、create/update/contract/bulk で共通利用（`undefined` は省略、`null` はクリア扱い）
- **`createPlotCore`**: `GravestoneInfo` を create（→ bulk 経路も自動修正）+ 履歴記録
- **`updatePlotCore`**: `GravestoneInfo` の create/update/delete を upsert で対応（`null` で既存削除、履歴記録あり）
- **`createPlotContract`**: 分割販売契約でも `GravestoneInfo` を永続化
- **テスト**: 保存→マッピング検証の往復テストを5件追加（mock prisma に `gravestoneInfo` 追加、`buildGravestoneInfoData` は実装をそのまま使用）

## frontend について

`plots.ts` の `gravestoneInfo: null`（2箇所）は **モック応答ビルダー** であり、実リクエスト整形（`plot-form.ts`）は既に `gravestoneInfo` を送信している。よって frontend 変更は不要（issue のチェックリストは誤診断）。方位/位置の select 化（#147）は本修正で保存経路が通ったため別途実施可能。

## 検証

- `npm test` … 891 passed（新規5件含む）
- `npm run lint` … 0 errors（既存 warning は #142 の範囲）
- `npx tsc --noEmit` … pass

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)