### PR TITLE
chore(lint): no-unsafe 警告を解消 第3弾 (Refs #142)

### DIFF
--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -75,7 +75,7 @@ export const login = async (req: Request, res: Response) => {
       });
     }
 
-    const { email, password } = req.body;
+    const { email, password } = req.body as { email?: string; password?: string };
 
     if (!email || !password) {
       return res.status(400).json({
@@ -213,7 +213,8 @@ export const logout = async (req: Request, res: Response) => {
     }
 
     // Cookieまたはヘッダーからトークンを取得
-    const cookieToken = req.cookies?.[ACCESS_TOKEN_COOKIE];
+    const cookies = req.cookies as Record<string, string | undefined> | undefined;
+    const cookieToken = cookies?.[ACCESS_TOKEN_COOKIE];
     const authHeader = req.headers.authorization;
     const headerToken = authHeader?.replace('Bearer ', '').trim();
     const token = cookieToken || headerToken;
@@ -333,8 +334,10 @@ export const refreshToken = async (req: Request, res: Response) => {
     }
 
     // Cookieまたはリクエストボディからリフレッシュトークンを取得
-    const cookieRefreshToken = req.cookies?.[REFRESH_TOKEN_COOKIE];
-    const bodyRefreshToken = req.body?.refresh_token;
+    const cookies = req.cookies as Record<string, string | undefined> | undefined;
+    const body = req.body as { refresh_token?: string } | undefined;
+    const cookieRefreshToken = cookies?.[REFRESH_TOKEN_COOKIE];
+    const bodyRefreshToken = body?.refresh_token;
     const refresh_token = cookieRefreshToken || bodyRefreshToken;
     const tokenSource = cookieRefreshToken ? 'cookie' : bodyRefreshToken ? 'body' : 'none';
 
@@ -429,7 +432,10 @@ export const changePassword = async (req: Request, res: Response) => {
       });
     }
 
-    const { currentPassword, newPassword } = req.body;
+    const { currentPassword, newPassword } = req.body as {
+      currentPassword?: string;
+      newPassword?: string;
+    };
 
     log.info({ staffId: req.user.id }, 'Auth: password change attempt');
 
@@ -550,7 +556,7 @@ export const updateProfile = async (req: Request, res: Response) => {
       });
     }
 
-    const { name, email } = req.body;
+    const { name, email } = req.body as { name?: string; email?: string };
 
     log.info(
       { staffId: req.user.id, hasName: name !== undefined, hasEmail: email !== undefined },
@@ -660,7 +666,7 @@ export const forgotPassword = async (req: Request, res: Response) => {
       });
     }
 
-    const { email } = req.body;
+    const { email } = req.body as { email: string };
 
     log.info({ email }, 'Auth: password reset request');
 
@@ -718,7 +724,7 @@ export const resetPassword = async (req: Request, res: Response) => {
       });
     }
 
-    const { code, newPassword } = req.body;
+    const { code, newPassword } = req.body as { code: string; newPassword: string };
 
     log.info('Auth: password reset attempt via code');
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -42,7 +42,8 @@ declare global {
  */
 const extractToken = (req: Request): string | null => {
   // 1. Cookieからトークンを取得（推奨）
-  const cookieToken = req.cookies?.[ACCESS_TOKEN_COOKIE];
+  const cookies = req.cookies as Record<string, string | undefined> | undefined;
+  const cookieToken = cookies?.[ACCESS_TOKEN_COOKIE];
   if (cookieToken) {
     return cookieToken;
   }
@@ -64,7 +65,7 @@ export const authenticate = async (
   req: Request,
   res: Response,
   next: NextFunction
-): Promise<any> => {
+): Promise<Response | void> => {
   const log = getRequestLogger();
 
   try {
@@ -210,7 +211,7 @@ export const optionalAuthenticate = async (
   req: Request,
   _res: Response,
   next: NextFunction
-): Promise<any> => {
+): Promise<void> => {
   try {
     if (!supabase) {
       return next();

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -4,10 +4,23 @@ import * as Sentry from '@sentry/node';
 import { getRequestLogger } from '../utils/logger';
 
 /**
+ * エラーハンドラーが参照するアプリケーションエラーの形状。
+ * Express のエラーは unknown で受け取り、この型に narrow してから扱う。
+ */
+interface HandledError {
+  name?: string;
+  message?: string;
+  status?: number;
+  code?: string;
+  details?: unknown[];
+}
+
+/**
  * グローバルエラーハンドラー
  * すべてのエラーをキャッチして統一されたレスポンス形式で返す
  */
-export const errorHandler = (error: any, req: Request, res: Response, _next: NextFunction) => {
+export const errorHandler = (error: unknown, req: Request, res: Response, _next: NextFunction) => {
+  const err: HandledError = typeof error === 'object' && error !== null ? error : {};
   const log = getRequestLogger();
   log.error(
     {
@@ -47,17 +60,17 @@ export const errorHandler = (error: any, req: Request, res: Response, _next: Nex
     });
 
     // エラータイプに応じたレベル設定
-    if (error.name === 'ValidationError' || error.name === 'NotFoundError') {
+    if (err.name === 'ValidationError' || err.name === 'NotFoundError') {
       scope.setLevel('warning');
-    } else if (error.status && error.status < 500) {
+    } else if (err.status && err.status < 500) {
       scope.setLevel('info');
     } else {
       scope.setLevel('error');
     }
 
     // エラーコードのタグ追加
-    if (error.code) {
-      scope.setTag('error_code', error.code);
+    if (err.code) {
+      scope.setTag('error_code', err.code);
     }
 
     // Prismaエラーコードのタグ追加
@@ -85,67 +98,67 @@ export const errorHandler = (error: any, req: Request, res: Response, _next: Nex
   }
 
   // カスタムエラーの処理
-  if (error.name === 'ValidationError') {
+  if (err.name === 'ValidationError') {
     return res.status(400).json({
       success: false,
       error: {
         code: 'VALIDATION_ERROR',
-        message: error.message || 'バリデーションエラーが発生しました',
-        details: error.details || [],
+        message: err.message || 'バリデーションエラーが発生しました',
+        details: err.details || [],
       },
     });
   }
 
-  if (error.name === 'UnauthorizedError') {
+  if (err.name === 'UnauthorizedError') {
     return res.status(401).json({
       success: false,
       error: {
         code: 'UNAUTHORIZED',
-        message: error.message || '認証が必要です',
+        message: err.message || '認証が必要です',
         details: [],
       },
     });
   }
 
-  if (error.name === 'ForbiddenError') {
+  if (err.name === 'ForbiddenError') {
     return res.status(403).json({
       success: false,
       error: {
         code: 'FORBIDDEN',
-        message: error.message || '権限が不足しています',
+        message: err.message || '権限が不足しています',
         details: [],
       },
     });
   }
 
-  if (error.name === 'NotFoundError') {
+  if (err.name === 'NotFoundError') {
     return res.status(404).json({
       success: false,
       error: {
         code: 'NOT_FOUND',
-        message: error.message || 'リソースが見つかりません',
+        message: err.message || 'リソースが見つかりません',
         details: [],
       },
     });
   }
 
-  if (error.name === 'ConflictError') {
+  if (err.name === 'ConflictError') {
     return res.status(409).json({
       success: false,
       error: {
         code: 'CONFLICT',
-        message: error.message || '競合が発生しました',
-        details: error.details || [],
+        message: err.message || '競合が発生しました',
+        details: err.details || [],
       },
     });
   }
 
   // デフォルトのエラーレスポンス
-  return res.status(error.status || 500).json({
+  return res.status(err.status || 500).json({
     success: false,
     error: {
-      code: error.code || 'INTERNAL_SERVER_ERROR',
-      message: error.message || '内部サーバーエラーが発生しました',
+      code: err.code || 'INTERNAL_SERVER_ERROR',
+      message: err.message || '内部サーバーエラーが発生しました',
       details: [],
     },
   });
@@ -288,9 +301,9 @@ export const notFoundHandler = (req: Request, res: Response) => {
  * カスタムエラークラス
  */
 export class ValidationError extends Error {
-  details: any[];
+  details: unknown[];
 
-  constructor(message: string, details: any[] = []) {
+  constructor(message: string, details: unknown[] = []) {
     super(message);
     this.name = 'ValidationError';
     this.details = details;
@@ -319,9 +332,9 @@ export class NotFoundError extends Error {
 }
 
 export class ConflictError extends Error {
-  details: any[];
+  details: unknown[];
 
-  constructor(message: string, details: any[] = []) {
+  constructor(message: string, details: unknown[] = []) {
     super(message);
     this.name = 'ConflictError';
     this.details = details;

--- a/src/middleware/permission.ts
+++ b/src/middleware/permission.ts
@@ -128,7 +128,7 @@ export const API_PERMISSIONS: Record<string, Role[]> = {
  * 特定の権限レベルが必要な操作をチェック
  */
 export const requirePermission = (requiredRoles: Role[]) => {
-  return (req: Request, res: Response, next: NextFunction): any => {
+  return (req: Request, res: Response, next: NextFunction): Response | void => {
     if (!req.user) {
       return res.status(401).json({
         success: false,
@@ -182,7 +182,8 @@ export const checkApiPermission = () => {
     }
 
     const method = req.method;
-    const path = req.route?.path || req.path;
+    const route = req.route as { path?: string } | undefined;
+    const path = route?.path || req.path;
     const apiKey = `${method} ${path}`;
 
     // パスパラメータをワイルドカードに変換

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -78,7 +78,7 @@ export async function createPlotCore(
 
   // 2. 契約面積の妥当性検証
   const validationResult = await validateContractArea(
-    tx as any,
+    tx,
     physicalPlot.id,
     input.contractPlot.contractAreaSqm
   );
@@ -308,7 +308,7 @@ export async function createPlotCore(
   }
 
   // 10. 物理区画のステータス更新
-  await updatePhysicalPlotStatus(tx as any, physicalPlot.id);
+  await updatePhysicalPlotStatus(tx, physicalPlot.id);
 
   // 11. 履歴の自動記録
   if (!input.physicalPlot.id) {
@@ -417,7 +417,7 @@ export const createPlot = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    const input: CreatePlotRequest = req.body;
+    const input = req.body as CreatePlotRequest;
 
     const result = await prisma.$transaction(async (tx) => {
       return createPlotCore(tx, input, req);

--- a/src/plots/controllers/deletePlot.ts
+++ b/src/plots/controllers/deletePlot.ts
@@ -167,7 +167,7 @@ export const deletePlot = async (
       }
 
       // 7. PhysicalPlotのステータスを更新
-      await updatePhysicalPlotStatus(tx as any, physicalPlotId);
+      await updatePhysicalPlotStatus(tx, physicalPlotId);
     });
 
     res.status(200).json({

--- a/src/plots/controllers/getPlotContracts.ts
+++ b/src/plots/controllers/getPlotContracts.ts
@@ -13,7 +13,7 @@ import { getRequestLogger } from '../../utils/logger';
  * 物理区画の契約一覧取得
  * GET /plots/:id/contracts
  */
-export const getPlotContracts = async (req: Request, res: Response): Promise<any> => {
+export const getPlotContracts = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const { id } = req.params as Record<string, string>;
 

--- a/src/plots/controllers/getPlotHistory.ts
+++ b/src/plots/controllers/getPlotHistory.ts
@@ -6,6 +6,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
 import prisma from '../../db/prisma';
 import { NotFoundError } from '../../middleware/errorHandler';
 import { formatHistoryWithLabels } from '../services/historyLabels';
@@ -47,7 +48,7 @@ export const getPlotHistory = async (
     // physical_plot_id は分割販売時に他の契約区画と共有されるため、
     // PhysicalPlot 自体の履歴のみ physical_plot_id で拾い、
     // それ以外は contract_plot_id 一致に絞る（他契約への漏れ防止）。
-    const whereCondition: any = {
+    const whereCondition: Prisma.HistoryWhereInput = {
       OR: [
         { contract_plot_id: id },
         {

--- a/src/plots/controllers/getPlotInventory.ts
+++ b/src/plots/controllers/getPlotInventory.ts
@@ -13,7 +13,7 @@ import { getRequestLogger } from '../../utils/logger';
  * 物理区画の在庫状況取得
  * GET /plots/:id/inventory
  */
-export const getPlotInventory = async (req: Request, res: Response): Promise<any> => {
+export const getPlotInventory = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const { id } = req.params as Record<string, string>;
 

--- a/src/staff/staffController.ts
+++ b/src/staff/staffController.ts
@@ -139,7 +139,17 @@ export const createStaff = async (
   next: NextFunction
 ): Promise<void> => {
   try {
-    const { name, email, role = 'viewer', skipSupabase = false } = req.body;
+    const {
+      name,
+      email,
+      role = 'viewer',
+      skipSupabase = false,
+    } = req.body as {
+      name?: string;
+      email?: string;
+      role?: string;
+      skipSupabase?: boolean;
+    };
 
     // バリデーション
     if (!name || !name.trim()) {
@@ -362,7 +372,12 @@ export const updateStaff = async (
       throw new NotFoundError('スタッフが見つかりません');
     }
 
-    const { name, email, role, isActive } = req.body;
+    const { name, email, role, isActive } = req.body as {
+      name?: string;
+      email?: string;
+      role?: string;
+      isActive?: boolean;
+    };
     const normalizedEmail = email ? email.trim().toLowerCase() : undefined;
 
     // メールアドレスの重複チェック


### PR DESCRIPTION
## 概要
`業務確認不要` ラベル issue #142（型安全性の技術的負債）の継続対応・第3弾。
middleware / auth / staff / plots 小コントローラを **型のみ** でクリーン化。挙動は一切変えていない。

## 変更内容
| ファイル | 対応 |
|---|---|
| `middleware/errorHandler.ts` | `error: any` → `unknown` 受け→`HandledError` へ narrow。`ValidationError`/`ConflictError` の `details: any[]` → `unknown[]` |
| `auth/authController.ts` | `req.body` / `req.cookies` を型付き destructure。ガードのある箇所は optional、ガード無し（Supabase へ直接渡す）箇所は必須型でアサートし**現挙動を維持** |
| `staff/staffController.ts` | createStaff / updateStaff の `req.body` を型付き destructure |
| `middleware/permission.ts` | ミドルウェア戻り値 `any` → `Response \| void`、`req.route` を型付け |
| `middleware/auth.ts` | `authenticate` 戻り値 `Promise<any>` → `Promise<Response \| void>`、`optionalAuthenticate` → `Promise<void>`、`req.cookies` 型付け |
| `plots/controllers/getPlotHistory.ts` | `whereCondition: any` → `Prisma.HistoryWhereInput` |
| `plots/controllers/createPlot.ts` | 不要な `tx as any` 除去（ヘルパーは `Prisma.TransactionClient` を受ける）、`req.body` を型アサート |
| `plots/controllers/deletePlot.ts` | 不要な `tx as any` 除去 |
| `plots/controllers/getPlotInventory.ts` / `getPlotContracts.ts` | 戻り値 `Promise<any>` → `Promise<Response \| void>` |

## 結果
- ESLint 警告 **1,029 → 921（108件減）** / 0 errors（累計 1,211 → 921）
- `tsc` ビルド通過
- 全 **868 テスト pass**（48 suites）

## スコープ外（別途対応が必要な潜在バグ）
型を付けると**コンパイルエラーになる＝現スキーマと不整合**な箇所が2件見つかった。no-unsafe の整形ではなく挙動修正を伴うため本PRから除外し、別issue化を推奨：
- `scripts/generate-collective-burial-invoices.ts` — `target.Plot?.Contractors?.[0]` / `target.billing_amount` を参照しているが、`getBillingTargets` の実際の返り値は `contractPlot` / `saleContractRoles.customer` 構造で `Plot`/`Contractors`/`billing_amount` は存在しない。`target: any` で握りつぶされており、契約者名が常に null になっている可能性。
- `prisma/scripts/migrate-contract-status.ts` — 存在しない `ContractStatus.cancelled` / `ContractStatus.suspended` を参照（現enumは `vacant`/`active`/`terminated`）。一回限りの移行スクリプト。

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)