### PR TITLE
chore(lint): no-unsafe 警告削減 第1弾 — masters/collective-burials (Refs #142)

### DIFF
--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -7,6 +7,30 @@ import { BillingStatus } from '@prisma/client';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
 import prisma from '../db/prisma';
 
+/** リクエストボディの型（Express の req.body は any のため、境界で明示的に型付けする） */
+interface CreateCollectiveBurialBody {
+  contractPlotId?: string;
+  burialCapacity?: number;
+  validityPeriodYears?: number;
+  billingAmount?: number | null;
+  notes?: string | null;
+}
+
+interface UpdateCollectiveBurialBody {
+  burialCapacity?: number;
+  validityPeriodYears?: number;
+  capacityReachedDate?: string | null;
+  billingScheduledDate?: string | null;
+  billingStatus?: string;
+  billingAmount?: number | null;
+  notes?: string | null;
+}
+
+interface UpdateBillingStatusBody {
+  billingStatus?: BillingStatus;
+  billingAmount?: number;
+}
+
 /**
  * 合祀一覧取得
  */
@@ -260,7 +284,8 @@ export const createCollectiveBurial = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    const { contractPlotId, burialCapacity, validityPeriodYears, billingAmount, notes } = req.body;
+    const { contractPlotId, burialCapacity, validityPeriodYears, billingAmount, notes } =
+      req.body as CreateCollectiveBurialBody;
 
     // バリデーション
     if (!contractPlotId) {
@@ -341,7 +366,7 @@ export const updateCollectiveBurial = async (
       billingStatus,
       billingAmount,
       notes,
-    } = req.body;
+    } = req.body as UpdateCollectiveBurialBody;
 
     // 存在確認
     const existing = await prisma.collectiveBurial.findFirst({
@@ -428,7 +453,7 @@ export const updateBillingStatus = async (
 ): Promise<void> => {
   try {
     const { id } = req.params as Record<string, string>;
-    const { billingStatus, billingAmount } = req.body;
+    const { billingStatus, billingAmount } = req.body as UpdateBillingStatusBody;
 
     // バリデーション
     if (!billingStatus || !['pending', 'billed', 'paid'].includes(billingStatus)) {

--- a/src/collective-burials/utils.ts
+++ b/src/collective-burials/utils.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma, CollectiveBurial } from '@prisma/client';
 
 /**
  * 請求予定日を計算
@@ -22,9 +22,9 @@ export const calculateBillingScheduledDate = (
  * @returns 更新された合祀情報（存在しない場合はnull）
  */
 export const updateCollectiveBurialCount = async (
-  prisma: PrismaClient | any, // トランザクション内のprismaも受け入れる
+  prisma: PrismaClient | Prisma.TransactionClient, // トランザクション内のprismaも受け入れる
   plotId: string
-): Promise<any | null> => {
+): Promise<CollectiveBurial | null> => {
   // 1. 合祀情報を取得
   const collectiveBurial = await prisma.collectiveBurial.findUnique({
     where: { contract_plot_id: plotId },
@@ -46,7 +46,7 @@ export const updateCollectiveBurialCount = async (
   const capacityReached = currentCount >= collectiveBurial.burial_capacity;
   const wasCapacityReached = collectiveBurial.capacity_reached_date !== null;
 
-  const updateData: any = {
+  const updateData: Prisma.CollectiveBurialUpdateInput = {
     current_burial_count: currentCount,
   };
 
@@ -96,7 +96,7 @@ export const isCapacityReached = async (prisma: PrismaClient, plotId: string): P
  * @param prisma Prismaクライアント
  * @returns 請求対象の合祀情報リスト
  */
-export const getBillingTargets = async (prisma: PrismaClient): Promise<any[]> => {
+export const getBillingTargets = async (prisma: PrismaClient) => {
   const today = new Date();
   today.setHours(0, 0, 0, 0); // 時刻を0:00:00に設定
 

--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -29,6 +29,40 @@ interface SectionNameMasterData extends MasterData {
 }
 
 /**
+ * マスタ CRUD で使う Prisma デリゲートの最小構造型。
+ * 各マスタの Prisma デリゲートは型が異なるため、共通して使う create/update/delete
+ * のみを構造的に表現し、`getMasterDelegate` で 1 箇所だけアサーションする。
+ */
+interface MasterRow {
+  id: number;
+  code: string;
+  name: string;
+  description: string | null;
+  sort_order: number | null;
+  is_active: boolean;
+  tax_rate?: { toString: () => string } | null;
+  period?: string | null;
+}
+
+interface MasterDelegate {
+  create: (args: { data: Record<string, unknown> }) => Promise<MasterRow>;
+  update: (args: { where: { id: number }; data: Record<string, unknown> }) => Promise<MasterRow>;
+  delete: (args: { where: { id: number } }) => Promise<MasterRow>;
+}
+
+/**
+ * エラーオブジェクト（Prisma など）から `code` を安全に取り出す。
+ * `catch (error: unknown)` を維持したまま P2002 / P2025 判定を行うためのヘルパ。
+ */
+const getErrorCode = (error: unknown): string | undefined => {
+  if (error !== null && typeof error === 'object' && 'code' in error) {
+    const { code } = error as { code?: unknown };
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+};
+
+/**
  * 墓地タイプマスタ取得
  * GET /api/v1/masters/cemetery-type
  */
@@ -465,8 +499,8 @@ export const getPositionMaster = async (_req: Request, res: Response) => {
 /**
  * マスタタイプからPrismaモデルデリゲートを取得
  */
-const getMasterDelegate = (masterType: MasterType) => {
-  const delegateMap: Record<MasterType, any> = {
+const getMasterDelegate = (masterType: MasterType): MasterDelegate => {
+  const delegateMap: Record<MasterType, unknown> = {
     'cemetery-type': prisma.cemeteryTypeMaster,
     'payment-method': prisma.paymentMethodMaster,
     'tax-type': prisma.taxTypeMaster,
@@ -480,7 +514,7 @@ const getMasterDelegate = (masterType: MasterType) => {
     direction: prisma.directionMaster,
     position: prisma.positionMaster,
   };
-  return delegateMap[masterType];
+  return delegateMap[masterType] as MasterDelegate;
 };
 
 const masterTypeLabels: Record<MasterType, string> = {
@@ -542,23 +576,23 @@ export const createMaster = async (req: Request, res: Response): Promise<void> =
       rest.code = rest.name.substring(0, 20);
     }
 
-    const createData: any = {
+    const createData: Record<string, unknown> = {
       ...rest,
       sort_order: sortOrder ?? null,
       is_active: isActive ?? true,
     };
 
     if (masterType === 'tax-type' && taxRate !== undefined) {
-      createData.tax_rate = taxRate;
+      createData['tax_rate'] = taxRate;
     }
     if (masterType === 'section-name' && period !== undefined) {
-      createData.period = period;
+      createData['period'] = period;
     }
 
     const created = await delegate.create({ data: createData });
     const label = masterTypeLabels[masterType];
 
-    const formatted: any = {
+    const formatted: Record<string, unknown> = {
       id: created.id,
       code: created.code,
       name: created.name,
@@ -567,10 +601,10 @@ export const createMaster = async (req: Request, res: Response): Promise<void> =
       isActive: created.is_active,
     };
     if (masterType === 'tax-type' && 'tax_rate' in created) {
-      formatted.taxRate = created.tax_rate?.toString() || null;
+      formatted['taxRate'] = created.tax_rate?.toString() || null;
     }
     if (masterType === 'section-name' && 'period' in created) {
-      formatted.period = created.period;
+      formatted['period'] = created.period;
     }
 
     res.status(201).json({
@@ -578,10 +612,10 @@ export const createMaster = async (req: Request, res: Response): Promise<void> =
       data: formatted,
       message: `${label}マスタを作成しました`,
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     const label = masterTypeLabels[masterType];
 
-    if (error?.code === 'P2002') {
+    if (getErrorCode(error) === 'P2002') {
       res.status(409).json({
         success: false,
         error: {
@@ -657,14 +691,14 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
     const delegate = getMasterDelegate(masterType);
     const { taxRate, sortOrder, isActive, period, ...rest } = parsed.data;
 
-    const updateData: any = { ...rest };
-    if (sortOrder !== undefined) updateData.sort_order = sortOrder;
-    if (isActive !== undefined) updateData.is_active = isActive;
+    const updateData: Record<string, unknown> = { ...rest };
+    if (sortOrder !== undefined) updateData['sort_order'] = sortOrder;
+    if (isActive !== undefined) updateData['is_active'] = isActive;
     if (masterType === 'tax-type' && taxRate !== undefined) {
-      updateData.tax_rate = taxRate;
+      updateData['tax_rate'] = taxRate;
     }
     if (masterType === 'section-name' && period !== undefined) {
-      updateData.period = period;
+      updateData['period'] = period;
     }
 
     const updated = await delegate.update({
@@ -673,7 +707,7 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
     });
 
     const label = masterTypeLabels[masterType];
-    const formatted: any = {
+    const formatted: Record<string, unknown> = {
       id: updated.id,
       code: updated.code,
       name: updated.name,
@@ -682,10 +716,10 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
       isActive: updated.is_active,
     };
     if (masterType === 'tax-type' && 'tax_rate' in updated) {
-      formatted.taxRate = updated.tax_rate?.toString() || null;
+      formatted['taxRate'] = updated.tax_rate?.toString() || null;
     }
     if (masterType === 'section-name' && 'period' in updated) {
-      formatted.period = updated.period;
+      formatted['period'] = updated.period;
     }
 
     res.status(200).json({
@@ -693,10 +727,10 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
       data: formatted,
       message: `${label}マスタを更新しました`,
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     const label = masterTypeLabels[masterType];
 
-    if (error?.code === 'P2025') {
+    if (getErrorCode(error) === 'P2025') {
       res.status(404).json({
         success: false,
         error: {
@@ -708,7 +742,7 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
-    if (error?.code === 'P2002') {
+    if (getErrorCode(error) === 'P2002') {
       res.status(409).json({
         success: false,
         error: {
@@ -774,10 +808,10 @@ export const deleteMaster = async (req: Request, res: Response): Promise<void> =
       success: true,
       message: `${label}マスタを削除しました`,
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     const label = masterTypeLabels[masterType];
 
-    if (error?.code === 'P2025') {
+    if (getErrorCode(error) === 'P2025') {
       res.status(404).json({
         success: false,
         error: {


### PR DESCRIPTION
## 概要
型安全性の技術的負債（ESLint `@typescript-eslint/no-unsafe-*` / `no-explicit-any` 警告 **1,152件**, #142）の削減 **第1弾**。

全1,152件のうち **82%が plot 系コア6ファイルに集中**しており、そこはシステムの中核（区画ベース）でリグレッション影響が大きい。そのため本PRでは、**より低リスクで独立性の高い2モジュール（masters / collective-burials）を、型のみの変更（挙動不変）で完全クリーン化**する。残り（主に plot コア）は別PRで段階対応する（方針は #142 にコメント）。

## 変更（型のみ・ロジック不変）

### `src/masters/masterController.ts`（-72）
- **根本原因**: `getMasterDelegate` の戻り値が `Record<MasterType, any>` 由来の `any` で、`delegate.create()` → `created.x` → `formatted` まで `any` が連鎖していた
- 戻り型を、CRUD で使う `create`/`update`/`delete` のみを表す構造的 `MasterDelegate` 型に。源流の `any` を 1 箇所のアサーションに局所化
- `createData`/`updateData`/`formatted` を `Record<string, unknown>` に（`noPropertyAccessFromIndexSignature` 準拠でブラケット記法）
- `catch (error: any)` → `catch (error: unknown)` + `getErrorCode()` ヘルパで P2002/P2025 を安全に判定

### `src/collective-burials/utils.ts`（-25）
- `prisma: PrismaClient | any` → `PrismaClient | Prisma.TransactionClient`（`| any` が型を潰していた）
- 戻り値を `CollectiveBurial` 型に、`updateData` を `Prisma.CollectiveBurialUpdateInput` に

### `src/collective-burials/collectiveBurialController.ts`（-11）
- `req.body`（Express 上は `any`）由来の `no-unsafe-assignment` を、リクエストボディ型（`CreateCollectiveBurialBody` 等）を定義して**境界で明示キャスト**（既存の `req.params as Record<string, string>` と同じ方針）

## 結果
- **1,152 → 1,044 warnings**（0 errors）。masters / collective-burials モジュールは警告ゼロ
- **挙動変更なし**（型注釈・境界キャストのみ）

## 検証
- `npx tsc --noEmit` clean
- `eslint`（対象3ファイル）0 warnings
- **全テスト 51 suites / 897 tests pass**（masters 60 / collective-burials 5 を含む）

## スコープ外（#142 残課題）
- plot 系コア（contractService 333 / getPlotById 200 / createPlotContract 144 / customerService 104 / updatePlot 96）約 949件 — 中核ロジックのため、Prisma `GetPayload` 型の導入を含む慎重なレビュー前提で別PR対応
- `errorHandler.ts`（35）— エラーハンドリングの要のため別途

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)