### PR TITLE
fix(staff): 既存Supabaseアカウントへの招待再送をパスワード再設定メールに切替 (#175)

### DIFF
--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -49,6 +49,12 @@ export interface InviteUserResult {
   success: boolean;
   user?: User;
   error?: string;
+  /**
+   * エラーの機械可読な種別。呼び出し側が文字列マッチに頼らず分岐できるようにする。
+   * - 'already_registered': 同一メールのSupabaseユーザーが既に存在する
+   * - 'rate_limit': 招待メール送信のレート制限
+   */
+  errorCode?: 'already_registered' | 'rate_limit';
 }
 
 /**
@@ -252,11 +258,15 @@ export const updateSupabaseUserEmail = async (
 };
 
 /**
- * 招待メールを再送信
+ * 招待メールを再送信（Supabaseユーザーが未作成のスタッフ向け）
+ *
+ * `inviteUserByEmail` は新規ユーザー作成を伴うため、既にSupabaseアカウントが
+ * 存在するメールに対しては `already registered` で失敗する。既存アカウントへの
+ * 再送は {@link sendPasswordReset} を使うこと。
  *
  * @param email - ユーザーのメールアドレス
  * @param redirectTo - パスワード設定後のリダイレクト先URL（オプション）
- * @returns 送信結果
+ * @returns 送信結果（`errorCode` で既存登録/レート制限を判別可能）
  */
 export const resendInvitation = async (
   email: string,
@@ -276,19 +286,79 @@ export const resendInvitation = async (
 
     if (error) {
       let errorMessage = error.message;
-      if (error.message.includes('rate limit')) {
+      let errorCode: InviteUserResult['errorCode'];
+      if (error.message.includes('already registered')) {
+        errorMessage = 'このメールアドレスは既にSupabaseに登録されています';
+        errorCode = 'already_registered';
+      } else if (error.message.includes('rate limit')) {
         errorMessage = '招待メールの送信制限に達しました。しばらく待ってから再試行してください';
+        errorCode = 'rate_limit';
       }
 
       return {
         success: false,
         error: errorMessage,
+        errorCode,
       };
     }
 
     return {
       success: true,
       user: data.user,
+    };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : '不明なエラーが発生しました';
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+};
+
+/**
+ * パスワード再設定メールを送信（Supabaseアカウントが既に存在するスタッフ向け）
+ *
+ * 既存ユーザーに対して `inviteUserByEmail` は使えない（`already registered` で失敗する）。
+ * recovery メールを送ることで、既存ユーザーがパスワードを（再）設定できるようにする。
+ *
+ * @param email - ユーザーのメールアドレス
+ * @param redirectTo - パスワード設定画面のリダイレクト先URL（オプション）
+ * @returns 送信結果（recovery のため `user` は返らない）
+ */
+export const sendPasswordReset = async (
+  email: string,
+  redirectTo?: string
+): Promise<InviteUserResult> => {
+  if (!supabaseAdmin) {
+    return {
+      success: false,
+      error: 'Supabase Admin サービスが利用できません',
+    };
+  }
+
+  try {
+    const { error } = await supabaseAdmin.auth.resetPasswordForEmail(email, {
+      redirectTo,
+    });
+
+    if (error) {
+      let errorMessage = error.message;
+      let errorCode: InviteUserResult['errorCode'];
+      if (error.message.includes('rate limit')) {
+        errorMessage =
+          'パスワード再設定メールの送信制限に達しました。しばらく待ってから再試行してください';
+        errorCode = 'rate_limit';
+      }
+
+      return {
+        success: false,
+        error: errorMessage,
+        errorCode,
+      };
+    }
+
+    return {
+      success: true,
     };
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : '不明なエラーが発生しました';

--- a/src/staff/staffController.ts
+++ b/src/staff/staffController.ts
@@ -13,6 +13,7 @@ import {
   deleteSupabaseUser,
   updateSupabaseUserEmail,
   resendInvitation,
+  sendPasswordReset,
 } from '../config/supabase';
 
 // スタッフ一覧のレスポンス型
@@ -617,28 +618,69 @@ export const resendStaffInvitation = async (
       throw new ValidationError('Supabase Admin サービスが利用できません');
     }
 
-    // 招待メール再送信
-    const result = await resendInvitation(
-      existingStaff.email,
-      process.env['FRONTEND_URL'] ? `${process.env['FRONTEND_URL']}/set-password` : undefined
-    );
+    const redirectTo = process.env['FRONTEND_URL']
+      ? `${process.env['FRONTEND_URL']}/set-password`
+      : undefined;
 
-    if (!result.success) {
-      throw new ValidationError(result.error || '招待メールの送信に失敗しました');
+    // #175: supabase_uid が仮（pending_）= Supabaseアカウント未作成のスタッフは招待メール
+    // （inviteUserByEmail = ユーザー新規作成）でよいが、既に実アカウントがあるスタッフへ
+    // 招待を送ると `already registered` で失敗する。既存アカウントには recovery（パスワード
+    // 再設定）メールを送る。
+    const isPending =
+      !existingStaff.supabase_uid || existingStaff.supabase_uid.startsWith('pending_');
+
+    if (isPending) {
+      // 仮UID: 招待メール送信（=Supabaseユーザー新規作成）
+      const result = await resendInvitation(existingStaff.email, redirectTo);
+
+      // 仮UIDなのにSupabase側に既存アカウントがある（UID未同期等）場合は、招待ではなく
+      // パスワード再設定メールにフォールバックして再送を成立させる。
+      if (!result.success && result.errorCode === 'already_registered') {
+        const fallback = await sendPasswordReset(existingStaff.email, redirectTo);
+        if (!fallback.success) {
+          throw new ValidationError(fallback.error || 'パスワード再設定メールの送信に失敗しました');
+        }
+        res.json({
+          success: true,
+          data: {
+            message: 'パスワード再設定メールを送信しました',
+          },
+        });
+        return;
+      }
+
+      if (!result.success) {
+        throw new ValidationError(result.error || '招待メールの送信に失敗しました');
+      }
+
+      // 新規作成されたSupabaseユーザーの実UIDで仮UIDを更新
+      if (result.user) {
+        await prisma.staff.update({
+          where: { id: staffId },
+          data: { supabase_uid: result.user.id },
+        });
+      }
+
+      res.json({
+        success: true,
+        data: {
+          message: '招待メールを再送信しました',
+        },
+      });
+      return;
     }
 
-    // supabase_uidが仮の値の場合、新しいUIDで更新
-    if (result.user && existingStaff.supabase_uid?.startsWith('pending_')) {
-      await prisma.staff.update({
-        where: { id: staffId },
-        data: { supabase_uid: result.user.id },
-      });
+    // 既存アカウント: パスワード再設定メールを送信
+    const result = await sendPasswordReset(existingStaff.email, redirectTo);
+
+    if (!result.success) {
+      throw new ValidationError(result.error || 'パスワード再設定メールの送信に失敗しました');
     }
 
     res.json({
       success: true,
       data: {
-        message: '招待メールを再送信しました',
+        message: 'パスワード再設定メールを送信しました',
       },
     });
   } catch (error) {

--- a/tests/staff/staffController.test.ts
+++ b/tests/staff/staffController.test.ts
@@ -24,9 +24,13 @@ const mockSupabaseAdminAuth = {
   updateUserById: jest.fn(),
 };
 
+// resetPasswordForEmail は auth.admin ではなく auth 直下のメソッド
+const mockResetPasswordForEmail = jest.fn();
+
 const mockSupabase = {
   auth: {
     admin: mockSupabaseAdminAuth,
+    resetPasswordForEmail: mockResetPasswordForEmail,
   },
 };
 
@@ -555,6 +559,97 @@ describe('Staff Controller', () => {
             }),
           })
         );
+      });
+
+      it('既にSupabaseアカウントを持つスタッフにはパスワード再設定メールを送る (#175)', async () => {
+        mockRequest.params = { id: '2' };
+
+        const mockExistingStaff = {
+          id: 2,
+          name: 'Staff',
+          email: 'staff@example.com',
+          supabase_uid: '11111111-2222-3333-4444-555555555555', // 実UUID = 既存アカウント
+          is_active: true,
+        };
+        mockPrisma.staff.findFirst.mockResolvedValue(mockExistingStaff);
+        mockResetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+
+        await resendStaffInvitation(mockRequest as Request, mockResponse as Response, mockNext);
+
+        // inviteUserByEmail は呼ばず、recovery メールを送る
+        expect(mockSupabaseAdminAuth.inviteUserByEmail).not.toHaveBeenCalled();
+        expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+          'staff@example.com',
+          expect.any(Object)
+        );
+        // 既存アカウントなので supabase_uid は更新しない
+        expect(mockPrisma.staff.update).not.toHaveBeenCalled();
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({
+              message: 'パスワード再設定メールを送信しました',
+            }),
+          })
+        );
+      });
+
+      it('仮UIDでもSupabase側に既存登録がある場合はパスワード再設定にフォールバックする (#175)', async () => {
+        mockRequest.params = { id: '2' };
+
+        const mockExistingStaff = {
+          id: 2,
+          name: 'Staff',
+          email: 'staff@example.com',
+          supabase_uid: 'pending_123',
+          is_active: true,
+        };
+        mockPrisma.staff.findFirst.mockResolvedValue(mockExistingStaff);
+        // 招待は already registered で失敗
+        mockSupabaseAdminAuth.inviteUserByEmail.mockResolvedValue({
+          data: { user: null },
+          error: { message: 'A user with this email address has already registered' },
+        });
+        // フォールバックの recovery は成功
+        mockResetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+
+        await resendStaffInvitation(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockSupabaseAdminAuth.inviteUserByEmail).toHaveBeenCalled();
+        expect(mockResetPasswordForEmail).toHaveBeenCalledWith(
+          'staff@example.com',
+          expect.any(Object)
+        );
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({
+              message: 'パスワード再設定メールを送信しました',
+            }),
+          })
+        );
+      });
+
+      it('パスワード再設定メールの送信に失敗した場合、ValidationErrorを返す (#175)', async () => {
+        mockRequest.params = { id: '2' };
+
+        mockPrisma.staff.findFirst.mockResolvedValue({
+          id: 2,
+          name: 'Staff',
+          email: 'staff@example.com',
+          supabase_uid: '11111111-2222-3333-4444-555555555555',
+          is_active: true,
+        });
+        mockResetPasswordForEmail.mockResolvedValue({
+          data: {},
+          error: { message: 'email rate limit exceeded' },
+        });
+
+        await resendStaffInvitation(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('送信制限');
       });
 
       it('スタッフが見つからない場合、NotFoundErrorを返す', async () => {


### PR DESCRIPTION
## 概要

Closes #175

既にSupabaseアカウントを持つスタッフ（`supabase_uid` が実UUID）に対して「招待再送」(`POST /api/v1/staff/:id/resend-invitation`) を行うと、内部の `inviteUserByEmail` が `already registered` を返して**失敗する**問題を修正。

「招待再送」の業務シナリオには次の2つが含まれる:
- (a) **仮UID（`pending_*`）スタッフへの初回招待送信** — Supabaseユーザー未作成
- (b) **既存アカウントへのパスワード（再）設定** — Supabaseユーザー作成済み

`inviteUserByEmail` は (a) 専用（=ユーザー新規作成）であり、(b) には不適切。`supabase_uid` が `pending_` か否かで送出方法を出し分けるようにした。

## 変更内容

### `src/config/supabase.ts`
- **`sendPasswordReset(email, redirectTo)` を追加** — `supabaseAdmin.auth.resetPasswordForEmail` で recovery（パスワード再設定）メールを送信。既存ユーザーがパスワードを設定し直せる。
- **`resendInvitation` の `already registered` を日本語化** + `errorCode` を付与（issue 修正方針②）。
- `InviteUserResult` に機械可読な `errorCode`（`already_registered` / `rate_limit`）を追加。

### `src/staff/staffController.ts` — `resendStaffInvitation`
| 対象スタッフ | supabase_uid | 挙動 |
|---|---|---|
| 招待のみ/未ログイン | `pending_*` | **招待メール**（従来どおり、成功時に実UIDへ更新） |
| 既存Supabaseアカウントあり | 実UUID | **パスワード再設定メール** |

- 仮UIDなのに Supabase 側に既存登録がある（UID未同期等）場合は、`already_registered` を検知して **recovery メールにフォールバック**し再送を成立させる。
- 成功メッセージを文脈で出し分け（`招待メールを再送信しました` / `パスワード再設定メールを送信しました`）。

### テスト
`tests/staff/staffController.test.ts` に3ケース追加 — 既存アカウントへの recovery 送出 / フォールバック / 送信失敗時の `ValidationError`。**全887テスト pass**。tsc・ESLint(src)・Prettier いずれもクリーン。

## 検証メモ（issue の検証項目について）
- 検証項目1（実Supabaseプロジェクトでの `inviteUserByEmail` の戻り確認）は**ライブSupabase環境が必要なため未実施**。本PRは SDK 仕様（`inviteUserByEmail`=新規作成 / `resetPasswordForEmail`=recovery送信）に基づく実装＋ユニットテストで対応している。実環境での到達確認は別途お願いしたい。
- 検証項目2（業務シナリオ確定）は (a)(b) 両方を想定し `pending_` 判定で出し分ける方針で実装。

## 関連
- #173 / #174（staff⇔Supabase 整合性）— UID未同期ケースはフォールバックで救済

🤖 Generated with [Claude Code](https://claude.com/claude-code)