### PR TITLE
fix(plots): 未収金額を請求実績から導出し payment_status と同期 (frontend #170)

### DIFF
--- a/scripts/legacy-migration/steps/12-payment-status.ts
+++ b/scripts/legacy-migration/steps/12-payment-status.ts
@@ -1,22 +1,26 @@
 import type { PaymentStatus } from '@prisma/client';
 
-import { paymentStatusFromTotals } from '../../../src/plots/services/paymentStatusLogic';
+import {
+  paymentStatusFromTotals,
+  uncollectedFromTotals,
+} from '../../../src/plots/services/paymentStatusLogic';
 import type { MigrationStep } from '../types';
 
 /**
- * ContractPlot.payment_status backfill（#162）
+ * ContractPlot.payment_status / uncollected_amount backfill（#162 / #170）
  *
- * 移行（05-contract-plot）では payment_status を全件 'unpaid' 固定で投入している。
+ * 移行（05-contract-plot）では payment_status='unpaid' / uncollected_amount=0 固定で投入している。
  * Billing / Payment 投入後に、契約区画ごとに「請求額 vs 入金額」を集計して
- * 'paid' / 'partial_paid' / 'unpaid' を再計算する。
+ * payment_status（paid / partial_paid / unpaid）と未収金額（請求額 − 入金額）を再計算する。
  *
  * 判定ロジックはランタイム（src/plots/services/paymentStatusLogic）と共有している。
  *  - 解約済み請求（terminated）は債務消滅扱いで集計から除外
  *  - overdue（延滞）は期限超過の業務定義が未確定のため自動付与しない
+ *  - 未収金額 = max(0, 請求額 − 入金額)（#170）
  *
  * 冪等性:
- *   再計算結果（paid / partial_paid）に該当する区画のみ更新する。
- *   移行直後は全区画が 'unpaid' なので、未入金の区画は更新不要（no-op）。
+ *   payment_status='unpaid' かつ uncollected=0（＝移行初期値）に収束する区画は更新不要（no-op）。
+ *   「請求あり・入金0」の区画は status=unpaid のままだが未収>0 になるため更新対象（#170 の主因）。
  *   何度実行しても同じ結果に収束する。
  */
 
@@ -37,56 +41,66 @@ export const stepPaymentStatus: MigrationStep = {
       _sum: { amount: true, paid_amount: true },
     });
 
-    // 算出ステータスごとに区画 ID をバケツ分け
-    const byStatus: Record<PaymentStatus, string[]> = {
-      unpaid: [],
-      partial_paid: [],
-      paid: [],
-      overdue: [],
-      refunded: [],
-    };
+    // (payment_status, uncollected) の組ごとに区画 ID をまとめて updateMany を最小化する。
+    // 移行初期値（unpaid / 0）に一致する区画は更新不要（no-op）なので除外する。
+    const buckets = new Map<
+      string,
+      { status: PaymentStatus; uncollected: number; ids: string[] }
+    >();
+    let setPaid = 0;
+    let setPartial = 0;
+    let setUncollected = 0;
+    let leftAtInitial = 0;
 
     for (const g of grouped) {
       const totalAmount = g._sum.amount ?? 0;
       const totalPaid = g._sum.paid_amount ?? 0;
       const status = paymentStatusFromTotals(totalAmount, totalPaid);
-      byStatus[status].push(g.contract_plot_id);
+      const uncollected = uncollectedFromTotals(totalAmount, totalPaid, status);
+
+      if (status === 'unpaid' && uncollected === 0) {
+        leftAtInitial += 1;
+        continue; // 移行初期値と同じ（no-op）
+      }
+      if (status === 'paid') setPaid += 1;
+      if (status === 'partial_paid') setPartial += 1;
+      if (uncollected > 0) setUncollected += 1;
+
+      const key = `${status}|${uncollected}`;
+      const bucket = buckets.get(key);
+      if (bucket) bucket.ids.push(g.contract_plot_id);
+      else buckets.set(key, { status, uncollected, ids: [g.contract_plot_id] });
     }
 
-    // 'unpaid' は移行初期値と同じなので更新不要。paid / partial_paid のみ反映。
-    const paidIds = byStatus.paid;
-    const partialIds = byStatus.partial_paid;
-    const updated = paidIds.length + partialIds.length;
+    const updated = grouped.length - leftAtInitial;
 
     if (dryRun) {
       const notes: Record<string, number> = {
         contract_plots_with_billing: grouped.length,
-        would_set_paid: paidIds.length,
-        would_set_partial_paid: partialIds.length,
+        would_set_paid: setPaid,
+        would_set_partial_paid: setPartial,
+        would_set_uncollected: setUncollected,
       };
-      logger.info(notes, 'paymentStatus backfill (dry-run)');
-      return { inserted: 0, skipped: grouped.length - updated, notes };
+      logger.info(notes, 'paymentStatus/uncollected backfill (dry-run)');
+      return { inserted: 0, skipped: leftAtInitial, notes };
     }
 
-    const targets: Array<{ status: PaymentStatus; ids: string[] }> = [
-      { status: 'paid', ids: paidIds },
-      { status: 'partial_paid', ids: partialIds },
-    ];
-    for (const { status, ids } of targets) {
+    for (const { status, uncollected, ids } of buckets.values()) {
       for (const idChunk of chunk(ids, 1000)) {
         await prisma.contractPlot.updateMany({
           where: { id: { in: idChunk }, deleted_at: null },
-          data: { payment_status: status },
+          data: { payment_status: status, uncollected_amount: uncollected },
         });
       }
     }
 
     const notes: Record<string, number> = {
       contract_plots_with_billing: grouped.length,
-      set_paid: paidIds.length,
-      set_partial_paid: partialIds.length,
-      left_unpaid: byStatus.unpaid.length,
+      set_paid: setPaid,
+      set_partial_paid: setPartial,
+      set_uncollected: setUncollected,
+      left_at_initial: leftAtInitial,
     };
-    return { inserted: updated, skipped: grouped.length - updated, notes };
+    return { inserted: updated, skipped: leftAtInitial, notes };
   },
 };

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -163,7 +163,8 @@ export async function createPlotCore(
       permit_number: input.saleContract.permitNumber || null,
       permit_date: input.saleContract.permitDate ? new Date(input.saleContract.permitDate) : null,
       start_date: input.saleContract.startDate ? new Date(input.saleContract.startDate) : null,
-      uncollected_amount: input.saleContract.uncollectedAmount ?? 0,
+      // 未収金額は請求実績から導出する派生値（#170）。新規区画は請求未生成のため 0。手入力は無視。
+      uncollected_amount: 0,
       notes: input.saleContract.notes || null,
       grave_kind: input.saleContract.graveKind ?? null,
       grave_kubun: input.saleContract.graveKubun ?? null,

--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -115,7 +115,8 @@ export const createPlotContract = async (req: Request, res: Response): Promise<R
             ? new Date(input.saleContract.permitDate)
             : null,
           start_date: input.saleContract.startDate ? new Date(input.saleContract.startDate) : null,
-          uncollected_amount: input.saleContract.uncollectedAmount ?? 0,
+          // 未収金額は請求実績から導出する派生値（#170）。新規区画は請求未生成のため 0。手入力は無視。
+          uncollected_amount: 0,
           notes: input.saleContract.notes || null,
           grave_kind: input.saleContract.graveKind ?? null,
           grave_kubun: input.saleContract.graveKubun ?? null,

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -187,10 +187,7 @@ export async function updatePlotCore(
         ? new Date(input.saleContract.startDate)
         : null;
     }
-    if (input.saleContract.uncollectedAmount !== undefined) {
-      // uncollected_amount は非 null（schema default 0）。null は create と同様 0 にフォールバック。
-      updateData.uncollected_amount = input.saleContract.uncollectedAmount ?? 0;
-    }
+    // 未収金額は請求実績から導出する派生値（#170）。手入力は無視し、請求/入金 CRUD と backfill で同期する。
     if (input.saleContract.notes !== undefined) {
       updateData.notes = input.saleContract.notes;
     }

--- a/src/plots/services/paymentStatusLogic.ts
+++ b/src/plots/services/paymentStatusLogic.ts
@@ -1,7 +1,7 @@
 import { PaymentStatus } from '@prisma/client';
 
 /**
- * ContractPlot.payment_status の派生ロジック（DB 非依存の純関数）。
+ * ContractPlot.payment_status / uncollected_amount の派生ロジック（DB 非依存の純関数）。
  *
  * ランタイム（paymentStatusService）と移行 backfill（scripts/legacy-migration）の
  * 双方から参照され、判定ロジックの単一ソースになる。
@@ -31,17 +31,44 @@ export const paymentStatusFromTotals = (
 };
 
 /**
- * ContractPlot の請求群から payment_status を導出する。
+ * 請求合計と入金合計から未収金額を導出する。
+ *
+ * 未収金額 = active 請求の (請求額 − 入金額)。
+ *  - refunded（返金済み）: 債権が消滅しているため未収 0（#170）
+ *  - それ以外: max(0, totalAmount − totalPaid)（過入金でも負にしない）
+ */
+export const uncollectedFromTotals = (
+  totalAmount: number,
+  totalPaid: number,
+  status: PaymentStatus
+): number => {
+  if (status === PaymentStatus.refunded) return 0;
+  return Math.max(0, totalAmount - totalPaid);
+};
+
+/**
+ * ContractPlot の請求群から payment_status と uncollected_amount を同時に導出する。
  *
  * 解約済み請求（terminated）は債務が消滅しているため集計から除外する。
  * これにより「解約前に全額入金 → 解約」の区画が誤って未入金扱いになるのを防ぐ。
+ * payment_status と未収金額を同一の集計から導出することで、両者が論理的に矛盾しないことを保証する（#170）。
+ */
+export const deriveContractPlotPayment = (
+  billings: { amount: number; paid_amount: number; terminated: boolean }[],
+  currentStatus?: PaymentStatus
+): { status: PaymentStatus; uncollectedAmount: number } => {
+  const active = billings.filter((b) => !b.terminated);
+  const totalAmount = active.reduce((sum, b) => sum + b.amount, 0);
+  const totalPaid = active.reduce((sum, b) => sum + b.paid_amount, 0);
+  const status = paymentStatusFromTotals(totalAmount, totalPaid, currentStatus);
+  return { status, uncollectedAmount: uncollectedFromTotals(totalAmount, totalPaid, status) };
+};
+
+/**
+ * ContractPlot の請求群から payment_status を導出する。
+ * @deprecated 集計を二重化しないため {@link deriveContractPlotPayment} を使うこと。後方互換で残置。
  */
 export const deriveContractPlotPaymentStatus = (
   billings: { amount: number; paid_amount: number; terminated: boolean }[],
   currentStatus?: PaymentStatus
-): PaymentStatus => {
-  const active = billings.filter((b) => !b.terminated);
-  const totalAmount = active.reduce((sum, b) => sum + b.amount, 0);
-  const totalPaid = active.reduce((sum, b) => sum + b.paid_amount, 0);
-  return paymentStatusFromTotals(totalAmount, totalPaid, currentStatus);
-};
+): PaymentStatus => deriveContractPlotPayment(billings, currentStatus).status;

--- a/src/plots/services/paymentStatusService.ts
+++ b/src/plots/services/paymentStatusService.ts
@@ -2,18 +2,23 @@ import { PaymentStatus, Prisma } from '@prisma/client';
 
 import prisma from '../../db/prisma';
 
-import { deriveContractPlotPaymentStatus } from './paymentStatusLogic';
+import { deriveContractPlotPayment } from './paymentStatusLogic';
 
-export { deriveContractPlotPaymentStatus, paymentStatusFromTotals } from './paymentStatusLogic';
+export {
+  deriveContractPlotPayment,
+  deriveContractPlotPaymentStatus,
+  paymentStatusFromTotals,
+  uncollectedFromTotals,
+} from './paymentStatusLogic';
 
 type PaymentStatusClient = Prisma.TransactionClient | typeof prisma;
 
 /**
- * 指定 ContractPlot について、紐付く Billing 群（の入金集計 paid_amount）から
- * payment_status を再計算して更新する。
+ * 指定 ContractPlot について、紐付く Billing 群（請求額 amount と入金集計 paid_amount）から
+ * payment_status と uncollected_amount を再計算して更新する。
  *
  * Payment / Billing の作成・更新・削除時に呼ばれ、
- * ContractPlot.payment_status を「請求 vs 入金」の派生値として常に最新に保つ。
+ * ContractPlot.payment_status と未収金額を「請求 vs 入金」の派生値として常に最新に保つ（#170）。
  *
  * @returns 更新後のステータス。区画が見つからなければ null。
  */
@@ -32,11 +37,14 @@ export const recalculateContractPlotPaymentStatus = async (
     select: { amount: true, paid_amount: true, terminated: true },
   });
 
-  const status = deriveContractPlotPaymentStatus(billings, contractPlot.payment_status);
+  const { status, uncollectedAmount } = deriveContractPlotPayment(
+    billings,
+    contractPlot.payment_status
+  );
 
   await client.contractPlot.update({
     where: { id: contractPlotId },
-    data: { payment_status: status },
+    data: { payment_status: status, uncollected_amount: uncollectedAmount },
   });
 
   return status;

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -178,6 +178,7 @@ const saleContractSchema = sharedSaleContractSchema.omit({ paymentStatus: true }
   paymentStatus: z.string().max(50).optional().or(z.literal('')),
   customerRole: z.string().max(50).optional().or(z.literal('')), // 後方互換性のため残す（deprecated）
   roles: z.array(saleContractRoleSchema).optional(), // 複数役割サポート（新方式）
+  // @deprecated 手入力廃止（#170）。後方互換で受理するが controller で無視し、請求実績からの導出値で上書きされる。
   uncollectedAmount: z
     .number()
     .int()

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -374,7 +374,7 @@ describe('billingController', () => {
       // 請求削除後に区画の payment_status を再計算する（#162）
       expect(txMock.contractPlot.update).toHaveBeenCalledWith({
         where: { id: PLOT_UUID },
-        data: { payment_status: 'unpaid' },
+        data: { payment_status: 'unpaid', uncollected_amount: 0 },
       });
     });
 

--- a/tests/billings/billingService.test.ts
+++ b/tests/billings/billingService.test.ts
@@ -201,7 +201,7 @@ describe('recalculateBillingPayments', () => {
     });
     expect(contractPlotUpdate).toHaveBeenCalledWith({
       where: { id: 'cp1' },
-      data: { payment_status: 'partial_paid' },
+      data: { payment_status: 'partial_paid', uncollected_amount: 5000 },
     });
   });
 });

--- a/tests/plots/paymentStatusService.test.ts
+++ b/tests/plots/paymentStatusService.test.ts
@@ -1,5 +1,7 @@
 import {
   paymentStatusFromTotals,
+  uncollectedFromTotals,
+  deriveContractPlotPayment,
   deriveContractPlotPaymentStatus,
   recalculateContractPlotPaymentStatus,
 } from '../../src/plots/services/paymentStatusService';
@@ -80,6 +82,66 @@ describe('deriveContractPlotPaymentStatus', () => {
   });
 });
 
+describe('uncollectedFromTotals', () => {
+  it('returns billed minus paid', () => {
+    expect(uncollectedFromTotals(10000, 3000, 'partial_paid')).toBe(7000);
+    expect(uncollectedFromTotals(10000, 0, 'unpaid')).toBe(10000);
+  });
+
+  it('returns 0 when fully paid', () => {
+    expect(uncollectedFromTotals(10000, 10000, 'paid')).toBe(0);
+  });
+
+  it('clamps to 0 on overpayment (never negative)', () => {
+    expect(uncollectedFromTotals(10000, 12000, 'paid')).toBe(0);
+  });
+
+  it('returns the remaining debt for overdue', () => {
+    expect(uncollectedFromTotals(10000, 0, 'overdue')).toBe(10000);
+  });
+
+  it('returns 0 for refunded regardless of totals (#170: 債権消滅)', () => {
+    expect(uncollectedFromTotals(10000, 0, 'refunded')).toBe(0);
+    expect(uncollectedFromTotals(10000, 3000, 'refunded')).toBe(0);
+  });
+});
+
+describe('deriveContractPlotPayment', () => {
+  it('derives status and uncollected from the same aggregation', () => {
+    expect(
+      deriveContractPlotPayment([
+        { amount: 10000, paid_amount: 10000, terminated: false },
+        { amount: 5000, paid_amount: 0, terminated: false },
+      ])
+    ).toEqual({ status: 'partial_paid', uncollectedAmount: 5000 });
+  });
+
+  it('excludes terminated billings from both status and uncollected', () => {
+    expect(
+      deriveContractPlotPayment([
+        { amount: 10000, paid_amount: 10000, terminated: false },
+        { amount: 99999, paid_amount: 0, terminated: true },
+      ])
+    ).toEqual({ status: 'paid', uncollectedAmount: 0 });
+  });
+
+  it('reports the full billed amount as uncollected when nothing is paid (#170 主因)', () => {
+    expect(
+      deriveContractPlotPayment([{ amount: 162000, paid_amount: 0, terminated: false }])
+    ).toEqual({ status: 'unpaid', uncollectedAmount: 162000 });
+  });
+
+  it('returns unpaid / 0 when there are no active billings', () => {
+    expect(deriveContractPlotPayment([])).toEqual({ status: 'unpaid', uncollectedAmount: 0 });
+  });
+
+  it('zeroes uncollected for refunded (currentStatus preserved)', () => {
+    expect(
+      deriveContractPlotPayment([{ amount: 10000, paid_amount: 0, terminated: false }], 'refunded')
+    ).toEqual({ status: 'refunded', uncollectedAmount: 0 });
+  });
+});
+
 describe('recalculateContractPlotPaymentStatus', () => {
   let contractPlotFindFirst: jest.Mock;
   let contractPlotUpdate: jest.Mock;
@@ -108,7 +170,7 @@ describe('recalculateContractPlotPaymentStatus', () => {
     expect(result).toBe('paid');
     expect(contractPlotUpdate).toHaveBeenCalledWith({
       where: { id: 'cp1' },
-      data: { payment_status: 'paid' },
+      data: { payment_status: 'paid', uncollected_amount: 0 },
     });
   });
 
@@ -122,7 +184,7 @@ describe('recalculateContractPlotPaymentStatus', () => {
     expect(result).toBe('overdue');
     expect(contractPlotUpdate).toHaveBeenCalledWith({
       where: { id: 'cp1' },
-      data: { payment_status: 'overdue' },
+      data: { payment_status: 'overdue', uncollected_amount: 10000 },
     });
   });
 


### PR DESCRIPTION
## 概要
frontend #170（台帳詳細の未収金額矛盾「未入金なのに未収0」）の根本対応。

`ContractPlot.uncollected_amount` を手入力カラムから、active 請求の (請求額−入金額) による導出値に変更。#162(payment_status 導出, #191)と同一ソースになり、両者が論理的に矛盾しなくなる。`price`/`management_fee`(String) のパースは不要（金額は全て `Billing.amount`(Int)）。

## 変更
- `paymentStatusLogic`: `uncollectedFromTotals` / `deriveContractPlotPayment` を追加（refunded は未収0、集計を一本化）
- `paymentStatusService`: `recalculateContractPlotPaymentStatus` の update に `uncollected_amount` を相乗り（請求/入金 CRUD で自動同期）
- controllers(create/update/createContract): 手入力廃止（`uncollected_amount:0` 固定、validation は後方互換で残置）
- backfill(`steps/12-payment-status`): (status,uncollected) 単位更新に変更し「請求あり・入金0」区画の未収放置を是正（#170 主因）

## テスト
- 全 867 テスト pass / tsc clean / lint clean
- `paymentStatusService.test` に uncollectedFromTotals / deriveContractPlotPayment / recalc 期待値を追加

## ⚠️ デプロイ後の作業
本番DBに未収金額の backfill が必要: `npx ts-node scripts/migrate-from-legacy.ts --only paymentStatus`（まず `--dry-run`）。請求(billings)データ投入が前提。

## 関連
- frontend #170（表示面は別PR）
- types: uncollectedAmount を導出値化（zaitsu82/komine-types#30）
- 前提: #162/#191 はマージ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)