### PR TITLE
fix(plots): 台帳から空き区画除外＋vacant面積計算/新規active化 (#167, #165)

### DIFF
--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -7,7 +7,14 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { Prisma, PaymentStatus, ContractRole, DmSetting, AddressType } from '@prisma/client';
+import {
+  Prisma,
+  PaymentStatus,
+  ContractRole,
+  ContractStatus,
+  DmSetting,
+  AddressType,
+} from '@prisma/client';
 import { CreatePlotRequest } from '@komine/types';
 import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
@@ -129,6 +136,9 @@ export async function createPlotCore(
   const contractPlot = await tx.contractPlot.create({
     data: {
       physical_plot_id: physicalPlot.id,
+      // 新規作成は実契約（顧客あり）のため active。schema default は vacant（在庫の器契約）。
+      // active を立てないと在庫面積計算（#165）・台帳表示（#167）から漏れる。
+      contract_status: ContractStatus.active,
       contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
       location_description: input.contractPlot.locationDescription || null,
       burial_capacity: input.collectiveBurial?.burialCapacity ?? null,

--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -6,7 +6,7 @@
  */
 
 import { Request, Response } from 'express';
-import { Prisma, PaymentStatus, ContractRole } from '@prisma/client';
+import { Prisma, PaymentStatus, ContractRole, ContractStatus } from '@prisma/client';
 import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
 import { getRequestLogger } from '../../utils/logger';
@@ -92,6 +92,8 @@ export const createPlotContract = async (req: Request, res: Response): Promise<a
       const contractPlot = await tx.contractPlot.create({
         data: {
           physical_plot_id: physicalPlotId,
+          // 分割販売の新規契約も実契約のため active（schema default の vacant ではない）。#165 / #167 参照。
+          contract_status: ContractStatus.active,
           contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
           location_description: input.contractPlot.locationDescription || null,
           // 販売契約情報（ContractPlotに統合済み）

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -107,8 +107,12 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
     const take = limit;
 
     // 検索条件の構築
+    // 台帳問い合わせ（/plots）には契約のない空き区画（contract_status='vacant'）を表示しない。
+    // 空き区画は区画残数管理（/plot-availability, inventory系）にのみ表示する（#167）。
+    // active / terminated は過去・現在の契約がある区画のため従来どおり一覧へ含める。
     const whereCondition: Prisma.ContractPlotWhereInput = {
       deleted_at: null,
+      contract_status: { not: 'vacant' },
     };
 
     // フリーテキスト検索（区画番号、顧客名、顧客名カナ、電話番号、住所）

--- a/src/plots/utils.ts
+++ b/src/plots/utils.ts
@@ -62,6 +62,9 @@ export async function calculateAvailableArea(
       contractPlots: {
         where: {
           deleted_at: null,
+          // active（契約中）のみを契約済み面積に計上する。vacant（在庫の器契約）と
+          // terminated（解約済）は契約済み面積に含めない（#165）。
+          contract_status: 'active',
         },
         select: {
           contract_area_sqm: true,
@@ -113,6 +116,8 @@ export async function validateContractArea(
       contractPlots: {
         where: {
           deleted_at: null,
+          // active（契約中）のみを契約済み面積に計上する（#165）。
+          contract_status: 'active',
           ...(excludeContractPlotId && { id: { not: excludeContractPlotId } }),
         },
         select: {

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -419,6 +419,22 @@ describe('Plot Controller (ContractPlot Model)', () => {
       expect(whereArg).not.toHaveProperty('grave_kubun');
       expect(whereArg).not.toHaveProperty('grave_type');
     });
+
+    it('should exclude vacant (空き区画) from both list and count (#167)', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: 1, limit: 10 } as any;
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const findManyWhere = mockPrisma.contractPlot.findMany.mock.calls[0][0].where;
+      const countWhere = mockPrisma.contractPlot.count.mock.calls[0][0].where;
+
+      // 一覧・件数の両方に vacant 除外条件が効いていること
+      expect(findManyWhere).toMatchObject({ contract_status: { not: 'vacant' } });
+      expect(countWhere).toMatchObject({ contract_status: { not: 'vacant' } });
+    });
   });
 
   describe('getPlotById', () => {

--- a/tests/utils/inventoryUtils.test.ts
+++ b/tests/utils/inventoryUtils.test.ts
@@ -48,11 +48,34 @@ describe('inventoryUtils', () => {
         where: { id: 'plot-1' },
         include: {
           contractPlots: {
-            where: { deleted_at: null },
+            where: { deleted_at: null, contract_status: 'active' },
             select: { contract_area_sqm: true },
           },
         },
       });
+    });
+
+    it('vacant / terminated 契約は契約済み面積に計上しない（active のみ集計, #165）', async () => {
+      // DB クエリ側で active のみに絞るため、モックは active のみ返す前提。
+      // ここでは集計クエリに contract_status: 'active' フィルタが渡ることを検証する。
+      mockPrismaClient.physicalPlot.findUnique.mockResolvedValue({
+        id: 'plot-1',
+        area_sqm: { toNumber: () => 3.6 },
+        contractPlots: [],
+      });
+
+      const result = await calculateAvailableArea(mockPrismaClient, 'plot-1');
+
+      expect(result).toBe(3.6);
+      expect(mockPrismaClient.physicalPlot.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.objectContaining({
+            contractPlots: expect.objectContaining({
+              where: expect.objectContaining({ contract_status: 'active' }),
+            }),
+          }),
+        })
+      );
     });
 
     it('契約がある場合、残り面積を返す', async () => {
@@ -159,6 +182,7 @@ describe('inventoryUtils', () => {
           contractPlots: {
             where: {
               deleted_at: null,
+              contract_status: 'active',
               id: { not: 'contract-1' },
             },
             select: { contract_area_sqm: true },


### PR DESCRIPTION
vacant（在庫の器契約）と active（実契約）の扱いを一貫させる変更。#167 と #165 は同根のため1本にまとめた。

## 変更内容

### 1. 台帳問い合わせから空き区画を除外（#167）
- `getPlots` の `whereCondition` に `contract_status: { not: 'vacant' }` を追加（一覧・件数の両方）
- 契約者名空欄として並んでいた 2,701件（全体の44%）の正体は vacant な在庫区画。台帳から除外して指摘を解消
- 区画残数管理（inventory系）は `PhysicalPlot.status` ベースの別クエリのため影響なし

### 2. 在庫面積計算で vacant/terminated を計上しない（#165）
- `calculateAvailableArea` / `validateContractArea` の集計に `contract_status: 'active'` フィルタを追加
- vacant 区画が契約操作トリガで `sold_out` に化ける／新規契約をブロックする不具合を解消

### 3. 新規契約を active として作成（#165, #167 双方の前提）
- `createPlot` / `createPlotContract` は `contract_status` を未設定で作成しており schema default の **vacant** になっていた
- これだと上記フィルタで新規実契約が在庫面積に計上されず、#167 で台帳からも消える
- `ContractStatus.active` を明示して整合させた

> 3 は 1・2 の前提となる潜在バグ修正。3 がないと 1（新規契約が台帳から消える）・2（新規契約が面積計算から漏れる）が成立しないため同一PRに同梱。

## テスト
- `npm test -- tests/plots` 214 passed（15 suites）
- `npm test -- tests/utils/inventoryUtils.test.ts` green（vacant除外・active限定集計の検証を追加）
- getPlots に vacant 除外検証（一覧・件数）を追加
- lint 0 errors

## スコープ外
- 既存 2,701件の status バックフィル（現状 status は正しいため不要だが要観察）
- inventoryService の contractedArea 按分を active に揃えるか（読み取り経路は status 起点で available には影響なし。別途検討）
- 一覧への契約ステータス列/バッジ追加（UX強化・別issue）

Closes #167
Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
