### PR TITLE
fix(plots): ContractPlot.payment_status を請求実績から導出 (#162)

### DIFF
--- a/scripts/legacy-migration/steps/12-payment-status.ts
+++ b/scripts/legacy-migration/steps/12-payment-status.ts
@@ -1,0 +1,92 @@
+import type { PaymentStatus } from '@prisma/client';
+
+import { paymentStatusFromTotals } from '../../../src/plots/services/paymentStatusLogic';
+import type { MigrationStep } from '../types';
+
+/**
+ * ContractPlot.payment_status backfill（#162）
+ *
+ * 移行（05-contract-plot）では payment_status を全件 'unpaid' 固定で投入している。
+ * Billing / Payment 投入後に、契約区画ごとに「請求額 vs 入金額」を集計して
+ * 'paid' / 'partial_paid' / 'unpaid' を再計算する。
+ *
+ * 判定ロジックはランタイム（src/plots/services/paymentStatusLogic）と共有している。
+ *  - 解約済み請求（terminated）は債務消滅扱いで集計から除外
+ *  - overdue（延滞）は期限超過の業務定義が未確定のため自動付与しない
+ *
+ * 冪等性:
+ *   再計算結果（paid / partial_paid）に該当する区画のみ更新する。
+ *   移行直後は全区画が 'unpaid' なので、未入金の区画は更新不要（no-op）。
+ *   何度実行しても同じ結果に収束する。
+ */
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+export const stepPaymentStatus: MigrationStep = {
+  name: 'paymentStatus',
+  dependsOn: ['billing', 'payment'],
+  async run({ prisma, logger, dryRun }) {
+    // 解約済みを除いた請求を契約区画単位で集計（請求額 / 入金額）
+    const grouped = await prisma.billing.groupBy({
+      by: ['contract_plot_id'],
+      where: { deleted_at: null, terminated: false },
+      _sum: { amount: true, paid_amount: true },
+    });
+
+    // 算出ステータスごとに区画 ID をバケツ分け
+    const byStatus: Record<PaymentStatus, string[]> = {
+      unpaid: [],
+      partial_paid: [],
+      paid: [],
+      overdue: [],
+      refunded: [],
+    };
+
+    for (const g of grouped) {
+      const totalAmount = g._sum.amount ?? 0;
+      const totalPaid = g._sum.paid_amount ?? 0;
+      const status = paymentStatusFromTotals(totalAmount, totalPaid);
+      byStatus[status].push(g.contract_plot_id);
+    }
+
+    // 'unpaid' は移行初期値と同じなので更新不要。paid / partial_paid のみ反映。
+    const paidIds = byStatus.paid;
+    const partialIds = byStatus.partial_paid;
+    const updated = paidIds.length + partialIds.length;
+
+    if (dryRun) {
+      const notes: Record<string, number> = {
+        contract_plots_with_billing: grouped.length,
+        would_set_paid: paidIds.length,
+        would_set_partial_paid: partialIds.length,
+      };
+      logger.info(notes, 'paymentStatus backfill (dry-run)');
+      return { inserted: 0, skipped: grouped.length - updated, notes };
+    }
+
+    const targets: Array<{ status: PaymentStatus; ids: string[] }> = [
+      { status: 'paid', ids: paidIds },
+      { status: 'partial_paid', ids: partialIds },
+    ];
+    for (const { status, ids } of targets) {
+      for (const idChunk of chunk(ids, 1000)) {
+        await prisma.contractPlot.updateMany({
+          where: { id: { in: idChunk }, deleted_at: null },
+          data: { payment_status: status },
+        });
+      }
+    }
+
+    const notes: Record<string, number> = {
+      contract_plots_with_billing: grouped.length,
+      set_paid: paidIds.length,
+      set_partial_paid: partialIds.length,
+      left_unpaid: byStatus.unpaid.length,
+    };
+    return { inserted: updated, skipped: grouped.length - updated, notes };
+  },
+};

--- a/scripts/legacy-migration/steps/13-summary.ts
+++ b/scripts/legacy-migration/steps/13-summary.ts
@@ -51,6 +51,17 @@ export const stepSummary: MigrationStep = {
       }),
     ]);
 
+    // payment_status の分布（#162 backfill の検証用）
+    const paymentStatusGroups = await prisma.contractPlot.groupBy({
+      by: ['payment_status'],
+      where: { deleted_at: null },
+      _count: { _all: true },
+    });
+    const paymentStatusDist = paymentStatusGroups.reduce<Record<string, number>>((acc, g) => {
+      acc[g.payment_status] = g._count._all;
+      return acc;
+    }, {});
+
     // レガシー側のベースライン
     interface LegacyCountsRow {
       physical: number;
@@ -89,6 +100,7 @@ export const stepSummary: MigrationStep = {
         staff: staffCount,
         usage_fee_total: Number(usageFeeTotal._sum.amount ?? 0),
         management_fee_total: Number(managementFeeTotal._sum.amount ?? 0),
+        payment_status_distribution: paymentStatusDist,
       },
       legacy: {
         physical_plots: Number(legacy?.physical ?? 0),

--- a/scripts/migrate-from-legacy.ts
+++ b/scripts/migrate-from-legacy.ts
@@ -45,7 +45,8 @@ import { stepBuriedPerson } from './legacy-migration/steps/08-buried-person';
 import { stepConstructionInfo } from './legacy-migration/steps/09-construction-info';
 import { stepBilling } from './legacy-migration/steps/10-billing';
 import { stepPayment } from './legacy-migration/steps/11-payment';
-import { stepSummary } from './legacy-migration/steps/12-summary';
+import { stepPaymentStatus } from './legacy-migration/steps/12-payment-status';
+import { stepSummary } from './legacy-migration/steps/13-summary';
 import type {
   MigrationContext,
   MigrationStep,
@@ -64,6 +65,7 @@ const ALL_STEPS: MigrationStep[] = [
   stepConstructionInfo,
   stepBilling,
   stepPayment,
+  stepPaymentStatus,
   stepSummary,
 ];
 

--- a/scripts/verify-migration.ts
+++ b/scripts/verify-migration.ts
@@ -43,7 +43,7 @@ import { closeLegacyPool, legacyCount, legacyQuery } from './legacy-migration/le
 // ---------------------------------------------------------------------------
 // ベースライン（Query_result_A〜F / dry-run で確定済み）
 //   confirmed: query_result/MIGRATION_STATUS.md「検証ベースライン」および
-//   scripts/legacy-migration/steps/12-summary.ts と一致させること。
+//   scripts/legacy-migration/steps/13-summary.ts と一致させること。
 // ---------------------------------------------------------------------------
 const BASELINE = {
   // レガシー側(del_flg=0)の確定件数
@@ -618,7 +618,7 @@ function buildReport(args: {
     '本レポートは `scripts/verify-migration.ts` により自動生成。再実行: `npm run verify:migration`。'
   );
   lines.push(
-    'ベースラインは `scripts/legacy-migration/steps/12-summary.ts` および MIGRATION_STATUS.md と整合。'
+    'ベースラインは `scripts/legacy-migration/steps/13-summary.ts` および MIGRATION_STATUS.md と整合。'
   );
   lines.push('');
 

--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@prisma/client';
 import { ZodError } from 'zod';
 import prisma from '../db/prisma';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
+import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentStatusService';
 import {
   createBillingSchema,
   updateBillingSchema,
@@ -195,24 +196,29 @@ export const createBilling = async (
     if (!contractPlot) throw new NotFoundError('指定の契約区画が見つかりません');
     if (!customer) throw new NotFoundError('指定の顧客が見つかりません');
 
-    const created = await prisma.billing.create({
-      data: {
-        contract_plot_id: input.contractPlotId,
-        customer_id: input.customerId,
-        category: input.category,
-        amount: input.amount,
-        use_start_year: input.useStartYear ?? null,
-        use_end_year: input.useEndYear ?? null,
-        target_month: input.targetMonth ?? null,
-        billing_years: input.billingYears ?? null,
-        contract_date: toDateOrNull(input.contractDate),
-        billing_date: toDateOrNull(input.billingDate),
-        application_type: input.applicationType ?? null,
-        billing_type: input.billingType ?? null,
-        status: input.status ?? 'pending',
-        notes: input.notes ?? null,
-      },
-      include: includeRelations,
+    const created = await prisma.$transaction(async (tx) => {
+      const billing = await tx.billing.create({
+        data: {
+          contract_plot_id: input.contractPlotId,
+          customer_id: input.customerId,
+          category: input.category,
+          amount: input.amount,
+          use_start_year: input.useStartYear ?? null,
+          use_end_year: input.useEndYear ?? null,
+          target_month: input.targetMonth ?? null,
+          billing_years: input.billingYears ?? null,
+          contract_date: toDateOrNull(input.contractDate),
+          billing_date: toDateOrNull(input.billingDate),
+          application_type: input.applicationType ?? null,
+          billing_type: input.billingType ?? null,
+          status: input.status ?? 'pending',
+          notes: input.notes ?? null,
+        },
+        include: includeRelations,
+      });
+      // 請求額が増えたので ContractPlot の payment_status を再計算（#162）
+      await recalculateContractPlotPaymentStatus(tx, input.contractPlotId);
+      return billing;
     });
 
     res.status(201).json({ success: true, data: formatBilling(created) });
@@ -261,10 +267,15 @@ export const updateBilling = async (
       data.terminated_date = toDateOrNull(input.terminatedDate);
     if (input.notes !== undefined) data.notes = input.notes;
 
-    const updated = await prisma.billing.update({
-      where: { id },
-      data,
-      include: includeRelations,
+    const updated = await prisma.$transaction(async (tx) => {
+      const billing = await tx.billing.update({
+        where: { id },
+        data,
+        include: includeRelations,
+      });
+      // 請求額・解約フラグの変更が入金状況に影響しうるので再計算（#162）
+      await recalculateContractPlotPaymentStatus(tx, existing.contract_plot_id);
+      return billing;
     });
 
     res.status(200).json({ success: true, data: formatBilling(updated) });
@@ -303,6 +314,8 @@ export const deleteBilling = async (
         where: { id },
         data: { deleted_at: new Date() },
       });
+      // 請求が消えたので ContractPlot の payment_status を再計算（#162）
+      await recalculateContractPlotPaymentStatus(tx, existing.contract_plot_id);
     });
 
     res.status(200).json({ success: true, data: { message: '請求を削除しました' } });

--- a/src/billings/billingService.ts
+++ b/src/billings/billingService.ts
@@ -1,5 +1,6 @@
 import { BillingRecordStatus, Prisma } from '@prisma/client';
 import prisma from '../db/prisma';
+import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentStatusService';
 
 /**
  * 請求 (Billing) のステータスを入金合計から自動計算する。
@@ -73,4 +74,7 @@ export const recalculateBillingPayments = async (
       status,
     },
   });
+
+  // 入金集計が変わったので、紐付く ContractPlot の payment_status も再計算する（#162）
+  await recalculateContractPlotPaymentStatus(client, billing.contract_plot_id);
 };

--- a/src/plots/services/paymentStatusLogic.ts
+++ b/src/plots/services/paymentStatusLogic.ts
@@ -1,0 +1,47 @@
+import { PaymentStatus } from '@prisma/client';
+
+/**
+ * ContractPlot.payment_status の派生ロジック（DB 非依存の純関数）。
+ *
+ * ランタイム（paymentStatusService）と移行 backfill（scripts/legacy-migration）の
+ * 双方から参照され、判定ロジックの単一ソースになる。
+ */
+
+/**
+ * 入金合計と請求合計から ContractPlot.payment_status を導出する。
+ *
+ * 遷移ロジック（billingService.computeBillingStatus と整合）:
+ *  - refunded（返金済み）: 自動算出ソースが無いため手動設定を尊重して維持する
+ *  - 入金合計 >= 請求額（請求額 > 0）: 'paid'
+ *  - 入金合計 > 0: 'partial_paid'
+ *  - overdue（延滞）: 期限超過の業務定義が未確定のため自動判定しない（#162）。
+ *    既に overdue が設定済みで入金が無い場合のみ 'overdue' を維持する
+ *  - それ以外: 'unpaid'
+ */
+export const paymentStatusFromTotals = (
+  totalAmount: number,
+  totalPaid: number,
+  currentStatus?: PaymentStatus
+): PaymentStatus => {
+  if (currentStatus === PaymentStatus.refunded) return PaymentStatus.refunded;
+  if (totalAmount > 0 && totalPaid >= totalAmount) return PaymentStatus.paid;
+  if (totalPaid > 0) return PaymentStatus.partial_paid;
+  if (currentStatus === PaymentStatus.overdue) return PaymentStatus.overdue;
+  return PaymentStatus.unpaid;
+};
+
+/**
+ * ContractPlot の請求群から payment_status を導出する。
+ *
+ * 解約済み請求（terminated）は債務が消滅しているため集計から除外する。
+ * これにより「解約前に全額入金 → 解約」の区画が誤って未入金扱いになるのを防ぐ。
+ */
+export const deriveContractPlotPaymentStatus = (
+  billings: { amount: number; paid_amount: number; terminated: boolean }[],
+  currentStatus?: PaymentStatus
+): PaymentStatus => {
+  const active = billings.filter((b) => !b.terminated);
+  const totalAmount = active.reduce((sum, b) => sum + b.amount, 0);
+  const totalPaid = active.reduce((sum, b) => sum + b.paid_amount, 0);
+  return paymentStatusFromTotals(totalAmount, totalPaid, currentStatus);
+};

--- a/src/plots/services/paymentStatusService.ts
+++ b/src/plots/services/paymentStatusService.ts
@@ -1,0 +1,43 @@
+import { PaymentStatus, Prisma } from '@prisma/client';
+
+import prisma from '../../db/prisma';
+
+import { deriveContractPlotPaymentStatus } from './paymentStatusLogic';
+
+export { deriveContractPlotPaymentStatus, paymentStatusFromTotals } from './paymentStatusLogic';
+
+type PaymentStatusClient = Prisma.TransactionClient | typeof prisma;
+
+/**
+ * 指定 ContractPlot について、紐付く Billing 群（の入金集計 paid_amount）から
+ * payment_status を再計算して更新する。
+ *
+ * Payment / Billing の作成・更新・削除時に呼ばれ、
+ * ContractPlot.payment_status を「請求 vs 入金」の派生値として常に最新に保つ。
+ *
+ * @returns 更新後のステータス。区画が見つからなければ null。
+ */
+export const recalculateContractPlotPaymentStatus = async (
+  client: PaymentStatusClient,
+  contractPlotId: string
+): Promise<PaymentStatus | null> => {
+  const contractPlot = await client.contractPlot.findFirst({
+    where: { id: contractPlotId, deleted_at: null },
+    select: { payment_status: true },
+  });
+  if (!contractPlot) return null;
+
+  const billings = await client.billing.findMany({
+    where: { contract_plot_id: contractPlotId, deleted_at: null },
+    select: { amount: true, paid_amount: true, terminated: true },
+  });
+
+  const status = deriveContractPlotPaymentStatus(billings, contractPlot.payment_status);
+
+  await client.contractPlot.update({
+    where: { id: contractPlotId },
+    data: { payment_status: status },
+  });
+
+  return status;
+};

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -32,6 +32,7 @@ const mockPrisma = {
   },
   contractPlot: {
     findFirst: jest.fn(),
+    update: jest.fn(),
   },
   $transaction: jest.fn(),
 };
@@ -118,6 +119,12 @@ describe('billingController', () => {
     jest.clearAllMocks();
     res = buildResponse();
     next = jest.fn();
+    // 既定: $transaction はそのまま mockPrisma をトランザクションクライアントとして渡す
+    mockPrisma.$transaction.mockImplementation(async (cb: (tx: typeof mockPrisma) => unknown) =>
+      cb(mockPrisma)
+    );
+    // payment_status 再計算（recalculateContractPlotPaymentStatus）が読む請求一覧の既定値
+    mockPrisma.billing.findMany.mockResolvedValue([]);
   });
 
   describe('getBillings', () => {
@@ -335,10 +342,20 @@ describe('billingController', () => {
 
   describe('deleteBilling', () => {
     it('soft-deletes the billing and orphans related payments', async () => {
-      mockPrisma.billing.findFirst.mockResolvedValue({ id: VALID_UUID });
+      mockPrisma.billing.findFirst.mockResolvedValue({
+        id: VALID_UUID,
+        contract_plot_id: PLOT_UUID,
+      });
       const txMock = {
-        billing: { update: jest.fn().mockResolvedValue({}) },
+        billing: {
+          update: jest.fn().mockResolvedValue({}),
+          findMany: jest.fn().mockResolvedValue([]),
+        },
         payment: { updateMany: jest.fn().mockResolvedValue({ count: 2 }) },
+        contractPlot: {
+          findFirst: jest.fn().mockResolvedValue({ payment_status: 'unpaid' }),
+          update: jest.fn().mockResolvedValue({}),
+        },
       };
       mockPrisma.$transaction.mockImplementation(async (cb) => cb(txMock));
 
@@ -353,6 +370,11 @@ describe('billingController', () => {
       expect(txMock.billing.update).toHaveBeenCalledWith({
         where: { id: VALID_UUID },
         data: { deleted_at: expect.any(Date) },
+      });
+      // 請求削除後に区画の payment_status を再計算する（#162）
+      expect(txMock.contractPlot.update).toHaveBeenCalledWith({
+        where: { id: PLOT_UUID },
+        data: { payment_status: 'unpaid' },
       });
     });
 

--- a/tests/billings/billingService.test.ts
+++ b/tests/billings/billingService.test.ts
@@ -59,20 +59,32 @@ describe('computeBillingStatus', () => {
 
 describe('recalculateBillingPayments', () => {
   let billingFindFirst: jest.Mock;
+  let billingFindMany: jest.Mock;
   let paymentFindMany: jest.Mock;
   let billingUpdate: jest.Mock;
+  let contractPlotFindFirst: jest.Mock;
+  let contractPlotUpdate: jest.Mock;
 
   const buildClient = () => {
     billingFindFirst = jest.fn();
+    // ContractPlot.payment_status の再計算が読む請求一覧（既定: 空）
+    billingFindMany = jest.fn().mockResolvedValue([]);
     paymentFindMany = jest.fn();
     billingUpdate = jest.fn();
+    contractPlotFindFirst = jest.fn().mockResolvedValue({ payment_status: 'unpaid' });
+    contractPlotUpdate = jest.fn();
     return {
       billing: {
         findFirst: billingFindFirst,
+        findMany: billingFindMany,
         update: billingUpdate,
       },
       payment: {
         findMany: paymentFindMany,
+      },
+      contractPlot: {
+        findFirst: contractPlotFindFirst,
+        update: contractPlotUpdate,
       },
     } as unknown as Parameters<typeof recalculateBillingPayments>[0];
   };
@@ -159,6 +171,37 @@ describe('recalculateBillingPayments', () => {
         last_payment_date: null,
         status: 'partial_paid',
       },
+    });
+  });
+
+  it('recalculates the linked ContractPlot.payment_status after updating the billing (#162)', async () => {
+    const client = buildClient();
+    billingFindFirst.mockResolvedValue({
+      id: 'b1',
+      contract_plot_id: 'cp1',
+      amount: 10000,
+      billing_date: new Date('2026-03-01'),
+      terminated: false,
+      status: 'billed',
+    });
+    paymentFindMany.mockResolvedValue([
+      { payment_amount: 10000, payment_date: new Date('2026-05-01') },
+    ]);
+    // 区画には他に未入金の管理料請求が残っている → 区画全体は partial_paid
+    billingFindMany.mockResolvedValue([
+      { amount: 10000, paid_amount: 10000, terminated: false },
+      { amount: 5000, paid_amount: 0, terminated: false },
+    ]);
+
+    await recalculateBillingPayments(client, 'b1');
+
+    expect(contractPlotFindFirst).toHaveBeenCalledWith({
+      where: { id: 'cp1', deleted_at: null },
+      select: { payment_status: true },
+    });
+    expect(contractPlotUpdate).toHaveBeenCalledWith({
+      where: { id: 'cp1' },
+      data: { payment_status: 'partial_paid' },
     });
   });
 });

--- a/tests/plots/paymentStatusService.test.ts
+++ b/tests/plots/paymentStatusService.test.ts
@@ -1,0 +1,139 @@
+import {
+  paymentStatusFromTotals,
+  deriveContractPlotPaymentStatus,
+  recalculateContractPlotPaymentStatus,
+} from '../../src/plots/services/paymentStatusService';
+
+describe('paymentStatusFromTotals', () => {
+  it('returns "paid" when paid amount equals or exceeds billed amount (amount > 0)', () => {
+    expect(paymentStatusFromTotals(10000, 10000)).toBe('paid');
+    expect(paymentStatusFromTotals(10000, 12000)).toBe('paid');
+  });
+
+  it('returns "partial_paid" when 0 < paid < amount', () => {
+    expect(paymentStatusFromTotals(10000, 1)).toBe('partial_paid');
+    expect(paymentStatusFromTotals(10000, 9999)).toBe('partial_paid');
+  });
+
+  it('returns "unpaid" when no payment is made', () => {
+    expect(paymentStatusFromTotals(10000, 0)).toBe('unpaid');
+  });
+
+  it('does not auto-assign "paid" when amount is 0 (no obligation, no payment)', () => {
+    // 請求額 0 円・入金 0 円 → unpaid（amount > 0 を paid 条件にしているため）
+    expect(paymentStatusFromTotals(0, 0)).toBe('unpaid');
+  });
+
+  it('treats a payment with no obligation (amount 0, paid > 0) as partial_paid', () => {
+    expect(paymentStatusFromTotals(0, 5000)).toBe('partial_paid');
+  });
+
+  it('preserves manually-set "overdue" when there is no payment (#162: overdue は自動判定しない)', () => {
+    expect(paymentStatusFromTotals(10000, 0, 'overdue')).toBe('overdue');
+  });
+
+  it('transitions "overdue" → "paid"/"partial_paid" once a payment lands', () => {
+    expect(paymentStatusFromTotals(10000, 10000, 'overdue')).toBe('paid');
+    expect(paymentStatusFromTotals(10000, 3000, 'overdue')).toBe('partial_paid');
+  });
+
+  it('preserves manually-set "refunded" regardless of totals', () => {
+    expect(paymentStatusFromTotals(10000, 10000, 'refunded')).toBe('refunded');
+    expect(paymentStatusFromTotals(10000, 0, 'refunded')).toBe('refunded');
+  });
+});
+
+describe('deriveContractPlotPaymentStatus', () => {
+  it('sums amount and paid across billings', () => {
+    expect(
+      deriveContractPlotPaymentStatus([
+        { amount: 10000, paid_amount: 10000, terminated: false },
+        { amount: 5000, paid_amount: 0, terminated: false },
+      ])
+    ).toBe('partial_paid');
+  });
+
+  it('returns "paid" when every active billing is fully covered', () => {
+    expect(
+      deriveContractPlotPaymentStatus([
+        { amount: 10000, paid_amount: 10000, terminated: false },
+        { amount: 5000, paid_amount: 5000, terminated: false },
+      ])
+    ).toBe('paid');
+  });
+
+  it('excludes terminated billings from the obligation (paid-then-terminated stays "paid")', () => {
+    // 解約済み未払い請求は債務消滅扱い → 残りの全額入金済み請求のみで判定
+    expect(
+      deriveContractPlotPaymentStatus([
+        { amount: 10000, paid_amount: 10000, terminated: false },
+        { amount: 99999, paid_amount: 0, terminated: true },
+      ])
+    ).toBe('paid');
+  });
+
+  it('returns "unpaid" when there are no active billings', () => {
+    expect(
+      deriveContractPlotPaymentStatus([{ amount: 99999, paid_amount: 0, terminated: true }])
+    ).toBe('unpaid');
+    expect(deriveContractPlotPaymentStatus([])).toBe('unpaid');
+  });
+});
+
+describe('recalculateContractPlotPaymentStatus', () => {
+  let contractPlotFindFirst: jest.Mock;
+  let contractPlotUpdate: jest.Mock;
+  let billingFindMany: jest.Mock;
+
+  const buildClient = () => {
+    contractPlotFindFirst = jest.fn();
+    contractPlotUpdate = jest.fn();
+    billingFindMany = jest.fn();
+    return {
+      contractPlot: { findFirst: contractPlotFindFirst, update: contractPlotUpdate },
+      billing: { findMany: billingFindMany },
+    } as unknown as Parameters<typeof recalculateContractPlotPaymentStatus>[0];
+  };
+
+  it('updates payment_status from the aggregated billings and returns it', async () => {
+    const client = buildClient();
+    contractPlotFindFirst.mockResolvedValue({ payment_status: 'unpaid' });
+    billingFindMany.mockResolvedValue([
+      { amount: 10000, paid_amount: 10000, terminated: false },
+      { amount: 5000, paid_amount: 5000, terminated: false },
+    ]);
+
+    const result = await recalculateContractPlotPaymentStatus(client, 'cp1');
+
+    expect(result).toBe('paid');
+    expect(contractPlotUpdate).toHaveBeenCalledWith({
+      where: { id: 'cp1' },
+      data: { payment_status: 'paid' },
+    });
+  });
+
+  it('passes the current status through so manual overdue/refunded is preserved', async () => {
+    const client = buildClient();
+    contractPlotFindFirst.mockResolvedValue({ payment_status: 'overdue' });
+    billingFindMany.mockResolvedValue([{ amount: 10000, paid_amount: 0, terminated: false }]);
+
+    const result = await recalculateContractPlotPaymentStatus(client, 'cp1');
+
+    expect(result).toBe('overdue');
+    expect(contractPlotUpdate).toHaveBeenCalledWith({
+      where: { id: 'cp1' },
+      data: { payment_status: 'overdue' },
+    });
+  });
+
+  it('returns null and skips update when the contract plot is not found', async () => {
+    const client = buildClient();
+    contractPlotFindFirst.mockResolvedValue(null);
+
+    const result = await recalculateContractPlotPaymentStatus(client, 'missing');
+
+    expect(result).toBeNull();
+    expect(billingFindMany).not.toHaveBeenCalled();
+    expect(contractPlotUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

区画一覧・詳細でほぼ全区画が「未入金」表示になっていた不具合 (#162) を修正。

移行で `ContractPlot.payment_status` を全件 `'unpaid'` 固定にしており、入金実績からの再計算がランタイムにも存在しなかったのが原因。`payment_status` を **請求(Billing)の `amount` vs `paid_amount` からの派生値** にし、格納列のまま各変更点で同期する方式にした（getPlots の filter/sort はカラム前提のまま動作）。

## 変更点

| ファイル | 内容 |
|---------|------|
| `src/plots/services/paymentStatusLogic.ts` (新) | DB非依存の純判定ロジック。ランタイムと移行で共有。`paid`/`partial_paid`/`unpaid` を算出。**overdue は期限超過の業務定義が未確定のため自動付与せず**、手動設定の `overdue`/`refunded` は尊重。解約済み請求(terminated)は債務消滅扱いで集計から除外 |
| `src/plots/services/paymentStatusService.ts` (新) | `recalculateContractPlotPaymentStatus` — 区画の請求群から再計算して更新 |
| `src/billings/billingService.ts` | `recalculateBillingPayments`（入金の作成/更新/削除時）に再計算フックを追加 → 入金実績から自動同期 |
| `src/billings/billingController.ts` | 請求の create/update/delete をトランザクション化し再計算フックを追加（請求額・解約フラグの変更も反映） |
| `scripts/legacy-migration/steps/12-payment-status.ts` (新) | 移行 backfill ステップ。請求集計から `payment_status` を一括補正 |
| `13-summary.ts` (旧12をリネーム) | payment_status 分布を検証出力に追加 |

## 本番/既存DBへの再適用

全移行を再実行せず、以下だけで補正可能:

```bash
npm run migrate:legacy -- --only=paymentStatus
```

## テスト

- 純ロジック / サービス / 再計算フックの単体テストを追加
- **全 857 テスト pass / lint 0 / prettier clean / tsc clean（src + 移行scripts）**

## 残課題

- **overdue（延滞）判定基準** は期限超過の業務定義が未確定のため、本PRでは自動判定に含めていない（issue #162 の方針③）。業務確認後に別途対応。

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
