### PR TITLE
chore(eslint): plot コア 3 コントローラを型付け（#142）

### DIFF
--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -7,6 +7,7 @@
 
 import { Request, Response } from 'express';
 import { Prisma, PaymentStatus, ContractRole, ContractStatus } from '@prisma/client';
+import { CreatePlotRequest } from '@komine/types';
 import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
 import { getRequestLogger } from '../../utils/logger';
@@ -15,10 +16,10 @@ import { getRequestLogger } from '../../utils/logger';
  * 物理区画に新規契約追加
  * POST /plots/:id/contracts
  */
-export const createPlotContract = async (req: Request, res: Response): Promise<any> => {
+export const createPlotContract = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const physicalPlotId = req.params['id'] as string;
-    const input = req.body;
+    const input = req.body as CreatePlotRequest;
 
     // PhysicalPlotの存在確認
     const physicalPlot = await prisma.physicalPlot.findUnique({
@@ -37,7 +38,7 @@ export const createPlotContract = async (req: Request, res: Response): Promise<a
 
     // 契約面積の検証
     const validationResult = await validateContractArea(
-      prisma as any,
+      prisma,
       physicalPlotId,
       input.contractPlot.contractAreaSqm
     );
@@ -144,7 +145,7 @@ export const createPlotContract = async (req: Request, res: Response): Promise<a
           data: {
             contract_plot_id: contractPlot.id, // sale_contract_id → contract_plot_idに変更
             customer_id: customer.id,
-            role: input.saleContract.customerRole || ContractRole.contractor,
+            role: (input.saleContract.customerRole as ContractRole) || ContractRole.contractor,
           },
         });
       }
@@ -203,7 +204,7 @@ export const createPlotContract = async (req: Request, res: Response): Promise<a
       }
 
       // PhysicalPlotのステータス更新
-      await updatePhysicalPlotStatus(tx as any, physicalPlotId);
+      await updatePhysicalPlotStatus(tx, physicalPlotId);
 
       return { contractPlot, customer };
     });

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -4,6 +4,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { History } from '@prisma/client';
 import prisma from '../../db/prisma';
 import { NotFoundError } from '../../middleware/errorHandler';
 import { formatHistoryWithLabels } from '../services/historyLabels';
@@ -66,7 +67,7 @@ export const getPlotById = async (
     // physical_plot_id で素朴に OR すると別契約の Customer / UsageFee 等の
     // 履歴まで漏れてしまう。PhysicalPlot 自体の履歴のみ physical_plot_id で
     // 拾い、それ以外は contract_plot_id 一致に絞る。
-    let histories: any[] = [];
+    let histories: History[] = [];
     if (includeHistory) {
       histories = await prisma.history.findMany({
         where: {
@@ -85,7 +86,11 @@ export const getPlotById = async (
       });
     }
 
-    const response: any = {
+    // 主契約者（role='contractor'）を取得（後方互換性のため）
+    const primaryRole = contractPlot.saleContractRoles?.find((role) => role.role === 'contractor');
+    const primaryCustomer = primaryRole?.customer;
+
+    const response = {
       // 契約区画基本情報
       id: contractPlot.id,
       contractAreaSqm: contractPlot.contract_area_sqm.toNumber(),
@@ -147,7 +152,7 @@ export const getPlotById = async (
         : null,
 
       // 埋葬者情報
-      buriedPersons: contractPlot.buriedPersons.map((person: any) => ({
+      buriedPersons: contractPlot.buriedPersons.map((person) => ({
         id: person.id,
         name: person.name,
         nameKana: person.name_kana,
@@ -164,7 +169,7 @@ export const getPlotById = async (
       })),
 
       // 家族連絡先情報
-      familyContacts: contractPlot.familyContacts.map((contact: any) => ({
+      familyContacts: contractPlot.familyContacts.map((contact) => ({
         id: contact.id,
         name: contact.name,
         nameKana: contact.name_kana,
@@ -204,7 +209,7 @@ export const getPlotById = async (
         : null,
 
       // 工事情報
-      constructionInfos: contractPlot.constructionInfos.map((construction: any) => ({
+      constructionInfos: contractPlot.constructionInfos.map((construction) => ({
         id: construction.id,
         constructionType: construction.construction_type,
         startDate: construction.start_date,
@@ -234,11 +239,11 @@ export const getPlotById = async (
         paymentAmount2: construction.payment_amount_2
           ? Number(construction.payment_amount_2)
           : null,
-        paymentScheduledDate2: construction.payment_scheduled_date_2,
+        paymentScheduledDate2: construction.payment_date_2,
         paymentStatus2: construction.payment_status_2,
         scheduledEndDate: construction.scheduled_end_date,
         constructionContent: construction.construction_content,
-        constructionNotes: construction.construction_notes,
+        constructionNotes: construction.notes,
       })),
 
       // 合祀情報
@@ -260,89 +265,84 @@ export const getPlotById = async (
 
       // 履歴情報（日本語ラベル付与）
       histories: includeHistory ? histories.map(formatHistoryWithLabels) : undefined,
-    };
 
-    // 主契約者（role='contractor'）を取得（後方互換性のため）
-    const primaryRole = contractPlot.saleContractRoles?.find(
-      (role: any) => role.role === 'contractor'
-    );
-    const primaryCustomer = primaryRole?.customer;
-
-    // 後方互換性のため、主契約者の情報を設定
-    if (primaryRole && primaryCustomer) {
-      response.primaryCustomer = {
-        id: primaryCustomer.id,
-        name: primaryCustomer.name,
-        nameKana: primaryCustomer.name_kana,
-        gender: primaryCustomer.gender,
-        birthDate: primaryCustomer.birth_date,
-        phoneNumber: primaryCustomer.phone_number,
-        faxNumber: primaryCustomer.fax_number,
-        email: primaryCustomer.email,
-        postalCode: primaryCustomer.postal_code,
-        address: primaryCustomer.address,
-        addressLine2: primaryCustomer.address_line_2,
-        registeredAddress: primaryCustomer.registered_address,
-        notes: primaryCustomer.notes,
-        role: primaryRole.role,
-        workInfo: primaryCustomer.workInfo
+      // 後方互換性のため、主契約者の情報を設定
+      primaryCustomer:
+        primaryRole && primaryCustomer
           ? {
-              companyName: primaryCustomer.workInfo.company_name,
-              companyNameKana: primaryCustomer.workInfo.company_name_kana,
-              workAddress: primaryCustomer.workInfo.work_address,
-              workPostalCode: primaryCustomer.workInfo.work_postal_code,
-              workPhoneNumber: primaryCustomer.workInfo.work_phone_number,
-              dmSetting: primaryCustomer.workInfo.dm_setting,
-              addressType: primaryCustomer.workInfo.address_type,
-              notes: primaryCustomer.workInfo.notes,
+              id: primaryCustomer.id,
+              name: primaryCustomer.name,
+              nameKana: primaryCustomer.name_kana,
+              gender: primaryCustomer.gender,
+              birthDate: primaryCustomer.birth_date,
+              phoneNumber: primaryCustomer.phone_number,
+              faxNumber: primaryCustomer.fax_number,
+              email: primaryCustomer.email,
+              postalCode: primaryCustomer.postal_code,
+              address: primaryCustomer.address,
+              addressLine2: primaryCustomer.address_line_2,
+              registeredAddress: primaryCustomer.registered_address,
+              notes: primaryCustomer.notes,
+              role: primaryRole.role,
+              workInfo: primaryCustomer.workInfo
+                ? {
+                    companyName: primaryCustomer.workInfo.company_name,
+                    companyNameKana: primaryCustomer.workInfo.company_name_kana,
+                    workAddress: primaryCustomer.workInfo.work_address,
+                    workPostalCode: primaryCustomer.workInfo.work_postal_code,
+                    workPhoneNumber: primaryCustomer.workInfo.work_phone_number,
+                    dmSetting: primaryCustomer.workInfo.dm_setting,
+                    addressType: primaryCustomer.workInfo.address_type,
+                    notes: primaryCustomer.workInfo.notes,
+                  }
+                : null,
             }
-          : null,
-      };
-    }
+          : undefined,
 
-    // 全ての役割と顧客情報を追加
-    response.roles =
-      contractPlot.saleContractRoles?.map((role: any) => ({
-        id: role.id,
-        role: role.role,
-        roleStartDate: role.role_start_date,
-        roleEndDate: role.role_end_date,
-        notes: role.notes,
-        customer: {
-          id: role.customer.id,
-          name: role.customer.name,
-          nameKana: role.customer.name_kana,
-          gender: role.customer.gender,
-          birthDate: role.customer.birth_date,
-          phoneNumber: role.customer.phone_number,
-          faxNumber: role.customer.fax_number,
-          email: role.customer.email,
-          postalCode: role.customer.postal_code,
-          address: role.customer.address,
-          addressLine2: role.customer.address_line_2,
-          registeredPostalCode: role.customer.registered_postal_code,
-          registeredAddress: role.customer.registered_address,
-          // 振込先情報（ゆうちょ自動払込 CSV 出力用、レガシー t_danka.kikan_name 系から移行）
-          bankName: role.customer.bank_name,
-          branchName: role.customer.branch_name,
-          accountType: role.customer.account_type,
-          accountNumber: role.customer.account_number,
-          accountHolder: role.customer.account_holder,
-          notes: role.customer.notes,
-          workInfo: role.customer.workInfo
-            ? {
-                companyName: role.customer.workInfo.company_name,
-                companyNameKana: role.customer.workInfo.company_name_kana,
-                workAddress: role.customer.workInfo.work_address,
-                workPostalCode: role.customer.workInfo.work_postal_code,
-                workPhoneNumber: role.customer.workInfo.work_phone_number,
-                dmSetting: role.customer.workInfo.dm_setting,
-                addressType: role.customer.workInfo.address_type,
-                notes: role.customer.workInfo.notes,
-              }
-            : null,
-        },
-      })) || [];
+      // 全ての役割と顧客情報
+      roles:
+        contractPlot.saleContractRoles?.map((role) => ({
+          id: role.id,
+          role: role.role,
+          roleStartDate: role.role_start_date,
+          roleEndDate: role.role_end_date,
+          notes: role.notes,
+          customer: {
+            id: role.customer.id,
+            name: role.customer.name,
+            nameKana: role.customer.name_kana,
+            gender: role.customer.gender,
+            birthDate: role.customer.birth_date,
+            phoneNumber: role.customer.phone_number,
+            faxNumber: role.customer.fax_number,
+            email: role.customer.email,
+            postalCode: role.customer.postal_code,
+            address: role.customer.address,
+            addressLine2: role.customer.address_line_2,
+            registeredPostalCode: role.customer.registered_postal_code,
+            registeredAddress: role.customer.registered_address,
+            // 振込先情報（ゆうちょ自動払込 CSV 出力用、レガシー t_danka.kikan_name 系から移行）
+            bankName: role.customer.bank_name,
+            branchName: role.customer.branch_name,
+            accountType: role.customer.account_type,
+            accountNumber: role.customer.account_number,
+            accountHolder: role.customer.account_holder,
+            notes: role.customer.notes,
+            workInfo: role.customer.workInfo
+              ? {
+                  companyName: role.customer.workInfo.company_name,
+                  companyNameKana: role.customer.workInfo.company_name_kana,
+                  workAddress: role.customer.workInfo.work_address,
+                  workPostalCode: role.customer.workInfo.work_postal_code,
+                  workPhoneNumber: role.customer.workInfo.work_phone_number,
+                  dmSetting: role.customer.workInfo.dm_setting,
+                  addressType: role.customer.workInfo.address_type,
+                  notes: role.customer.workInfo.notes,
+                }
+              : null,
+          },
+        })) || [],
+    };
 
     res.status(200).json({
       success: true,

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -107,7 +107,7 @@ export async function updatePlotCore(
   }
 
   // 2. ContractPlotの更新
-  const updateData: any = {};
+  const updateData: Prisma.ContractPlotUpdateInput = {};
 
   if (input.contractPlot) {
     if (input.contractPlot.contractAreaSqm !== undefined) {
@@ -188,7 +188,8 @@ export async function updatePlotCore(
         : null;
     }
     if (input.saleContract.uncollectedAmount !== undefined) {
-      updateData.uncollected_amount = input.saleContract.uncollectedAmount;
+      // uncollected_amount は非 null（schema default 0）。null は create と同様 0 にフォールバック。
+      updateData.uncollected_amount = input.saleContract.uncollectedAmount ?? 0;
     }
     if (input.saleContract.notes !== undefined) {
       updateData.notes = input.saleContract.notes;
@@ -279,12 +280,12 @@ export async function updatePlotCore(
   // 4. Customerの更新
   if (input.customer) {
     const primaryRole = existingContractPlot.saleContractRoles?.find(
-      (role: any) => role.role === 'contractor'
+      (role) => role.role === 'contractor'
     );
     const customerId = primaryRole?.customer.id;
 
     if (customerId) {
-      const customerUpdateData: any = {};
+      const customerUpdateData: Prisma.CustomerUpdateInput = {};
 
       if (input.customer.name !== undefined) customerUpdateData.name = input.customer.name;
       if (input.customer.nameKana !== undefined)
@@ -354,7 +355,7 @@ export async function updatePlotCore(
             });
           }
         } else {
-          const workInfoData: any = {};
+          const workInfoData: Partial<Prisma.WorkInfoUncheckedCreateInput> = {};
           if (input.workInfo.companyName !== undefined)
             workInfoData.company_name = input.workInfo.companyName;
           if (input.workInfo.companyNameKana !== undefined)
@@ -406,10 +407,13 @@ export async function updatePlotCore(
               });
             } else {
               const created = await tx.workInfo.create({
+                // workInfoData は update/create 兼用の Partial。create が要求する必須スカラ
+                // （company_name 等）は UpdatePlotRequest 側で任意のため型上は欠落しうるが、
+                // 旧 any 実装と同じ実行時挙動を維持する。
                 data: {
-                  customer_id: customerId,
                   ...workInfoData,
-                },
+                  customer_id: customerId,
+                } as Prisma.WorkInfoUncheckedCreateInput,
               });
               await recordEntityCreated(tx, {
                 entityType: 'WorkInfo',
@@ -463,7 +467,7 @@ export async function updatePlotCore(
     } else if (existingApplicantRole) {
       // 既存の applicant Customer を部分更新
       const applicantCustomerId = existingApplicantRole.customer.id;
-      const applicantUpdateData: any = {};
+      const applicantUpdateData: Prisma.CustomerUpdateInput = {};
       if (input.applicant.name !== undefined) applicantUpdateData.name = input.applicant.name;
       if (input.applicant.nameKana !== undefined)
         applicantUpdateData.name_kana = input.applicant.nameKana;
@@ -579,7 +583,7 @@ export async function updatePlotCore(
         });
       }
     } else {
-      const usageFeeData: any = {};
+      const usageFeeData: Partial<Prisma.UsageFeeUncheckedCreateInput> = {};
       if (input.usageFee.calculationType !== undefined)
         usageFeeData.calculation_type = input.usageFee.calculationType;
       if (input.usageFee.taxType !== undefined) usageFeeData.tax_type = input.usageFee.taxType;
@@ -674,7 +678,7 @@ export async function updatePlotCore(
         });
       }
     } else {
-      const managementFeeData: any = {};
+      const managementFeeData: Partial<Prisma.ManagementFeeUncheckedCreateInput> = {};
       if (input.managementFee.calculationType !== undefined)
         managementFeeData.calculation_type = input.managementFee.calculationType;
       if (input.managementFee.taxType !== undefined)
@@ -1190,7 +1194,7 @@ export async function updatePlotCore(
         });
         const beforeSerialized: Record<string, unknown> = {};
         for (const key of Object.keys(ciData)) {
-          const v = (before as any)[key];
+          const v = (before as Record<string, unknown>)[key];
           beforeSerialized[key] = v instanceof Date ? v.toISOString() : v;
         }
         ciHistoryEntries.push({
@@ -1231,7 +1235,7 @@ export async function updatePlotCore(
     input.contractPlot?.contractAreaSqm !== undefined &&
     input.contractPlot.contractAreaSqm !== oldContractArea
   ) {
-    await updatePhysicalPlotStatus(tx as any, physicalPlotId);
+    await updatePhysicalPlotStatus(tx, physicalPlotId);
   }
 
   // 13. 履歴の自動記録（ContractPlot、Customer）
@@ -1280,7 +1284,7 @@ export async function updatePlotCore(
 
   if (input.customer) {
     const primaryRole = existingContractPlot.saleContractRoles?.find(
-      (role: any) => role.role === 'contractor'
+      (role) => role.role === 'contractor'
     );
     const existingCustomer = primaryRole?.customer;
 
@@ -1335,7 +1339,7 @@ export const updatePlot = async (
 ): Promise<void> => {
   try {
     const { id } = req.params as Record<string, string>;
-    const input: UpdatePlotRequest = req.body;
+    const input = req.body as UpdatePlotRequest;
 
     // 履歴記録の createMany バッチ化・不要な findUnique 削減（issue #66）で
     // クエリ数は線形増加から定数的な増加に抑制。暫定 30 秒から 10 秒に短縮。


### PR DESCRIPTION
**Refs #142**（部分対応・issue は open 維持）

backend 残り 440 件の `@typescript-eslint/no-unsafe-*` 警告（plot コア 3 コントローラに集中）を **440 → 0** に削減。これで backend 全体の eslint 警告も **0** になります（[[project_eslint_142_deadcode]] が指す残課題を完全解消）。

| ファイル | before | after |
|---|---|---|
| `src/plots/controllers/getPlotById.ts` | 200 | 0 |
| `src/plots/controllers/createPlotContract.ts` | 144 | 0 |
| `src/plots/controllers/updatePlot.ts` | 96 | 0 |
| **合計** | **440** | **0** |

## 方針

[[project_gyoumukakunin_fuyou_batch]] の歴代 #142 バッチ（PR #180/#182/#183/#187）と同じ「型のみ・挙動不変」原則で対応。`(param: any)` カスケードを源流から断ち、Prisma が既に提供している型・`@komine/types` の Request 型・`Prisma.XUpdateInput` を当てるだけで全警告が連鎖的に消えました。

## 主な変更

### `getPlotById.ts`（200 → 0）
- `histories: any[]` を `History[]` に
- `response: any` を廃止し、`primaryCustomer` / `roles` を後 mutation でなくオブジェクトリテラルにインライン化（兄弟 `createPlotContract.ts` のレスポンス組み立てと同じスタイル）
- `.map((x: any) => ...)` の `: any` を全除去 → `findUnique({ include })` の payload 型が自動で流れる

### `createPlotContract.ts`（144 → 0）
- `req.body` を `as CreatePlotRequest` でキャスト（`createPlot.ts` と完全同形）
- `customerRole` を `(... as ContractRole) || ContractRole.contractor` に（`createPlot.ts:228` のパターンに統一）
- `validateContractArea(prisma as any, ...)` と `updatePhysicalPlotStatus(tx as any, ...)` の不要な any キャスト除去（両関数は `Prisma.TransactionClient` 受け、`prisma`/`tx` とも代入可能）
- 戻り値型 `Promise<any>` → `Promise<Response | void>`

### `updatePlot.ts`（96 → 0）
6 つの蓄積オブジェクトを Prisma 入力型に型付け:

| 変数 | 用途 | 当てた型 |
|---|---|---|
| `updateData` | ContractPlot update のみ | `Prisma.ContractPlotUpdateInput` |
| `customerUpdateData` | Customer update のみ | `Prisma.CustomerUpdateInput` |
| `applicantUpdateData` | Customer update のみ | `Prisma.CustomerUpdateInput` |
| `workInfoData` | update + create 兼用（spread） | `Partial<Prisma.WorkInfoUncheckedCreateInput>` |
| `usageFeeData` | update + create 兼用 | `Partial<Prisma.UsageFeeUncheckedCreateInput>` |
| `managementFeeData` | update + create 兼用 | `Partial<Prisma.ManagementFeeUncheckedCreateInput>` |

その他:
- `(role: any) => ...` の 2 箇所と `(before as any)[key]`、`updatePhysicalPlotStatus(tx as any, ...)` を除去
- `const input: UpdatePlotRequest = req.body` → `as` キャスト化で unsafe-assignment 解消

### `updateData.uncollected_amount` の `?? 0` フォールバック追加

`uncollected_amount` は schema 上で **非 null Int**（default 0）。一方 `UpdatePlotRequest.saleContract.uncollectedAmount` は `number | null` のため、null が来ると Prisma update で失敗する潜在バグでした。
`createPlotContract` 側は `?? 0` で揃えており、今回 update 側も同じ扱いに揃えています。**正常値の挙動は完全に同一**、null 渡し時のみ「Prisma エラー → 0 でデフォルト」に変化（業務上 null 入力は想定外なので安全）。

### `workInfoData` の create 側 type assertion

`Partial<Prisma.WorkInfoUncheckedCreateInput>` は update 側には充分だが、create 側は `company_name` 等を required string で要求するため、create サイト 1 箇所のみ `as Prisma.WorkInfoUncheckedCreateInput` でアサート。`any` よりは遥かに型情報がある状態で、旧 `any` 実装と挙動同一。理由はコードコメントで明記済。

## 副次的に発見した潜在バグ（合わせて修正）

`getPlotById.ts` の `any` を外したことで、`ConstructionInfo` のレスポンス組み立てで存在しない schema フィールドを参照していた 2 箇所が tsc エラーで顕在化:

```diff
-        paymentScheduledDate2: construction.payment_scheduled_date_2,  // 存在しない
+        paymentScheduledDate2: construction.payment_date_2,            // schema 実体

-        constructionNotes: construction.construction_notes,            // 存在しない
+        constructionNotes: construction.notes,                          // schema 実体
```

`PlotDetailResponse` 契約（`@komine/types`）にはどちらも `paymentScheduledDate2: string | null` / `notes: string | null` として定義されておりフロントも参照していますが、現状この 2 フィールドは**常に `undefined`** を返していました。修正で実値が返るようになります。

過去 PR #186（[[project_gyoumukakunin_fuyou_batch]] 第 5 弾、#184/#185）で同様の latent bug を `any` 剥がしで顕在化させ修正した方針と同じ扱い。

> [!NOTE]
> レスポンスの該当 2 フィールドのみ「常に null/undefined」から「実値返却」に挙動変化。フロントエンドは元から両フィールドを参照する型契約のため、ユーザー視点は「データが正しく見えるようになる」改善方向です。

## 検証

- `npx tsc --noEmit`: ✅ clean
- `npm run lint`: ✅ 0 errors / 0 warnings（440 → 0）
- `npm test`: ✅ **841/841 pass**（全 45 スイート、テスト数も既存と同じ）

## 残課題

[[project_eslint_142_deadcode]] が示していた残 440 件はこの PR で完全解消。**backend の `no-unsafe-*` 警告は 0** になります。`#142` issue 自体は他の `@typescript-eslint/*` カテゴリの警告が残るかは未確認のため open 維持を推奨。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)