### PR TITLE
fix(staff): Supabaseユーザーのorphan化防止＋再登録時の文言改善 (#173, #174)

### DIFF
--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -34,6 +34,12 @@ export interface CreateUserResult {
   success: boolean;
   user?: User;
   error?: string;
+  /**
+   * エラーの機械可読な種別。呼び出し側が文字列マッチに頼らず分岐できるようにする。
+   * - 'already_registered': 同一メールのSupabaseユーザーが既に存在する
+   * - 'rate_limit': 招待メール送信のレート制限
+   */
+  errorCode?: 'already_registered' | 'rate_limit';
 }
 
 /**
@@ -83,15 +89,19 @@ export const createSupabaseUser = async (
     if (error) {
       // よくあるエラーの日本語化
       let errorMessage = error.message;
+      let errorCode: CreateUserResult['errorCode'];
       if (error.message.includes('already registered')) {
         errorMessage = 'このメールアドレスは既にSupabaseに登録されています';
+        errorCode = 'already_registered';
       } else if (error.message.includes('rate limit')) {
         errorMessage = '招待メールの送信制限に達しました。しばらく待ってから再試行してください';
+        errorCode = 'rate_limit';
       }
 
       return {
         success: false,
         error: errorMessage,
+        errorCode,
       };
     }
 

--- a/src/staff/staffController.ts
+++ b/src/staff/staffController.ts
@@ -186,6 +186,24 @@ export const createStaff = async (
       );
 
       if (!supabaseResult.success || !supabaseResult.user) {
+        // #174: Supabase に同一メールのユーザーが残存しているケース。
+        // 重複チェック（deleted_at: null）は通過しているため、CRM上にアクティブな
+        // スタッフは存在しない。論理削除済みスタッフの有無で対処可能な文言に振り分ける。
+        if (supabaseResult.errorCode === 'already_registered') {
+          const softDeletedStaff = await prisma.staff.findFirst({
+            where: { email: normalizedEmail, deleted_at: { not: null } },
+          });
+          if (softDeletedStaff) {
+            throw new ConflictError(
+              'このメールアドレスは過去に削除されたスタッフで使用されており、認証基盤(Supabase)側にアカウントが残存しています。' +
+                '管理者に認証基盤側の残存アカウント削除を依頼してから再登録してください。'
+            );
+          }
+          throw new ConflictError(
+            'このメールアドレスは認証基盤(Supabase)側に既に登録されています。' +
+              'CRM上に該当スタッフが存在しない場合は、認証基盤側に残存しているアカウントの確認・削除が必要です。'
+          );
+        }
         throw new ConflictError(supabaseResult.error || 'Supabaseアカウントの作成に失敗しました');
       }
 
@@ -197,15 +215,48 @@ export const createStaff = async (
     }
 
     // スタッフ作成
-    const newStaff = await prisma.staff.create({
-      data: {
-        name: name.trim(),
-        email: normalizedEmail,
-        role: role as StaffRole,
-        supabase_uid: supabaseUid,
-        is_active: true,
-      },
-    });
+    // #173: Supabaseユーザー作成（=招待メール送信）後に staff.create が失敗すると
+    // 招待メールだけ飛んでDBレコードが無い orphan アカウントが残る。
+    // DB作成失敗時は作成済みSupabaseユーザーを補償削除（best-effort）してから再スロー。
+    let newStaff;
+    try {
+      newStaff = await prisma.staff.create({
+        data: {
+          name: name.trim(),
+          email: normalizedEmail,
+          role: role as StaffRole,
+          supabase_uid: supabaseUid,
+          is_active: true,
+        },
+      });
+    } catch (createError) {
+      if (invitationSent && !supabaseUid.startsWith('pending_')) {
+        try {
+          const cleanup = await deleteSupabaseUser(supabaseUid);
+          if (!cleanup.success) {
+            getRequestLogger().warn(
+              { email: normalizedEmail, supabaseUid, error: cleanup.error },
+              'staff.create 失敗後のSupabaseユーザー補償削除に失敗（orphanの可能性）'
+            );
+          } else {
+            getRequestLogger().warn(
+              { email: normalizedEmail, supabaseUid },
+              'staff.create 失敗のためSupabaseユーザーを補償削除した'
+            );
+          }
+        } catch (cleanupError) {
+          getRequestLogger().warn(
+            {
+              email: normalizedEmail,
+              supabaseUid,
+              error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            },
+            'staff.create 失敗後のSupabaseユーザー補償削除で例外（orphanの可能性）'
+          );
+        }
+      }
+      throw createError;
+    }
 
     const response: StaffDetail = {
       id: newStaff.id,

--- a/tests/staff/staffController.test.ts
+++ b/tests/staff/staffController.test.ts
@@ -251,6 +251,83 @@ describe('Staff Controller', () => {
         const error = (mockNext as jest.Mock).mock.calls[0][0];
         expect(error.message).toContain('Supabase');
       });
+
+      it('staff.create が失敗した場合、作成済みSupabaseユーザーを補償削除して再スローする (#173)', async () => {
+        mockRequest.body = {
+          name: 'Orphan Risk',
+          email: 'orphan@example.com',
+          role: 'viewer',
+        };
+
+        mockPrisma.staff.findFirst.mockResolvedValue(null);
+        mockSupabaseAdminAuth.inviteUserByEmail.mockResolvedValue({
+          data: { user: { id: 'orphan-uid' } },
+          error: null,
+        });
+        // DB作成が失敗
+        mockPrisma.staff.create.mockRejectedValue(new Error('DB write failed'));
+        mockSupabaseAdminAuth.deleteUser.mockResolvedValue({ error: null });
+
+        await createStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        // 作成済みSupabaseユーザーを補償削除している
+        expect(mockSupabaseAdminAuth.deleteUser).toHaveBeenCalledWith('orphan-uid');
+        // 元のDBエラーが伝播する
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toBe('DB write failed');
+      });
+
+      it('補償削除が失敗しても元のエラーを再スローする (#173)', async () => {
+        mockRequest.body = {
+          name: 'Orphan Risk',
+          email: 'orphan2@example.com',
+          role: 'viewer',
+        };
+
+        mockPrisma.staff.findFirst.mockResolvedValue(null);
+        mockSupabaseAdminAuth.inviteUserByEmail.mockResolvedValue({
+          data: { user: { id: 'orphan-uid-2' } },
+          error: null,
+        });
+        mockPrisma.staff.create.mockRejectedValue(new Error('DB write failed'));
+        // 補償削除も失敗
+        mockSupabaseAdminAuth.deleteUser.mockResolvedValue({
+          error: { message: 'delete failed' },
+        });
+
+        await createStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockSupabaseAdminAuth.deleteUser).toHaveBeenCalledWith('orphan-uid-2');
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toBe('DB write failed');
+      });
+
+      it('soft-delete済みスタッフのメールでSupabaseが残存する場合、対処可能なメッセージを返す (#174)', async () => {
+        mockRequest.body = {
+          name: 'Reuse',
+          email: 'deleted@example.com',
+          role: 'viewer',
+        };
+
+        // 1回目: 重複チェック（deleted_at: null）→ なし / 2回目: 論理削除済みチェック → あり
+        mockPrisma.staff.findFirst
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({ id: 9, email: 'deleted@example.com', deleted_at: new Date() });
+        mockSupabaseAdminAuth.inviteUserByEmail.mockResolvedValue({
+          data: { user: null },
+          error: { message: 'User already registered' },
+        });
+
+        await createStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('過去に削除されたスタッフ');
+        // DBレコードは作成しない
+        expect(mockPrisma.staff.create).not.toHaveBeenCalled();
+      });
     });
 
     describe('deleteStaff', () => {


### PR DESCRIPTION
staff ⇔ Supabase の整合性の穴を2点ふさぐ。両issueは同根のため1本にまとめた。

## #173 新規登録の部分失敗による orphan 化
`createStaff` は「Supabaseユーザー作成（=招待メール送信）」→「`prisma.staff.create`」の順で実行する。後者が失敗すると作成済みSupabaseユーザーを巻き戻さないため、招待メールだけ飛んでDBレコードが無い orphan アカウントが残っていた。

- `staff.create` を try/catch で囲み、失敗時に `deleteSupabaseUser(supabaseUid)` で補償削除（best-effort）してから再スロー
- 補償削除の成否は warn ログに記録。補償削除自体が失敗・例外でも元のDBエラーを優先して伝播
- `pending_` 仮UID / `skipSupabase` 経路は対象外（招待未送信のため）

## #174 soft-delete済みメールでの再登録が原因不明で失敗
論理削除済みスタッフと同じメールで再登録すると、重複チェック（`deleted_at: null`）は通過するが Supabase 側にユーザーが残存していると `already registered` で失敗する。従来は「このメールアドレスは既にSupabaseに登録されています」とだけ返り、CRM上に該当スタッフが見えない管理者には原因・対処が不明だった。

- `config/supabase.ts`: `CreateUserResult` に `errorCode`（`'already_registered' | 'rate_limit'`）を追加し、文字列マッチ依存を解消
- `createStaff`: `already_registered` 検出時に論理削除済みスタッフの有無を確認し、対処可能な文言に振り分け
  - 論理削除済みあり → 「過去に削除されたスタッフで使用されており、認証基盤(Supabase)側に残存。管理者に削除を依頼してから再登録」
  - なし → 「認証基盤側に残存しているアカウントの確認・削除が必要」

> 抜本対応（残存ユーザーの自動再利用＝option A）は認証基盤の状態変更を伴うため本PRでは扱わず、まず原因と対処が分かる文言（option B/最小）に留めた。

## テスト
- `npm test -- tests/staff/staffController.test.ts` 22 passed（補償削除 成功/失敗、再登録文言の3ケース追加）
- `npm test -- tests/staff/staffBulk.test.ts` 9 passed
- `npx tsc --noEmit` clean / lint 0 errors

Closes #173
Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
