### PR TITLE
fix(yucho): CSV出力を実フォーマット (12列カンマ区切り Shift-JIS) に修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kurosakicrm",
       "version": "1.3.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@komine/types": "file:../packages/types",
@@ -23,6 +24,7 @@
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
         "hpp": "^0.2.3",
+        "iconv-lite": "^0.7.2",
         "js-yaml": "^4.1.1",
         "mysql2": "^3.22.3",
         "pdf-lib": "^1.17.1",
@@ -68,10 +70,13 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "zod": "^4.3.6"
+        "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "jest": "^29.7.0",
         "rimraf": "^5.0.0",
+        "ts-jest": "^29.4.11",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
     "hpp": "^0.2.3",
+    "iconv-lite": "^0.7.2",
     "js-yaml": "^4.1.1",
     "mysql2": "^3.22.3",
     "pdf-lib": "^1.17.1",

--- a/src/validations/yuchoValidation.ts
+++ b/src/validations/yuchoValidation.ts
@@ -36,30 +36,14 @@ export const yuchoBillingQuerySchema = z.object({
 export type YuchoBillingQuery = z.infer<typeof yuchoBillingQuerySchema>;
 
 // CSV エクスポート用クエリスキーマ
-//   transferDate: 引落日（MMDDフォーマット用）
-//   clientCode:   委託者コード（10桁）
-//   clientName:   委託者名（半角40文字以内）
-//   bankCode:     金融機関コード（4桁、デフォルト 9900 = ゆうちょ）
-//   branchCode:   支店コード（3桁、デフォルト 000）
+// ゆうちょ自動払込みCSVは委託者ヘッダを持たないため、ヘッダ系パラメータ
+// (transferDate / clientCode / clientName / bankCode / branchCode) は不要。
 export const yuchoExportQuerySchema = z.object({
   year: yearSchema,
   month: monthSchema.optional(),
   category: YuchoCategoryEnum.optional().default('all'),
   status: YuchoStatusEnum.optional().default('unbilled'),
   format: YuchoFormatEnum.optional().default('zengin'),
-  transferDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'transferDate must be YYYY-MM-DD'),
-  clientCode: z.string().regex(/^\d{1,10}$/, 'clientCode must be up to 10 digits'),
-  clientName: z.string().min(1).max(40),
-  bankCode: z
-    .string()
-    .regex(/^\d{4}$/, 'bankCode must be 4 digits')
-    .optional()
-    .default('9900'),
-  branchCode: z
-    .string()
-    .regex(/^\d{3}$/, 'branchCode must be 3 digits')
-    .optional()
-    .default('000'),
 });
 
 export type YuchoExportQuery = z.infer<typeof yuchoExportQuerySchema>;

--- a/src/yucho/yuchoController.ts
+++ b/src/yucho/yuchoController.ts
@@ -2,15 +2,16 @@
  * ゆうちょ連携コントローラー
  *
  * - GET /api/v1/yucho/billing : 請求対象データの一覧取得
- * - GET /api/v1/yucho/export  : ゆうちょ自動払込み用 全銀協CSVを生成・返却
+ * - GET /api/v1/yucho/export  : ゆうちょ自動払込み用 CSV (Shift-JIS, 12列) を生成・返却
  */
 
 import { Request, Response, NextFunction } from 'express';
+import iconv from 'iconv-lite';
 import { ZodError } from 'zod';
 import { ValidationError } from '../middleware/errorHandler';
 import { yuchoBillingQuerySchema, yuchoExportQuerySchema } from '../validations/yuchoValidation';
 import { fetchYuchoBillingData } from './yuchoService';
-import { buildZenginCsv } from './yuchoCsv';
+import { buildYuchoCsv } from './yuchoCsv';
 
 const formatZodError = (err: ZodError): ValidationError => {
   const details = err.issues.map((i) => ({
@@ -64,21 +65,13 @@ export const exportYuchoCsv = async (
       status: params.status,
     });
 
-    const csv = buildZenginCsv({
-      header: {
-        clientCode: params.clientCode,
-        clientName: params.clientName,
-        transferDate: params.transferDate,
-        bankCode: params.bankCode,
-        branchCode: params.branchCode,
-      },
-      items: data.items,
-    });
+    const csv = buildYuchoCsv({ items: data.items });
+    const buffer = iconv.encode(csv, 'Shift_JIS');
 
     const fileName = `yucho_${params.year}${params.month != null ? String(params.month).padStart(2, '0') : 'all'}.csv`;
-    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Type', 'text/csv; charset=Shift_JIS');
     res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
-    res.status(200).send(csv);
+    res.status(200).send(buffer);
   } catch (error) {
     next(error);
   }

--- a/src/yucho/yuchoCsv.ts
+++ b/src/yucho/yuchoCsv.ts
@@ -1,23 +1,38 @@
 /**
- * 全銀協 預金口座振替フォーマット CSV ビルダー
+ * ゆうちょ自動払込み CSV ビルダー
  *
- * 1レコード120バイト固定長を CRLF で連結したテキストを生成する。
- * 半角カナへの正規化と、固定幅へのパディング/切詰めを行う。
+ * 利用者提供の実ファイル(2026-05-27 確認) に基づくフォーマット:
+ *   - カンマ区切り CSV・12列・Shift-JIS（エンコードは Controller 側で実施）
+ *   - ヘッダ/トレーラ/エンドレコードは無し（全行データ）
+ *   - 行頭は空列でカンマ始まり
  *
- * レコード構成:
- *   1: ヘッダー    — 委託者情報・引落日・委託者口座
- *   2: データ      — 顧客口座・引落金額（顧客毎）
- *   8: トレーラー  — 合計件数・合計金額
- *   9: エンド      — レコード終端
+ * 列定義:
+ *   1: 空
+ *   2: 金融機関コード (9900 固定 = ゆうちょ)
+ *   3: 金融機関名 半角カナ (15桁・空白パディング, "ﾕｳﾁﾖ" + 11空白)
+ *   4: 金融機関名 漢字 ("ゆうちょ銀行" 固定)
+ *   5: 店番 (3桁)
+ *   6: 空 (支店名カナ想定・現状は空)
+ *   7: 空 (支店名漢字想定・現状は空)
+ *   8: 預金種目 (1=普通)
+ *   9: 口座番号 (7桁)
+ *  10: 口座名義 半角カナ (30桁空白パディング・ダブルクオート囲み)
+ *  11: 引落金額
+ *  12: フラグ (1 固定)
  */
 
 import type { YuchoBillingItem } from '../validations/yuchoValidation';
 
-const RECORD_LENGTH = 120;
 const LINE_SEP = '\r\n';
+const BANK_CODE = '9900';
+const BANK_NAME_KANA = 'ﾕｳﾁﾖ';
+const BANK_NAME_KANA_WIDTH = 15;
+const BANK_NAME_KANJI = 'ゆうちょ銀行';
+const ACCOUNT_HOLDER_WIDTH = 30;
+const FLAG = '1';
 
 /**
- * 預金種目コード変換（Prisma enum → Zengin code）
+ * 預金種目コード変換（Prisma enum → ゆうちょ code）
  *   ordinary (普通)  → 1
  *   current  (当座)  → 2
  *   savings  (貯蓄)  → 4
@@ -37,7 +52,7 @@ const accountTypeCode = (type: string | null | undefined): string => {
 
 /**
  * 全角カナ・ひらがなを半角カナに変換する簡易コンバーター。
- * 全銀フォーマットは半角カナを要求するため。
+ * ゆうちょCSVの口座名義は半角カナを要求するため。
  */
 const KANA_MAP: Record<string, string> = {
   ガ: 'ｶﾞ',
@@ -137,25 +152,19 @@ const toHalfWidthKana = (input: string): string => {
   let result = '';
   for (const ch of input) {
     if (ch >= 'ぁ' && ch <= 'ん') {
-      // ひらがなをカタカナへ → 半角カナ
       const kata = String.fromCharCode(ch.charCodeAt(0) + HIRAGANA_OFFSET);
       result += KANA_MAP[kata] ?? kata;
     } else if (KANA_MAP[ch]) {
       result += KANA_MAP[ch];
-    } else if (ch >= '\uFF61' && ch <= '\uFF9F') {
-      // 既に半角カナ
+    } else if (ch >= '｡' && ch <= 'ﾟ') {
       result += ch;
-    } else if (ch >= '\uFF10' && ch <= '\uFF19') {
-      // 全角数字 → 半角
+    } else if (ch >= '０' && ch <= '９') {
       result += String.fromCharCode(ch.charCodeAt(0) - 0xfee0);
-    } else if (ch >= '\uFF21' && ch <= '\uFF5A') {
-      // 全角英字 → 半角
+    } else if (ch >= 'Ａ' && ch <= 'ｚ') {
       result += String.fromCharCode(ch.charCodeAt(0) - 0xfee0);
     } else if (ch.charCodeAt(0) < 0x80) {
-      // ASCII
       result += ch;
     } else {
-      // 変換できない文字はスペース
       result += ' ';
     }
   }
@@ -179,103 +188,9 @@ const padLeftZero = (value: string | number, width: number): string => {
   return '0'.repeat(width - s.length) + s;
 };
 
-interface HeaderParams {
-  clientCode: string; // 委託者コード(10桁)
-  clientName: string; // 委託者名(40バイト, 半角カナ)
-  transferDate: string; // YYYY-MM-DD
-  bankCode: string; // 取引銀行番号(4桁)
-  bankName?: string; // 取引銀行名(15バイト, デフォルト ﾕｳﾁﾖｷﾞﾝｺｳ)
-  branchCode: string; // 取引支店番号(3桁)
-  branchName?: string; // 取引支店名(15バイト)
-  accountType?: string; // 預金種目 (ordinary/current/savings)
-  accountNumber?: string; // 委託者口座番号(7桁)
-}
-
 /**
- * ヘッダレコード（区分=1）120バイトを生成
- */
-export const buildHeaderRecord = (params: HeaderParams): string => {
-  const transferMMDD = params.transferDate.replace(/-/g, '').slice(4, 8);
-  const parts = [
-    '1', // レコード区分
-    '91', // 種別コード（預金口座振替）
-    '0', // コード区分（JISコード）
-    padLeftZero(params.clientCode, 10),
-    padRight(toHalfWidthKana(params.clientName), 40),
-    transferMMDD, // 引落日 MMDD (4桁)
-    padLeftZero(params.bankCode, 4),
-    padRight(toHalfWidthKana(params.bankName ?? 'ﾕｳﾁﾖｷﾞﾝｺｳ'), 15),
-    padLeftZero(params.branchCode, 3),
-    padRight(toHalfWidthKana(params.branchName ?? ''), 15),
-    accountTypeCode(params.accountType ?? 'ordinary'),
-    padLeftZero(params.accountNumber ?? '', 7),
-  ];
-  const body = parts.join('');
-  return padRight(body, RECORD_LENGTH);
-};
-
-/**
- * データレコード（区分=2）120バイトを生成
- */
-export const buildDataRecord = (item: YuchoBillingItem): string => {
-  const info = item.billingInfo;
-  const parts = [
-    '2', // レコード区分
-    padLeftZero(extractBankCode(info?.bankName ?? ''), 4),
-    padRight(toHalfWidthKana(info?.bankName ?? ''), 15),
-    padLeftZero(extractBranchCode(info?.branchName ?? ''), 3),
-    padRight(toHalfWidthKana(info?.branchName ?? ''), 15),
-    '    ', // ダミー(4)
-    accountTypeCode(info?.accountType),
-    padLeftZero(info?.accountNumber ?? '', 7),
-    padRight(toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? ''), 30),
-    padLeftZero(item.billingAmount, 10),
-    '0', // 新規コード(0:その他)
-    padRight(item.contractPlotId.replace(/-/g, '').slice(0, 20), 20), // 顧客番号
-    '0', // 振替結果コード(0:未処理)
-  ];
-  const body = parts.join('');
-  return padRight(body, RECORD_LENGTH);
-};
-
-/**
- * トレーラレコード（区分=8）120バイトを生成
- */
-export const buildTrailerRecord = (totalCount: number, totalAmount: number): string => {
-  const parts = [
-    '8',
-    padLeftZero(totalCount, 6),
-    padLeftZero(totalAmount, 12),
-    padLeftZero(0, 6), // 振替済件数（未処理時は0）
-    padLeftZero(0, 12), // 振替済金額
-    padLeftZero(0, 6), // 振替不能件数
-    padLeftZero(0, 12), // 振替不能金額
-  ];
-  const body = parts.join('');
-  return padRight(body, RECORD_LENGTH);
-};
-
-/**
- * エンドレコード（区分=9）120バイトを生成
- */
-export const buildEndRecord = (): string => {
-  return padRight('9', RECORD_LENGTH);
-};
-
-/**
- * 銀行名から銀行コードを推定。ゆうちょ銀行は 9900。
- * 不明な場合は 0000 を返す（呼び出し側で上書き必要）。
- */
-const extractBankCode = (bankName: string): string => {
-  if (bankName.includes('ゆうちょ') || bankName.includes('ﾕｳﾁﾖ') || bankName.includes('郵便')) {
-    return '9900';
-  }
-  return '0000';
-};
-
-/**
- * 支店名から支店コード(3桁)を推定。漢数字を含む店舗名（〇一八店等）から数字を抽出。
- * 不明な場合は 000 を返す。
+ * 支店名から店番(3桁)を抽出。漢数字を含む店舗名（〇一八店等）から数字を抽出する。
+ * 不明な場合は 000 を返す。記号番号方式の本来採番は別 issue (#170) で対応。
  */
 const KANJI_DIGIT: Record<string, string> = {
   〇: '0',
@@ -295,10 +210,8 @@ const KANJI_DIGIT: Record<string, string> = {
 };
 
 const extractBranchCode = (branchName: string): string => {
-  // ASCII数字優先
   const ascii = branchName.match(/\d{3}/);
   if (ascii) return ascii[0];
-  // 漢数字3桁
   let digits = '';
   for (const ch of branchName) {
     if (KANJI_DIGIT[ch] != null) {
@@ -309,40 +222,54 @@ const extractBranchCode = (branchName: string): string => {
   return digits.length === 3 ? digits : '000';
 };
 
+/**
+ * データ行(1顧客=1行) を生成する。
+ */
+export const buildDataRow = (item: YuchoBillingItem): string => {
+  const info = item.billingInfo;
+  const accountHolder = padRight(
+    toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? ''),
+    ACCOUNT_HOLDER_WIDTH
+  );
+
+  const cells = [
+    '', // 1: 空
+    BANK_CODE, // 2: 金融機関コード
+    padRight(BANK_NAME_KANA, BANK_NAME_KANA_WIDTH), // 3: 金融機関名 半角カナ
+    BANK_NAME_KANJI, // 4: 金融機関名 漢字
+    padLeftZero(extractBranchCode(info?.branchName ?? ''), 3), // 5: 店番
+    '', // 6: 空
+    '', // 7: 空
+    accountTypeCode(info?.accountType), // 8: 預金種目
+    padLeftZero(info?.accountNumber ?? '', 7), // 9: 口座番号
+    `"${accountHolder}"`, // 10: 口座名義
+    String(item.billingAmount), // 11: 引落金額
+    FLAG, // 12: フラグ
+  ];
+  return cells.join(',');
+};
+
 interface BuildCsvParams {
-  header: HeaderParams;
   items: YuchoBillingItem[];
 }
 
 /**
  * CSV（振替ファイル）のデータ行として出力可能な請求項目かどうか。
  * 口座情報（billingInfo）があり、かつ請求金額が正であること。
- * 件数表示の整合性のため、この判定を CSV 生成（buildZenginCsv）と
+ * 件数表示の整合性のため、この判定を CSV 生成（buildYuchoCsv）と
  * 集計（yuchoService の summary）で共用する。これが実出力件数の唯一の基準となる。
  */
 export const isExportableBillingItem = (item: YuchoBillingItem): boolean =>
   Boolean(item.billingInfo) && item.billingAmount > 0;
 
 /**
- * 全銀協フォーマットの完全な CSV (固定長レコード) を生成する。
- * 出力例:
- *   1{ヘッダー...}\r\n
- *   2{データ1...}\r\n
- *   2{データ2...}\r\n
- *   8{トレーラー...}\r\n
- *   9{エンド...}\r\n
+ * ゆうちょ自動払込みCSV (12列カンマ区切り) を生成する。
+ * 戻り値は文字列。Shift-JIS エンコードは Controller 側で実施。
  */
-export const buildZenginCsv = ({ header, items }: BuildCsvParams): string => {
+export const buildYuchoCsv = ({ items }: BuildCsvParams): string => {
   const billable = items.filter(isExportableBillingItem);
-  const totalAmount = billable.reduce((sum, i) => sum + i.billingAmount, 0);
-
-  const lines = [
-    buildHeaderRecord(header),
-    ...billable.map(buildDataRecord),
-    buildTrailerRecord(billable.length, totalAmount),
-    buildEndRecord(),
-  ];
-  return lines.join(LINE_SEP) + LINE_SEP;
+  if (billable.length === 0) return '';
+  return billable.map(buildDataRow).join(LINE_SEP) + LINE_SEP;
 };
 
 // テスト用にエクスポート
@@ -351,6 +278,5 @@ export const __internal = {
   padRight,
   padLeftZero,
   accountTypeCode,
-  extractBankCode,
   extractBranchCode,
 };

--- a/tests/yucho/yuchoController.test.ts
+++ b/tests/yucho/yuchoController.test.ts
@@ -349,12 +349,9 @@ describe('yuchoController', () => {
     const validQuery = {
       year: '2026',
       month: '4',
-      transferDate: '2026-04-27',
-      clientCode: '1234567',
-      clientName: 'コミネレイエン',
     };
 
-    it('returns text/csv with attachment disposition and Zengin records', async () => {
+    it('returns Shift-JIS CSV buffer with attachment disposition and 12-column data rows', async () => {
       mockPrisma.managementFee.findMany.mockResolvedValue([
         {
           id: 'f1',
@@ -369,32 +366,52 @@ describe('yuchoController', () => {
       const req = buildRequest(validQuery);
       await exportYuchoCsv(req as Request, res as Response, next);
 
-      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=utf-8');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/csv; charset=Shift_JIS');
       expect(res.setHeader).toHaveBeenCalledWith(
         'Content-Disposition',
         expect.stringContaining('yucho_202604.csv')
       );
       expect(res.status).toHaveBeenCalledWith(200);
-      const sent = (res.send as jest.Mock).mock.calls[0][0] as string;
-      const lines = sent.split('\r\n').filter((l) => l.length > 0);
-      expect(lines[0]?.[0]).toBe('1');
-      expect(lines.find((l) => l[0] === '2')).toBeDefined();
-      expect(lines.find((l) => l[0] === '8')).toBeDefined();
-      expect(lines.find((l) => l[0] === '9')).toBeDefined();
+      const sent = (res.send as jest.Mock).mock.calls[0][0] as Buffer;
+      expect(Buffer.isBuffer(sent)).toBe(true);
+      // decode the Shift-JIS buffer back to verify structure
+      const iconv = (await import('iconv-lite')).default;
+      const decoded = iconv.decode(sent, 'Shift_JIS');
+      const lines = decoded.split('\r\n').filter((l) => l.length > 0);
+      expect(lines.length).toBe(1); // single billable item → one data row
+      const row = lines[0]!;
+      // 12 columns, starts with empty (comma-led)
+      expect(row.split(',')).toHaveLength(12);
+      expect(row.startsWith(',')).toBe(true);
+      // no header/trailer/end markers (no row starts with 1/8/9)
+      expect(lines.some((l) => l.startsWith('1,'))).toBe(false);
+      expect(lines.some((l) => l.startsWith('8,'))).toBe(false);
+      expect(lines.some((l) => l.startsWith('9,'))).toBe(false);
+      // internal contractPlotId (cp-1) must NOT appear in output
+      expect(decoded.includes('cp-1')).toBe(false);
     });
 
-    it('rejects missing transferDate via ValidationError', async () => {
-      const { transferDate: _omit, ...rest } = validQuery;
-      void _omit;
-      const req = buildRequest(rest);
-      await exportYuchoCsv(req as Request, res as Response, next);
-      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
-    });
+    it('encodes Japanese kanji bank name in Shift-JIS (not UTF-8 / not 文字化け)', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '12000',
+          contractPlot: buildContractPlot(),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
 
-    it('rejects malformed transferDate', async () => {
-      const req = buildRequest({ ...validQuery, transferDate: '2026/04/27' });
+      const req = buildRequest(validQuery);
       await exportYuchoCsv(req as Request, res as Response, next);
-      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+
+      const sent = (res.send as jest.Mock).mock.calls[0][0] as Buffer;
+      // Decoding as UTF-8 should be 文字化け (not contain ゆうちょ銀行)
+      expect(sent.toString('utf-8').includes('ゆうちょ銀行')).toBe(false);
+      // Decoding as Shift-JIS should restore the kanji intact
+      const iconv = (await import('iconv-lite')).default;
+      expect(iconv.decode(sent, 'Shift_JIS').includes('ゆうちょ銀行')).toBe(true);
     });
 
     it('uses "all" suffix in filename when month is omitted', async () => {
@@ -410,6 +427,19 @@ describe('yuchoController', () => {
         'Content-Disposition',
         expect.stringContaining('yucho_2026all.csv')
       );
+    });
+
+    it('sends empty buffer (no header row) when there are no billable items', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest(validQuery);
+      await exportYuchoCsv(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const sent = (res.send as jest.Mock).mock.calls[0][0] as Buffer;
+      expect(Buffer.isBuffer(sent)).toBe(true);
+      expect(sent.length).toBe(0);
     });
   });
 });

--- a/tests/yucho/yuchoCsv.test.ts
+++ b/tests/yucho/yuchoCsv.test.ts
@@ -1,14 +1,10 @@
 import {
-  buildHeaderRecord,
-  buildDataRecord,
-  buildTrailerRecord,
-  buildEndRecord,
-  buildZenginCsv,
+  buildDataRow,
+  buildYuchoCsv,
+  isExportableBillingItem,
   __internal,
 } from '../../src/yucho/yuchoCsv';
 import type { YuchoBillingItem } from '../../src/validations/yuchoValidation';
-
-const RECORD_LENGTH = 120;
 
 const baseItem = (overrides: Partial<YuchoBillingItem> = {}): YuchoBillingItem => ({
   category: 'management',
@@ -83,13 +79,7 @@ describe('yuchoCsv internals', () => {
     });
   });
 
-  describe('extractBankCode / extractBranchCode', () => {
-    it('returns 9900 for ゆうちょ銀行', () => {
-      expect(__internal.extractBankCode('ゆうちょ銀行')).toBe('9900');
-    });
-    it('returns 0000 for unknown banks', () => {
-      expect(__internal.extractBankCode('みずほ銀行')).toBe('0000');
-    });
+  describe('extractBranchCode', () => {
     it('extracts ASCII branch code', () => {
       expect(__internal.extractBranchCode('018店')).toBe('018');
     });
@@ -102,112 +92,167 @@ describe('yuchoCsv internals', () => {
   });
 });
 
-describe('Zengin record builders', () => {
-  it('buildHeaderRecord is exactly 120 bytes and starts with "1"', () => {
-    const record = buildHeaderRecord({
-      clientCode: '1234567',
-      clientName: 'コミネレイエン',
-      transferDate: '2026-04-27',
-      bankCode: '9900',
-      branchCode: '018',
-      accountType: 'ordinary',
-      accountNumber: '1234567',
+describe('buildDataRow', () => {
+  it('starts with empty column (comma-led row)', () => {
+    const row = buildDataRow(baseItem());
+    expect(row.startsWith(',')).toBe(true);
+  });
+
+  it('produces exactly 12 comma-separated columns', () => {
+    const row = buildDataRow(baseItem());
+    // 口座名義列にカンマは含まれない想定 (半角カナ+空白) なので単純に split で良い
+    expect(row.split(',')).toHaveLength(12);
+  });
+
+  it('uses fixed bank values (9900 / ﾕｳﾁﾖ padded to 15 / ゆうちょ銀行)', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    expect(cells[1]).toBe('9900');
+    expect(cells[2]).toBe('ﾕｳﾁﾖ           '); // 15桁
+    expect(cells[2]).toHaveLength(15);
+    expect(cells[3]).toBe('ゆうちょ銀行');
+  });
+
+  it('emits 3-digit branch code derived from branch name', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    expect(cells[4]).toBe('018'); // 〇一八 → 018
+  });
+
+  it('uses fixed deposit type code 1 (ordinary) by default', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    expect(cells[7]).toBe('1');
+  });
+
+  it('zero-pads account number to 7 digits', () => {
+    const item = baseItem({
+      billingInfo: { ...baseItem().billingInfo!, accountNumber: '12345' },
     });
-    expect(record).toHaveLength(RECORD_LENGTH);
-    expect(record[0]).toBe('1');
-    // 種別コード = 91, コード区分 = 0
-    expect(record.slice(1, 4)).toBe('910');
-    // 委託者コードはゼロ埋め10桁
-    expect(record.slice(4, 14)).toBe('0001234567');
-    // 引落日 (MMDD)
-    expect(record.slice(54, 58)).toBe('0427');
+    const cells = buildDataRow(item).split(',');
+    expect(cells[8]).toBe('0012345');
   });
 
-  it('buildDataRecord is exactly 120 bytes and starts with "2"', () => {
-    const record = buildDataRecord(baseItem());
-    expect(record).toHaveLength(RECORD_LENGTH);
-    expect(record[0]).toBe('2');
-    // 銀行コード(4) + 銀行名(15) + 支店コード(3)
-    expect(record.slice(1, 5)).toBe('9900');
-    expect(record.slice(20, 23)).toBe('018');
+  it('wraps account holder in double quotes and pads to 30 half-width chars', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    const holder = cells[9]!;
+    expect(holder.startsWith('"')).toBe(true);
+    expect(holder.endsWith('"')).toBe(true);
+    const inner = holder.slice(1, -1);
+    expect(inner).toHaveLength(30);
+    expect(inner.startsWith('ﾔﾏﾀﾞﾀﾛｳ')).toBe(true);
+    expect(inner.trimEnd()).toBe('ﾔﾏﾀﾞﾀﾛｳ');
   });
 
-  it('buildTrailerRecord starts with "8" and contains zero-padded count/amount', () => {
-    const record = buildTrailerRecord(3, 36000);
-    expect(record).toHaveLength(RECORD_LENGTH);
-    expect(record[0]).toBe('8');
-    expect(record.slice(1, 7)).toBe('000003');
-    expect(record.slice(7, 19)).toBe('000000036000');
+  it('falls back to customerNameKana when accountHolder is missing', () => {
+    const item = baseItem({
+      billingInfo: { ...baseItem().billingInfo!, accountHolder: null },
+      customerNameKana: 'サトウハナコ',
+    });
+    const cells = buildDataRow(item).split(',');
+    const inner = cells[9]!.slice(1, -1);
+    expect(inner).toHaveLength(30);
+    expect(inner.trimEnd()).toBe('ｻﾄｳﾊﾅｺ');
   });
 
-  it('buildEndRecord starts with "9" and is 120 bytes', () => {
-    const record = buildEndRecord();
-    expect(record).toHaveLength(RECORD_LENGTH);
-    expect(record[0]).toBe('9');
+  it('outputs billing amount as bare integer (no zero-padding) in column 11', () => {
+    const cells = buildDataRow(baseItem({ billingAmount: 12000 })).split(',');
+    expect(cells[10]).toBe('12000');
+  });
+
+  it('uses fixed flag value 1 in column 12', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    expect(cells[11]).toBe('1');
+  });
+
+  it('does NOT leak internal contractPlotId anywhere in the row', () => {
+    const item = baseItem({ contractPlotId: 'cuid-secret-DEADBEEF' });
+    const row = buildDataRow(item);
+    expect(row.includes('cuid-secret-DEADBEEF')).toBe(false);
+    expect(row.includes('DEADBEEF')).toBe(false);
+  });
+
+  it('keeps columns 1, 6, 7 empty (matches reference file shape)', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    expect(cells[0]).toBe('');
+    expect(cells[5]).toBe('');
+    expect(cells[6]).toBe('');
+  });
+
+  it('produces a row matching the reference file shape', () => {
+    const item = baseItem({
+      customerNameKana: 'セイ メイ',
+      billingInfo: {
+        bankName: 'ゆうちょ銀行',
+        branchName: '〇七四', // → 074
+        accountType: 'ordinary',
+        accountNumber: '1234567',
+        accountHolder: 'セイ メイ',
+      },
+      billingAmount: 8000,
+    });
+    const cells = buildDataRow(item).split(',');
+    expect(cells[0]).toBe(''); //                 1: empty
+    expect(cells[1]).toBe('9900'); //              2: bank code
+    expect(cells[2]).toBe('ﾕｳﾁﾖ           '); //   3: bank kana (15)
+    expect(cells[3]).toBe('ゆうちょ銀行'); //        4: bank kanji
+    expect(cells[4]).toBe('074'); //               5: branch (〇七四 → 074)
+    expect(cells[5]).toBe(''); //                  6: empty
+    expect(cells[6]).toBe(''); //                  7: empty
+    expect(cells[7]).toBe('1'); //                 8: deposit type
+    expect(cells[8]).toBe('1234567'); //           9: account number
+    expect(cells[9]!.slice(1, -1).trimEnd()).toBe('ｾｲ ﾒｲ'); // 10: holder
+    expect(cells[10]).toBe('8000'); //            11: amount
+    expect(cells[11]).toBe('1'); //               12: flag
   });
 });
 
-describe('buildZenginCsv', () => {
-  const header = {
-    clientCode: '1234567',
-    clientName: 'コミネレイエン',
-    transferDate: '2026-04-27',
-    bankCode: '9900',
-    branchCode: '018',
-  };
-
-  it('terminates each record with CRLF', () => {
-    const items = [baseItem()];
-    const csv = buildZenginCsv({ header, items });
+describe('buildYuchoCsv', () => {
+  it('terminates each row with CRLF', () => {
+    const csv = buildYuchoCsv({ items: [baseItem()] });
     expect(csv.endsWith('\r\n')).toBe(true);
     const segments = csv.split('\r\n');
-    // 4 records (header, data, trailer, end) + trailing empty from final CRLF
-    expect(segments).toHaveLength(5);
-    expect(segments[segments.length - 1]).toBe('');
+    // 1 data row + trailing empty from final CRLF
+    expect(segments).toHaveLength(2);
+    expect(segments[1]).toBe('');
   });
 
-  it('produces 5 lines for 2 items (header + 2 data + trailer + end)', () => {
+  it('emits one data row per exportable item — no header/trailer/end rows', () => {
     const items = [baseItem(), baseItem({ sourceId: 'fee-2', billingAmount: 8000 })];
-    const csv = buildZenginCsv({ header, items });
+    const csv = buildYuchoCsv({ items });
     const lines = csv.split('\r\n').filter((l) => l.length > 0);
-    expect(lines.length).toBe(5);
-    expect(lines[0]?.[0]).toBe('1');
-    expect(lines[1]?.[0]).toBe('2');
-    expect(lines[2]?.[0]).toBe('2');
-    expect(lines[3]?.[0]).toBe('8');
-    expect(lines[4]?.[0]).toBe('9');
+    expect(lines.length).toBe(2);
+    // Both lines must start with empty column (comma-led)
+    for (const line of lines) {
+      expect(line.startsWith(',')).toBe(true);
+    }
   });
 
   it('skips items with no billingInfo', () => {
     const items = [baseItem(), baseItem({ sourceId: 'fee-2', billingInfo: null })];
-    const csv = buildZenginCsv({ header, items });
-    const dataLines = csv.split('\r\n').filter((l) => l.startsWith('2'));
-    expect(dataLines.length).toBe(1);
+    const csv = buildYuchoCsv({ items });
+    const rows = csv.split('\r\n').filter((l) => l.length > 0);
+    expect(rows.length).toBe(1);
   });
 
   it('skips items with zero amount', () => {
     const items = [baseItem(), baseItem({ sourceId: 'fee-2', billingAmount: 0 })];
-    const csv = buildZenginCsv({ header, items });
-    const dataLines = csv.split('\r\n').filter((l) => l.startsWith('2'));
-    expect(dataLines.length).toBe(1);
+    const csv = buildYuchoCsv({ items });
+    const rows = csv.split('\r\n').filter((l) => l.length > 0);
+    expect(rows.length).toBe(1);
   });
 
-  it('trailer total amount equals sum of billable items', () => {
-    const items = [
-      baseItem({ billingAmount: 12000 }),
-      baseItem({ sourceId: 'fee-2', billingAmount: 8000 }),
-      baseItem({ sourceId: 'fee-3', billingAmount: 5000 }),
-    ];
-    const csv = buildZenginCsv({ header, items });
-    const trailer = csv.split('\r\n').find((l) => l.startsWith('8'));
-    expect(trailer?.slice(1, 7)).toBe('000003');
-    expect(trailer?.slice(7, 19)).toBe('000000025000');
+  it('returns empty string when no exportable items', () => {
+    expect(buildYuchoCsv({ items: [] })).toBe('');
+    expect(buildYuchoCsv({ items: [baseItem({ billingInfo: null })] })).toBe('');
   });
+});
 
-  it('outputs only header + trailer + end when no items provided', () => {
-    const csv = buildZenginCsv({ header, items: [] });
-    const lines = csv.split('\r\n').filter((l) => l.length > 0);
-    expect(lines.length).toBe(3); // header + trailer + end
-    expect(lines[1]?.slice(1, 7)).toBe('000000'); // count = 0
+describe('isExportableBillingItem', () => {
+  it('is true when billingInfo present and amount > 0', () => {
+    expect(isExportableBillingItem(baseItem())).toBe(true);
+  });
+  it('is false when billingInfo is null', () => {
+    expect(isExportableBillingItem(baseItem({ billingInfo: null }))).toBe(false);
+  });
+  it('is false when amount is 0', () => {
+    expect(isExportableBillingItem(baseItem({ billingAmount: 0 }))).toBe(false);
   });
 });

--- a/tests/yucho/yuchoRoutes.test.ts
+++ b/tests/yucho/yuchoRoutes.test.ts
@@ -55,9 +55,7 @@ describe('Yucho Routes', () => {
   });
 
   it('GET /api/v1/yucho/export → 200 with CSV content type', async () => {
-    const res = await request(app).get(
-      '/api/v1/yucho/export?year=2026&month=4&transferDate=2026-04-27&clientCode=1234567&clientName=KOMINE'
-    );
+    const res = await request(app).get('/api/v1/yucho/export?year=2026&month=4');
     expect(res.status).toBe(200);
     expect(exportYuchoCsv).toHaveBeenCalled();
     expect(res.headers['content-type']).toContain('text/csv');


### PR DESCRIPTION
## Summary

利用者提供の実ファイル (2026-05-27 確認) に基づき、ゆうちょ自動払込み CSV のフォーマットを是正する。

- ❌ 現状: 全銀協120バイト固定長 (UTF-8、ヘッダ/トレーラ/エンド付き、内部 `contractPlotId` が顧客番号列に混入)
- ✅ 修正後: **カンマ区切り CSV・12列・Shift-JIS・データ行のみ**

## 列定義

| 列 | 内容 | 値 |
|---|---|---|
| 1 | 空 | `` |
| 2 | 金融機関コード | `9900` 固定 |
| 3 | 金融機関名 半角カナ | `ﾕｳﾁﾖ` + 11桁空白 (15桁) |
| 4 | 金融機関名 漢字 | `ゆうちょ銀行` 固定 |
| 5 | 店番 | 3桁 |
| 6 | 空 | `` |
| 7 | 空 | `` |
| 8 | 預金種目 | 1=普通 |
| 9 | 口座番号 | 7桁ゼロ埋め |
| 10 | 口座名義 | 半角カナ・30桁空白パディング・**ダブルクオート囲み** |
| 11 | 引落金額 | 整数 |
| 12 | フラグ | `1` 固定 |

## 業務確認済み事項

- **第11列 (金額)**: 引落金額を出力 (実ファイル例は空だが、運用方針として金額入りで確定)

## 受け入れ条件

- [x] 出力フォーマットを実体と一致させた (CSV 12列 Shift-JIS)
- [x] UI表記・ファイル名・MIME (`text/csv; charset=Shift_JIS`) が実体と一致
- [x] 顧客番号フィールド (旧10列目) に内部 `contractPlotId` が出力されない
- [x] テストで顧客番号フィールドと出力フォーマットの期待値を検証

## スコープ外 (別 issue)

- 委託者情報・顧客のゆうちょ記号番号モデル整備 → #170
- 管理料抽出ロジックの業務確認 → #171
- フロントエンド側の追従 (UI ラベル "全銀協" 表記の見直し等) → 別 PR で対応

## Test plan

- [x] `npm test -- tests/yucho` → 53 tests pass
- [x] `npm test` 全体 → 850 tests pass (regression なし)
- [x] `npm run lint -- --max-warnings=0` → clean
- [x] `npx tsc --noEmit` → clean
- [x] Shift-JIS エンコーディング検証 (UTF-8 で読むと文字化け、Shift-JIS で読むと「ゆうちょ銀行」が復元できることを assertion)
- [x] 内部 `contractPlotId` (cuid) が出力に一切現れないことを assertion

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)