### PR TITLE
chore(lint): no-unsafe 警告削減 第2弾 — middleware (Refs #142)

### DIFF
--- a/src/middleware/controllerLogger.ts
+++ b/src/middleware/controllerLogger.ts
@@ -42,12 +42,13 @@ export const withLogging = (
     const originalJson = res.json.bind(res);
     let logged = false;
 
-    res.json = function (body: any) {
+    res.json = function (body: unknown) {
       if (!logged) {
         logged = true;
         const duration = Date.now() - startTime;
         const status = res.statusCode;
-        const success = body?.success !== undefined ? body.success : status < 400;
+        const responseBody = body as { success?: boolean; error?: { code?: string } } | null;
+        const success = responseBody?.success !== undefined ? responseBody.success : status < 400;
 
         if (success) {
           log.info(
@@ -55,7 +56,7 @@ export const withLogging = (
             `[${module}] ${action} END`
           );
         } else {
-          const errorCode = body?.error?.code || 'UNKNOWN';
+          const errorCode = responseBody?.error?.code || 'UNKNOWN';
           log.warn(
             { module, action, status, duration, success: false, errorCode },
             `[${module}] ${action} END`
@@ -66,7 +67,7 @@ export const withLogging = (
     } as typeof res.json;
 
     // next()をラップしてエラーパッシングをキャプチャ
-    const wrappedNext: NextFunction = (err?: any) => {
+    const wrappedNext: NextFunction = (err?: unknown) => {
       if (err && !logged) {
         logged = true;
         const duration = Date.now() - startTime;

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -196,7 +196,7 @@ export const sanitizeInput = (req: Request, _res: Response, next: NextFunction) 
 /**
  * オブジェクト内の文字列を再帰的にサニタイゼーション
  */
-const sanitizeObject = (obj: any): any => {
+const sanitizeObject = (obj: unknown): unknown => {
   if (typeof obj === 'string') {
     return sanitizeString(obj);
   }
@@ -206,10 +206,11 @@ const sanitizeObject = (obj: any): any => {
   }
 
   if (obj !== null && typeof obj === 'object') {
-    const sanitized: any = {};
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        sanitized[key] = sanitizeObject(obj[key]);
+    const sanitized: Record<string, unknown> = {};
+    const source = obj as Record<string, unknown>;
+    for (const key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        sanitized[key] = sanitizeObject(source[key]);
       }
     }
     return sanitized;


### PR DESCRIPTION
## 概要
型安全性の技術的負債（ESLint `no-unsafe-*` / `no-explicit-any`, #142）削減の**第2弾**。第1弾（#180, masters/collective-burials, -108）に続き、インフラ系ミドルウェア2ファイルを**型のみの変更（挙動不変）**で警告ゼロにする。

## 変更（型のみ・ロジック不変）

### `src/middleware/controllerLogger.ts`（-7）
- `res.json` ラッパの `body: any` → `unknown` + 構造的キャスト（`{ success?; error?: { code? } }`）で `success` / `error.code` を参照
- `wrappedNext` の `err?: any` → `err?: unknown`

### `src/middleware/security.ts`（-9）
- `sanitizeObject` の `(obj: any): any` → `(obj: unknown): unknown`
- 再帰内の `sanitized` を `Record<string, unknown>` に、キーアクセスを型付き化
- **サニタイズのロジック・挙動は不変**

## 結果
- **1,044 → 1,028 warnings**（0 errors）
- 挙動変更なし

## 検証
- `npx tsc --noEmit` clean
- `eslint`（対象2ファイル）0
- **全 51 suites / 897 tests pass**

## 次ターゲット（#142 残）
`auth/authController.ts`（22, req.body 型付け）/ `middleware/auth.ts`（4）/ `plots/services/customerService.ts`（104）/ plot コア各controller。`req.body` 型付け・Prisma `GetPayload` 型導入が中心。auth・plot コアは中核ロジックのため要レビュー前提で1ファイルずつ。

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)