### PR TITLE
fix(yucho): CSV実出力件数と口座未登録の除外件数を可視化 (#172)

### DIFF
--- a/src/validations/yuchoValidation.ts
+++ b/src/validations/yuchoValidation.ts
@@ -92,8 +92,16 @@ export interface YuchoBillingItem {
 }
 
 export interface YuchoBillingSummary {
+  /** 請求対象の総件数（口座未登録を含む） */
   totalCount: number;
+  /** 請求対象の総額（口座未登録を含む） */
   totalAmount: number;
+  /** 実際にCSV（振替ファイル）へ出力される件数（口座登録あり・金額>0）。CSVのデータ行数と一致する */
+  exportableCount: number;
+  /** 実際にCSVへ出力される金額の合計。CSVトレーラーの合計金額と一致する */
+  exportableAmount: number;
+  /** 口座未登録のため振替ファイルから除外される件数（請求漏れ検知用） */
+  excludedNoAccountCount: number;
   byCategory: {
     management: { count: number; amount: number };
     collective: { count: number; amount: number };

--- a/src/yucho/yuchoCsv.ts
+++ b/src/yucho/yuchoCsv.ts
@@ -315,6 +315,15 @@ interface BuildCsvParams {
 }
 
 /**
+ * CSV（振替ファイル）のデータ行として出力可能な請求項目かどうか。
+ * 口座情報（billingInfo）があり、かつ請求金額が正であること。
+ * 件数表示の整合性のため、この判定を CSV 生成（buildZenginCsv）と
+ * 集計（yuchoService の summary）で共用する。これが実出力件数の唯一の基準となる。
+ */
+export const isExportableBillingItem = (item: YuchoBillingItem): boolean =>
+  Boolean(item.billingInfo) && item.billingAmount > 0;
+
+/**
  * 全銀協フォーマットの完全な CSV (固定長レコード) を生成する。
  * 出力例:
  *   1{ヘッダー...}\r\n
@@ -324,7 +333,7 @@ interface BuildCsvParams {
  *   9{エンド...}\r\n
  */
 export const buildZenginCsv = ({ header, items }: BuildCsvParams): string => {
-  const billable = items.filter((i) => i.billingInfo && i.billingAmount > 0);
+  const billable = items.filter(isExportableBillingItem);
   const totalAmount = billable.reduce((sum, i) => sum + i.billingAmount, 0);
 
   const lines = [

--- a/src/yucho/yuchoService.ts
+++ b/src/yucho/yuchoService.ts
@@ -8,6 +8,7 @@
 import { PaymentStatus } from '@prisma/client';
 import prisma from '../db/prisma';
 import type { YuchoBillingItem, YuchoBillingResponse } from '../validations/yuchoValidation';
+import { isExportableBillingItem } from './yuchoCsv';
 
 interface FetchParams {
   year: number;
@@ -249,9 +250,19 @@ export const fetchYuchoBillingData = async (params: FetchParams): Promise<YuchoB
   // 区画番号順でソート
   items.sort((a, b) => a.plotNumber.localeCompare(b.plotNumber));
 
+  // CSV（振替ファイル）へ実際に出力される項目と、口座未登録で除外される項目を分離。
+  // exportableCount は buildZenginCsv のデータ行数と一致する（同一 predicate を共用）。
+  const exportableItems = items.filter(isExportableBillingItem);
+  const excludedNoAccountCount = items.filter(
+    (i) => i.billingAmount > 0 && !isExportableBillingItem(i)
+  ).length;
+
   const summary = {
     totalCount: items.length,
     totalAmount: items.reduce((sum, i) => sum + i.billingAmount, 0),
+    exportableCount: exportableItems.length,
+    exportableAmount: exportableItems.reduce((sum, i) => sum + i.billingAmount, 0),
+    excludedNoAccountCount,
     byCategory: {
       management: {
         count: items.filter((i) => i.category === 'management').length,

--- a/tests/yucho/yuchoController.test.ts
+++ b/tests/yucho/yuchoController.test.ts
@@ -125,6 +125,63 @@ describe('yuchoController', () => {
       expect(payload.data.summary.totalAmount).toBe(62000);
       expect(payload.data.summary.byCategory.management.amount).toBe(12000);
       expect(payload.data.summary.byCategory.collective.amount).toBe(50000);
+      // 両件とも口座登録あり → 全件 exportable・除外0（#172）
+      expect(payload.data.summary.exportableCount).toBe(2);
+      expect(payload.data.summary.exportableAmount).toBe(62000);
+      expect(payload.data.summary.excludedNoAccountCount).toBe(0);
+    });
+
+    it('口座未登録の請求は exportable から除外され excludedNoAccountCount に計上される (#172)', async () => {
+      // 口座あり（出力対象）
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'fee-1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '12000',
+          contractPlot: buildContractPlot(),
+        },
+        // 口座未登録（bank/branch/account がすべて null）→ 振替ファイルから無言除外される対象
+        {
+          id: 'fee-2',
+          contract_plot_id: 'cp-3',
+          billing_month: '4',
+          management_fee: '8000',
+          contractPlot: buildContractPlot({
+            id: 'cp-3',
+            physicalPlot: { id: 'pp-3', plot_number: 'C-3', area_name: '第1期' },
+            saleContractRoles: [
+              {
+                role: 'contractor',
+                customer: {
+                  id: 'cust-3',
+                  name: '佐藤花子',
+                  name_kana: 'サトウハナコ',
+                  bank_name: null,
+                  branch_name: null,
+                  account_type: null,
+                  account_number: null,
+                  account_holder: null,
+                },
+              },
+            ],
+          }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      // 一覧（totalCount）は除外前の全件
+      expect(payload.data.summary.totalCount).toBe(2);
+      expect(payload.data.summary.totalAmount).toBe(20000);
+      // 実際にCSVへ出力されるのは口座ありの1件のみ
+      expect(payload.data.summary.exportableCount).toBe(1);
+      expect(payload.data.summary.exportableAmount).toBe(12000);
+      // 口座未登録の1件は除外として可視化
+      expect(payload.data.summary.excludedNoAccountCount).toBe(1);
     });
 
     it('filters out management fees whose billing_month does not match', async () => {


### PR DESCRIPTION
## 概要
口座未登録の請求対象が振替ファイル（CSV）から**無言で除外**される一方、画面の件数表示は除外前の全件を出すため、実出力件数と表示が一致せず**請求漏れに気づけない**問題に対応する。業務ルールは変えず、表示の正確化と除外の可視化のみ（issueスコープの「業務確認不要」範囲）。

## 変更内容（backend）
- `YuchoBillingSummary` に集計を追加
  - `exportableCount` … 実際にCSVへ出力される件数（口座登録あり・金額>0）。**CSVデータ行数と一致**
  - `exportableAmount` … 同金額合計。**CSVトレーラー合計と一致**
  - `excludedNoAccountCount` … 口座未登録で除外される件数（請求漏れ検知用）
- CSV出力可否の判定を `isExportableBillingItem` に切り出し、`buildZenginCsv`（実出力）と `yuchoService` の summary（表示）で**共用**。これにより表示件数と実出力件数のドリフトを構造的に防止
- `totalCount`（除外前）は従来どおり保持し、`exportable`/`excluded` と並存

## フロント連携
フロントは `/yucho/billing` の `summary.exportableCount` / `excludedNoAccountCount` を使って「全N件中M件出力／口座未登録K件は除外」を表示し、`exportableCount === 0` でダウンロードを無効化できる。フロント側対応は別PR（frontend）で実施。

## テスト
- `npm test -- tests/yucho` 44 passed
- 口座未登録1件を含むケースで `exportableCount=1 / excludedNoAccountCount=1 / totalCount=2` を検証
- `npx tsc --noEmit` clean / lint 0 errors

## スコープ外（業務確認要・別途）
- 口座未登録者への代替請求手段（紙請求書・督促フロー等）

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
