### PR TITLE
fix(db): 本番で DATABASE_URL 未注入時に DB_* から接続文字列を組み立てる (#192)

### DIFF
--- a/src/db/databaseUrl.ts
+++ b/src/db/databaseUrl.ts
@@ -1,0 +1,38 @@
+/**
+ * Prisma 用の DATABASE_URL を解決する。
+ *
+ * 本番 (ECS/Fargate) では Secrets Manager の DB 認証情報が `DB_HOST` / `DB_PORT` /
+ * `DB_USERNAME` / `DB_PASSWORD` / `DB_NAME` として **個別に** 注入される一方、Prisma
+ * (`PrismaPg`) は単一の接続文字列 `DATABASE_URL` を必要とする。
+ *
+ * - `DATABASE_URL` が直接与えられていればそれをそのまま使う（ローカル / .env / 既存運用）。
+ * - 無ければ個別の `DB_*` から組み立てる（ECS のように分割注入される環境向け）。
+ *
+ * ユーザー名・パスワードは接続文字列を壊す文字（`@` `:` `/` `?` 等）を含み得るため、
+ * `encodeURIComponent` でパーセントエンコードしてから埋め込む。
+ *
+ * @param env 参照する環境変数（テスト用に差し替え可能。既定は `process.env`）
+ * @returns 解決した接続文字列。組み立てに必要な値が揃わない場合は `undefined`。
+ */
+export function resolveDatabaseUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const direct = env['DATABASE_URL'];
+  if (direct && direct.trim() !== '') {
+    return direct;
+  }
+
+  const host = env['DB_HOST'];
+  const username = env['DB_USERNAME'];
+  const password = env['DB_PASSWORD'];
+  const dbName = env['DB_NAME'];
+
+  // host / username / dbName が揃わなければ組み立て不可（呼び出し側で接続エラーになる）
+  if (!host || !username || !dbName) {
+    return undefined;
+  }
+
+  const port = env['DB_PORT'] ?? '5432';
+  const user = encodeURIComponent(username);
+  const auth = password ? `${user}:${encodeURIComponent(password)}` : user;
+
+  return `postgresql://${auth}@${host}:${port}/${dbName}`;
+}

--- a/src/db/prisma.ts
+++ b/src/db/prisma.ts
@@ -1,13 +1,16 @@
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
+import { resolveDatabaseUrl } from './databaseUrl';
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
 const nodeEnv = process.env['NODE_ENV'];
 
 function createPrismaClient(): PrismaClient {
+  // ECS では DB 認証情報が DB_* として個別注入されるため、DATABASE_URL が無ければ
+  // それらから接続文字列を組み立てる（詳細は resolveDatabaseUrl 参照）。
   const adapter = new PrismaPg({
-    connectionString: process.env['DATABASE_URL'],
+    connectionString: resolveDatabaseUrl(),
   });
   return new PrismaClient({
     adapter,

--- a/tests/db/databaseUrl.test.ts
+++ b/tests/db/databaseUrl.test.ts
@@ -1,0 +1,86 @@
+import { resolveDatabaseUrl } from '../../src/db/databaseUrl';
+
+describe('resolveDatabaseUrl', () => {
+  it('returns DATABASE_URL as-is when it is set', () => {
+    const env = {
+      DATABASE_URL: 'postgresql://u:p@db.example.com:5432/app',
+      // DB_* も並存していても DATABASE_URL を優先
+      DB_HOST: 'ignored',
+      DB_USERNAME: 'ignored',
+      DB_PASSWORD: 'ignored',
+      DB_NAME: 'ignored',
+    } as NodeJS.ProcessEnv;
+    expect(resolveDatabaseUrl(env)).toBe('postgresql://u:p@db.example.com:5432/app');
+  });
+
+  it('falls back to constructing from DB_* when DATABASE_URL is empty', () => {
+    const env = {
+      DATABASE_URL: '',
+      DB_HOST: 'rds.internal',
+      DB_PORT: '5432',
+      DB_USERNAME: 'komine_admin',
+      DB_PASSWORD: 'secret',
+      DB_NAME: 'komine_cemetery_crm',
+    } as NodeJS.ProcessEnv;
+    expect(resolveDatabaseUrl(env)).toBe(
+      'postgresql://komine_admin:secret@rds.internal:5432/komine_cemetery_crm'
+    );
+  });
+
+  it('constructs from DB_* when DATABASE_URL is absent', () => {
+    const env = {
+      DB_HOST: 'rds.internal',
+      DB_PORT: '6543',
+      DB_USERNAME: 'admin',
+      DB_PASSWORD: 'pw',
+      DB_NAME: 'app',
+    } as NodeJS.ProcessEnv;
+    expect(resolveDatabaseUrl(env)).toBe('postgresql://admin:pw@rds.internal:6543/app');
+  });
+
+  it('defaults the port to 5432 when DB_PORT is missing', () => {
+    const env = {
+      DB_HOST: 'rds.internal',
+      DB_USERNAME: 'admin',
+      DB_PASSWORD: 'pw',
+      DB_NAME: 'app',
+    } as NodeJS.ProcessEnv;
+    expect(resolveDatabaseUrl(env)).toBe('postgresql://admin:pw@rds.internal:5432/app');
+  });
+
+  it('percent-encodes credentials that contain URL-breaking characters', () => {
+    const env = {
+      DB_HOST: 'rds.internal',
+      DB_PORT: '5432',
+      DB_USERNAME: 'komine_admin',
+      // RDS 生成パスワードに混じり得る記号
+      DB_PASSWORD: 'p@ss:w/rd?#%',
+      DB_NAME: 'app',
+    } as NodeJS.ProcessEnv;
+    const url = resolveDatabaseUrl(env);
+    expect(url).toBe(
+      `postgresql://komine_admin:${encodeURIComponent('p@ss:w/rd?#%')}@rds.internal:5432/app`
+    );
+    // 生のパスワードがそのまま現れないこと（@ や / が未エンコードだと URL が壊れる）
+    expect(url).not.toContain('p@ss:w/rd');
+  });
+
+  it('omits the password segment when DB_PASSWORD is empty', () => {
+    const env = {
+      DB_HOST: 'rds.internal',
+      DB_PORT: '5432',
+      DB_USERNAME: 'admin',
+      DB_PASSWORD: '',
+      DB_NAME: 'app',
+    } as NodeJS.ProcessEnv;
+    expect(resolveDatabaseUrl(env)).toBe('postgresql://admin@rds.internal:5432/app');
+  });
+
+  it('returns undefined when required DB_* values are missing', () => {
+    expect(resolveDatabaseUrl({ DB_HOST: 'only-host' } as NodeJS.ProcessEnv)).toBeUndefined();
+    expect(
+      resolveDatabaseUrl({ DB_USERNAME: 'u', DB_NAME: 'd' } as NodeJS.ProcessEnv)
+    ).toBeUndefined();
+    expect(resolveDatabaseUrl({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要

**Closes #192** / Refs zaitsu82/komine-infra#11

本番 (ECS) で `DATABASE_URL` が未注入のため Prisma が DB に接続できないブロッカーを修正する。

ECS では DB 認証情報が `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` / `DB_NAME` として個別注入される一方、Prisma(`PrismaPg`) は単一の `DATABASE_URL` を読む。これまで `DATABASE_URL` を組み立てる箇所が無く、本番では接続文字列が `undefined` だった。

## 変更内容

- `src/db/databaseUrl.ts` に `resolveDatabaseUrl()` を追加
  - `DATABASE_URL` があればそれをそのまま使用（ローカル/.env/既存運用を非破壊）
  - 無ければ `DB_*` から `postgresql://` 接続文字列を組み立てる
  - ユーザー名/パスワードは URL を壊す文字を含み得るため `encodeURIComponent`
  - `DB_PORT` 既定 5432、必須値欠落時は `undefined`
- `src/db/prisma.ts` を `resolveDatabaseUrl()` 経由に変更
- `tests/db/databaseUrl.test.ts` を新規追加（7 ケース）

## 検証

- `npm test`: **873 / 873 passed**（+7）
- `npx tsc --noEmit`: clean
- `eslint`: clean

## 補足

infra 側は `DB_*` を既に注入済みのため **infra 変更は不要**。ローカルは従来どおり `.env` の `DATABASE_URL` を使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
