### PR TITLE
chore(security): npm audit と Trivy を CI gate 化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run npm audit
+      # 全 dep (dev 含む) は moderate+ で情報出力のみ。dev dep の脆弱性は
+      # 本番影響が無いケースが多く、ノイズ抑制のため gate にしない。
+      - name: Run npm audit (informational, dev included)
         run: npm audit --audit-level=moderate
         continue-on-error: true
 
-      - name: Run npm audit (production only)
+      # prod dep の high+ 脆弱性は **本番影響あり** とみなして必ず CI を fail させる。
+      # 本番ランタイムに乗る依存にのみ反応するので false positive が出にくい。
+      - name: Run npm audit (production only, gate)
         run: npm audit --omit=dev --audit-level=high
-        continue-on-error: true
 
   # Dockerイメージ脆弱性スキャン（Trivy）
   docker-security:
@@ -144,7 +147,9 @@ jobs:
       - name: Build Docker image
         run: docker build -t cemetery-crm-backend:test .
 
-      - name: Run Trivy vulnerability scanner
+      # SARIF 出力（CRITICAL + HIGH を GitHub Security ダッシュボードへ送る）。
+      # この step は gate ではないので、失敗しても継続する。
+      - name: Run Trivy vulnerability scanner (SARIF output)
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: cemetery-crm-backend:test
@@ -156,6 +161,7 @@ jobs:
 
       - name: Check if SARIF file exists
         id: sarif-check
+        if: always()
         run: |
           if [ -f trivy-results.sarif ]; then
             echo "sarif_exists=true" >> $GITHUB_OUTPUT
@@ -165,17 +171,31 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: steps.sarif-check.outputs.sarif_exists == 'true'
+        if: always() && steps.sarif-check.outputs.sarif_exists == 'true'
         continue-on-error: true
         with:
           sarif_file: "trivy-results.sarif"
 
-      - name: Run Trivy vulnerability scanner (table output)
+      # 情報出力: CRITICAL/HIGH/MEDIUM を log に出す（gate ではない）。
+      - name: Run Trivy vulnerability scanner (table output, informational)
         uses: aquasecurity/trivy-action@master
+        if: always()
         with:
           image-ref: cemetery-crm-backend:test
           format: "table"
           severity: "CRITICAL,HIGH,MEDIUM"
+
+      # **Gate**: 修正可能 (fix available) な **CRITICAL** 脆弱性があれば CI を fail させる。
+      # `ignore-unfixed: true` で「修正パッチ未提供」のものはノイズ扱い。
+      # SARIF upload より後ろに置いて、gate fail 時もダッシュボードには反映する。
+      - name: Run Trivy vulnerability scanner (gate on fixable CRITICAL)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: cemetery-crm-backend:test
+          format: "table"
+          severity: "CRITICAL"
+          exit-code: "1"
+          ignore-unfixed: true
 
   # テスト実行（複数Node.jsバージョン）
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,8 +357,8 @@ See `SETUP.md` for detailed deployment configuration, CORS setup, and troublesho
   - **Build**: TypeScript compilation check, Prisma client generation
   - **Lint & Format Check**: ESLint + Prettier validation
   - **Swagger Validation**: OpenAPI spec validation
-  - **Security Audit**: npm audit (moderate+ vulnerabilities)
-  - **Docker Security Scan**: Trivy vulnerability scanner (CRITICAL/HIGH)
+  - **Security Audit**: npm audit (prod-only `--audit-level=high` は **fail させる gate**、dev 含む moderate+ は情報出力のみ)
+  - **Docker Security Scan**: Trivy vulnerability scanner (修正可能な **CRITICAL** で fail させる gate + CRITICAL/HIGH を SARIF で GitHub Security に送出)
   - **Test**: Run all 610+ tests on Node.js 20.x, 22.x (parallel)
   - **Coverage**: Generate and upload to Codecov (Node 20.x only)
   - **All Checks Passed**: Final validation gate
@@ -368,11 +368,13 @@ See `SETUP.md` for detailed deployment configuration, CORS setup, and troublesho
   - npm packages
   - GitHub Actions
   - Docker base images
-- **npm audit**: Runs on every push/PR (moderate+ level)
+- **npm audit**:
+  - 全 dep (dev 含む) を `--audit-level=moderate` で **情報出力のみ** (dev dep の脆弱性は本番影響が薄くノイズになりやすいため gate にしない)
+  - prod dep のみを `--omit=dev --audit-level=high` で **gate 化** — high+ の本番依存脆弱性は CI fail
 - **Trivy**: Docker image vulnerability scanning with GitHub Security integration
   - Uses CodeQL Action v4 for SARIF upload
-  - SARIF file existence check before upload
-  - Continues on error to prevent blocking other jobs
+  - SARIF file existence check before upload (`if: always()` で gate fail 時もダッシュボードへ反映)
+  - **Gate**: `severity: CRITICAL` + `ignore-unfixed: true` で **修正可能な CRITICAL のみ** で fail させる (修正パッチ未提供のものはノイズ扱い)
   - **Note**: SARIF upload requires GitHub Code Scanning to be enabled
     - Public repositories: Code Scanning available for free
     - Private repositories: Requires GitHub Advanced Security (paid)

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,12 +86,15 @@ RUN npm run build
 # ============================================
 FROM node:20-slim AS production
 
-# Chromium + 日本語フォント（Puppeteer PDF生成に必要）
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium \
-    fonts-ipafont-gothic \
-    fonts-ipafont-mincho \
-    && rm -rf /var/lib/apt/lists/*
+# セキュリティ: ベースイメージの脆弱性パッチを適用してから Chromium + 日本語フォントを導入。
+# `apt-get upgrade` で libgnutls30 等の CVE 修正を取り込む (Trivy CRITICAL gate 対応)。
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
+        chromium \
+        fonts-ipafont-gothic \
+        fonts-ipafont-mincho && \
+    rm -rf /var/lib/apt/lists/*
 
 # Puppeteer: システムChromiumを使用し、バンドル版ダウンロードをスキップ
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,12 +84,14 @@ Cemetery CRM Backendのセキュリティポリシー
 
 2. **npm audit**
    - CI/CDパイプラインで自動実行
-   - `moderate`以上の脆弱性を検出
+   - 全 dep (dev 含む): `moderate` 以上を **情報出力** (gate ではない)
+   - prod dep のみ: `high` 以上を検出した時点で **CI を fail させる gate**
 
 3. **Trivy**
    - Dockerイメージの脆弱性スキャン
-   - CRITICAL/HIGHの脆弱性を検出
-   - GitHub Security タブで結果確認可能
+   - SARIF 出力: CRITICAL/HIGH を GitHub Security タブへ送出
+   - **Gate**: 修正可能な (`ignore-unfixed: true`) CRITICAL 脆弱性で CI を fail
+   - 修正パッチ未提供のものはノイズ扱いで継続
 
 ### 手動セキュリティチェック
 


### PR DESCRIPTION
**Refs zaitsu82/komine-infra#11** (本番化セキュリティ堅牢化のクロスリポ作業)

## 背景

komine-infra #11 (堅牢化) の受け入れ条件のひとつ「CI が脆弱性で fail するゲートを持つ」が本リポでは未達。
現状の \`.github/workflows/ci.yml\` では:
- npm audit (prod-only \`--omit=dev --audit-level=high\`) に \`continue-on-error: true\` が付いていて **失敗しても CI pass**
- Trivy も \`exit-code: "0"\` で **検出しても CI pass**

つまり監査は **情報出力にしかなっていない**。脆弱性混入のチェックポイントとして機能していなかった。

## 変更点

### npm audit (\`.github/workflows/ci.yml\`)
- 全 dep の \`--audit-level=moderate\` は **情報出力のまま** (dev dep のノイズが多く gate にしない)
- prod-only \`--omit=dev --audit-level=high\` から \`continue-on-error: true\` を削除
  → **本番ランタイムに乗る依存の high+ 脆弱性で CI fail**

### Trivy
- SARIF 出力 step は従来通り \`exit-code: "0"\` + \`continue-on-error: true\` (ダッシュボード送出は best-effort)
- 新たに **gate step** を追加:
  - \`severity: "CRITICAL"\` のみ
  - \`exit-code: "1"\`
  - \`ignore-unfixed: true\` (修正パッチ未提供のものは除外、ノイズ防止)
- SARIF upload は \`if: always()\` を付けて、**gate fail 時もダッシュボードへ反映**
- 情報出力用 table step も \`if: always()\` で残す

### ドキュメント
- \`CLAUDE.md\`: CI/CD セクションを新方針に合わせて更新
- \`SECURITY.md\`: 自動セキュリティチェック節を新方針に更新

## 現状確認

- \`npm audit --omit=dev --audit-level=high\`: ✅ \`found 0 vulnerabilities\` (現状 gate 化しても pass)
- \`npm audit --audit-level=moderate\`: ✅ \`found 0 vulnerabilities\` (情報出力枠)

## 残作業 (komine-infra #11 関連、本 PR スコープ外)

| 項目 | 場所 |
|---|---|
| \`ALLOWED_ORIGINS\` 本番固定 | 本番ドメイン確定後 (komine-infra #10 待ち)。コード側の制御は実装済み (\`src/middleware/security.ts\`) |
| Helmet / Rate limiter 等の本番設定再確認 | 本番デプロイ時に環境変数で行う運用作業 |
| Supabase 認証本番設定 | Supabase ダッシュボード側の設定作業 |
| frontend 側の audit gate | komine-crm-frontend は **既に prod audit が gate 化** されており追加作業なし |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)