### PR TITLE
fix(migration): --only resume を dry-run で検証可能にする (idMap 再構築の dryRun ガード除去)

### DIFF
--- a/scripts/legacy-migration/steps/07-family-contact.ts
+++ b/scripts/legacy-migration/steps/07-family-contact.ts
@@ -46,10 +46,11 @@ export const stepFamilyContact: MigrationStep = {
   name: 'familyContact',
   dependsOn: ['customer', 'contractPlot'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) {
-      await rebuildIdMap(prisma, idMaps, 'customer', logger);
-      await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
-    }
+    // dry-run でも idMap を再構築する。rebuildIdMap は新DBからの読み取り専用かつ冪等なので
+    // 安全で、--only=<step> で 03〜06 を飛ばして resume するとき空マップで
+    // assertIdMapsReady が落ちるのを防ぐ。full dry-run では既に placeholder で埋まっており no-op。
+    await rebuildIdMap(prisma, idMaps, 'customer', logger);
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
     assertIdMapsReady('familyContact', idMaps, ['customer', 'contractPlot']);
 
     // t_danka から danka_cd → grave_cd の対応を取得

--- a/scripts/legacy-migration/steps/08-buried-person.ts
+++ b/scripts/legacy-migration/steps/08-buried-person.ts
@@ -42,7 +42,8 @@ export const stepBuriedPerson: MigrationStep = {
   name: 'buriedPerson',
   dependsOn: ['contractPlot'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
+    // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op）
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
     assertIdMapsReady('buriedPerson', idMaps, ['contractPlot']);
 
     const rows = await legacyQuery<MaisouRow>(

--- a/scripts/legacy-migration/steps/09-construction-info.ts
+++ b/scripts/legacy-migration/steps/09-construction-info.ts
@@ -34,7 +34,8 @@ export const stepConstructionInfo: MigrationStep = {
   name: 'constructionInfo',
   dependsOn: ['contractPlot'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
+    // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op）
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
     assertIdMapsReady('constructionInfo', idMaps, ['contractPlot']);
 
     const rows = await legacyQuery<FoundlogRow>(

--- a/scripts/legacy-migration/steps/10-billing.ts
+++ b/scripts/legacy-migration/steps/10-billing.ts
@@ -72,10 +72,9 @@ export const stepBilling: MigrationStep = {
   name: 'billing',
   dependsOn: ['customer', 'contractPlot'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) {
-      await rebuildIdMap(prisma, idMaps, 'customer', logger);
-      await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
-    }
+    // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op）
+    await rebuildIdMap(prisma, idMaps, 'customer', logger);
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
     assertIdMapsReady('billing', idMaps, ['customer', 'contractPlot']);
 
     const rows = await legacyQuery<SeikyuRow>(

--- a/scripts/legacy-migration/steps/11-payment.ts
+++ b/scripts/legacy-migration/steps/11-payment.ts
@@ -34,11 +34,12 @@ export const stepPayment: MigrationStep = {
   name: 'payment',
   dependsOn: ['billing'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) {
-      await rebuildIdMap(prisma, idMaps, 'customer', logger);
-      await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
-      await rebuildIdMap(prisma, idMaps, 'billing', logger);
-    }
+    // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op）。
+    // billing は同一 run の step10 が dry-run で placeholder を入れるため、billing→payment の
+    // 順で --only 実行すれば assertIdMapsReady を通せる。
+    await rebuildIdMap(prisma, idMaps, 'customer', logger);
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
+    await rebuildIdMap(prisma, idMaps, 'billing', logger);
     assertIdMapsReady('payment', idMaps, ['billing', 'contractPlot', 'customer']);
 
     const rows = await legacyQuery<NyukinRow>(

--- a/tests/scripts/legacy-migration/steps/dryrun-resume.test.ts
+++ b/tests/scripts/legacy-migration/steps/dryrun-resume.test.ts
@@ -1,0 +1,88 @@
+/**
+ * 回帰テスト: --only=<step> での resume を dry-run で検証できること (issue #163)
+ *
+ * 以前は各 step が `if (!dryRun)` で idMap の再構築をスキップしていたため、
+ * 03〜06 を飛ばした `--only=familyContact,... --dry-run`（runbook の事前確認手順）だと
+ * idMap が空のまま assertIdMapsReady が throw し、移行前の件数確認が動かなかった。
+ * rebuildIdMap は新DB（投入済みの 03〜06）からの読み取り専用かつ冪等なので、
+ * dry-run でも実行して resume を検証できるようにする。
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+// 移行元 MySQL に接続せず固定行を返す
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepFamilyContact } from '../../../../scripts/legacy-migration/steps/07-family-contact';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+describe('legacy migration resume + dry-run (issue #163)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  it('stepFamilyContact: dry-run で idMap が空でも新DBから再構築し、throw せず件数を返す', async () => {
+    // 新DB側（03〜06 投入済み）から idMap を再構築できる状態を模す
+    const customerFindMany = jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]);
+    const contractPlotFindMany = jest
+      .fn()
+      .mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]);
+    const familyContactCreate = jest.fn();
+    const prisma = {
+      customer: { findMany: customerFindMany },
+      contractPlot: { findMany: contractPlotFindMany },
+      familyContact: { create: familyContactCreate },
+    } as unknown as PrismaClient;
+
+    // 1回目: t_danka (danka_cd→grave_cd) のルックアップ, 2回目: t_family 本体
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      .mockResolvedValueOnce([
+        {
+          family_cd: 1,
+          danka_cd: 100,
+          family_sei: '山田',
+          family_mei: '太郎',
+          addr1: null,
+          addr2: null,
+          addr3: null,
+          job_addr1: null,
+          job_addr2: null,
+          job_addr3: null,
+        },
+      ]);
+
+    // createIdMaps() は空 = --only で 03〜06 を飛ばした状態を再現
+    const idMaps = createIdMaps();
+    const ctx: MigrationContext = { prisma, logger: buildLogger(), idMaps, dryRun: true };
+
+    const result = await stepFamilyContact.run(ctx);
+
+    // dry-run でも idMap が新DBから再構築された（= 旧挙動ではここが空で throw していた）
+    expect(customerFindMany).toHaveBeenCalledTimes(1);
+    expect(contractPlotFindMany).toHaveBeenCalledTimes(1);
+    expect(idMaps.customer.size).toBe(1);
+    expect(idMaps.contractPlot.size).toBe(1);
+
+    // dry-run なので件数だけ数え、書き込みはしない
+    expect(result.inserted).toBe(1);
+    expect(familyContactCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景 (Refs #163)

#163 の本番DB投入 runbook では、本投入前に以下の dry-run で件数を確認する手順になっている:

```bash
npm run migrate:legacy -- --only=familyContact,buriedPerson,constructionInfo,billing,payment,summary --dry-run
```

しかし**このコマンドはそのままだと step07 で即落ちする**ことが判明した:

```
InvariantViolationError: step familyContact: idMaps.customer, idMaps.contractPlot are empty,
abort to prevent NULL FK insertion
```

## 原因

- `--only=07..11` だと依存する **03〜06 が走らない**ので in-memory の idMap が空。
- 各 step は `if (!dryRun)` で **dry-run のとき `rebuildIdMap` をスキップ**していた。
- 一方 `assertIdMapsReady` は dry-run でも実行されるため、空マップで throw する。

→ `--only` での resume を dry-run で検証できず、runbook の事前確認手順が機能しなかった。
（full dry-run は 03〜06 が placeholder で idMap を埋めるため動くが、`--only` 部分実行では埋まらない）

## 修正

step07〜11 の `rebuildIdMap` 呼び出しから `!dryRun` ガードを除去し、dry-run でも idMap を再構築する。

- `rebuildIdMap` は新DB（投入済みの 03〜06）からの**読み取り専用かつ冪等**なので dry-run でも安全。
- full dry-run では既に placeholder で埋まっているため **no-op**（挙動不変）。
- 本実行（書き込みあり）は元々 `rebuildIdMap` を呼んでいたので**挙動不変**。

実環境で検証済み（dry-run で本番Postgres から `customer 3487 / contractPlot 6144` をロードし
`assertIdMapsReady` を通過することを確認。以降の停止はレガシーMySQL接続の別問題）。

## テスト

- `tests/scripts/legacy-migration/steps/dryrun-resume.test.ts` を追加
  - dry-run + 空 idMap でも新DBから再構築し、throw せず件数を返す回帰テスト
- 既存の移行 lib テスト（id-map-loader / invariants）含め green
- 変更ファイルの ESLint clean

## このPRに含まれないこと（#163 の残作業）

- **本番DBへの step07〜11 の実投入**（不可逆な本番書込のためオペレーター実施）。本PRは
  その事前確認 dry-run を動作可能にするツール修正のみ。
- **レガシー MySQL 接続設定**: 調査の結果、`.env` の `LEGACY_MYSQL_HOST=10.255.255.254` は
  誤り（実体は Windowsホスト `172.26.48.1:3306`）で、かつ MySQL 側が WSL クライアントIPを
  `ERROR 1130 (host not allowed)` で拒否している。本投入前にこの2点の解消が必要（別途対応）。

Refs #163