### PR TITLE
fix(plots): 区画詳細にcontractStatus等を返却し、一覧のcontractStatusフィルタを実装 (#199, #200)

### DIFF
--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -105,14 +105,17 @@ export const getPlotById = async (
         areaName: contractPlot.physicalPlot.area_name,
         areaSqm: contractPlot.physicalPlot.area_sqm.toNumber(),
         status: contractPlot.physicalPlot.status,
+        mapId: contractPlot.physicalPlot.map_id,
         notes: contractPlot.physicalPlot.notes,
       },
 
       // 販売契約情報（ContractPlotに統合済み）
       contractDate: contractPlot.contract_date,
       price: contractPlot.price,
+      contractStatus: contractPlot.contract_status,
       paymentStatus: contractPlot.payment_status,
       reservationDate: contractPlot.reservation_date,
+      requestDate: contractPlot.request_date,
       acceptanceNumber: contractPlot.acceptance_number,
       acceptanceDate: contractPlot.acceptance_date,
       staffInCharge: contractPlot.staff_in_charge,
@@ -123,11 +126,19 @@ export const getPlotById = async (
       uncollectedAmount: contractPlot.uncollected_amount,
       contractNotes: contractPlot.notes,
 
+      // レガシー由来の区分コード
+      graveKind: contractPlot.grave_kind,
+      graveKubun: contractPlot.grave_kubun,
+      graveType: contractPlot.grave_type,
+      legacyGraveCd: contractPlot.legacy_grave_cd,
+
       // 使用料情報
       usageFee: contractPlot.usageFee
         ? {
             calculationType: contractPlot.usageFee.calculation_type,
             taxType: contractPlot.usageFee.tax_type,
+            billingType: contractPlot.usageFee.billing_type,
+            billingYears: contractPlot.usageFee.billing_years,
             usageFee: contractPlot.usageFee.usage_fee,
             area: contractPlot.usageFee.area,
             unitPrice: contractPlot.usageFee.unit_price,
@@ -165,6 +176,10 @@ export const getPlotById = async (
         posthumousName: person.posthumous_name,
         reportDate: person.report_date,
         religion: person.religion,
+        deathPlace: person.death_place,
+        causeOfDeath: person.cause_of_death,
+        chiefMournerName: person.chief_mourner_name,
+        chiefMournerRelationship: person.chief_mourner_relationship,
         notes: person.notes,
       })),
 

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -16,6 +16,7 @@ interface PlotSearchQuery {
   status?: 'available' | 'partially_sold' | 'sold_out';
   cemeteryType?: string;
   paymentStatus?: 'unpaid' | 'partial_paid' | 'paid' | 'overdue' | 'refunded';
+  contractStatus?: 'active' | 'terminated';
   sortBy?:
     | 'plotNumber'
     | 'customerName'
@@ -94,6 +95,7 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
       status,
       cemeteryType,
       paymentStatus,
+      contractStatus,
       sortBy,
       sortOrder = 'asc',
       nameKanaPrefix,
@@ -171,6 +173,12 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
     // 入金ステータスフィルター
     if (paymentStatus) {
       whereCondition.payment_status = paymentStatus;
+    }
+
+    // 契約ステータスフィルター（#200）
+    // スキーマで active / terminated に限定済みのため、既定の vacant 除外と矛盾しない
+    if (contractStatus) {
+      whereCondition.contract_status = contractStatus;
     }
 
     // 区分フィルター（grave_kind / grave_kubun / grave_type）

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -39,6 +39,9 @@ export const plotSearchQuerySchema = paginationSchema.extend({
   paymentStatus: z
     .enum(['unpaid', 'partial_paid', 'paid', 'overdue', 'refunded', 'cancelled'])
     .optional(),
+  // 契約ステータスフィルター（#200）。台帳問い合わせは vacant 非表示（#167）のため
+  // active / terminated のみ許可する。vacant は在庫系エンドポイントで扱う。
+  contractStatus: z.enum(['active', 'terminated']).optional(),
   sortBy: z
     .enum([
       'plotNumber',

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -137,6 +137,12 @@ paths:
           description: 区画区分フィルタ（grave_type、レガシー tinyint 値）
           schema:
             type: integer
+        - name: contractStatus
+          in: query
+          description: 契約ステータスフィルタ（台帳問い合わせはvacant非表示のためactive/terminatedのみ指定可）
+          schema:
+            type: string
+            enum: [active, terminated]
       responses:
         "200":
           description: 取得成功

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -253,6 +253,40 @@ describe('Plot Controller (ContractPlot Model)', () => {
       );
     });
 
+    it('should filter by contractStatus when specified (#200)', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: '1', limit: '10', contractStatus: 'terminated' };
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.contractPlot.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contract_status: 'terminated',
+          }),
+        })
+      );
+    });
+
+    it('should exclude vacant plots by default (#167)', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: '1', limit: '10' };
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.contractPlot.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contract_status: { not: 'vacant' },
+          }),
+        })
+      );
+    });
+
     it('should calculate next billing date from last_billing_month', async () => {
       const mockContractPlots = [
         {
@@ -449,18 +483,25 @@ describe('Plot Controller (ContractPlot Model)', () => {
         deleted_at: null,
         contract_date: new Date('2024-01-01'),
         price: 1000000,
+        contract_status: 'active',
         payment_status: 'paid',
         reservation_date: null,
+        request_date: new Date('2023-12-01'),
         acceptance_number: null,
         permit_date: null,
         start_date: null,
         notes: null,
+        grave_kind: 1,
+        grave_kubun: 2,
+        grave_type: 3,
+        legacy_grave_cd: 101,
         physicalPlot: {
           id: 'pp1',
           plot_number: 'A-01',
           area_name: '一般墓地A',
           area_sqm: new Prisma.Decimal(3.6),
           status: 'sold_out',
+          map_id: 7,
           notes: null,
         },
         buriedPersons: [],
@@ -508,10 +549,24 @@ describe('Plot Controller (ContractPlot Model)', () => {
         })
       );
       expect(responseStatus).toHaveBeenCalledWith(200);
+      // PlotDetailResponse の必須フィールド欠落を回帰検知する（#199）
       expect(responseJson).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
-          data: expect.any(Object),
+          data: expect.objectContaining({
+            id: 'cp1',
+            contractStatus: 'active',
+            paymentStatus: 'paid',
+            requestDate: new Date('2023-12-01'),
+            graveKind: 1,
+            graveKubun: 2,
+            graveType: 3,
+            legacyGraveCd: 101,
+            physicalPlot: expect.objectContaining({
+              id: 'pp1',
+              mapId: 7,
+            }),
+          }),
         })
       );
     });

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -39,6 +39,19 @@ describe('Plot Validation (ContractPlot Model)', () => {
       expect(result.page).toBe(2);
       expect(result.limit).toBe(50);
     });
+
+    it('contractStatus に active / terminated を指定できること（#200）', () => {
+      expect(plotSearchQuerySchema.parse({ contractStatus: 'active' }).contractStatus).toBe(
+        'active'
+      );
+      expect(plotSearchQuerySchema.parse({ contractStatus: 'terminated' }).contractStatus).toBe(
+        'terminated'
+      );
+    });
+
+    it('contractStatus に vacant は指定できないこと（台帳問い合わせは vacant 非表示 #167）', () => {
+      expect(() => plotSearchQuerySchema.parse({ contractStatus: 'vacant' })).toThrow();
+    });
   });
 
   describe('plotIdParamsSchema', () => {


### PR DESCRIPTION
## 概要
バグ監査起票の2件（同根=plotコントローラの型不整合）をまとめて修正。

### #199: 区画詳細APIが contractStatus を返さない
`@komine/types` の `PlotDetailResponse` は `contractStatus` を必須定義しているが、`getPlotById` のレスポンスに含まれておらず、フロントで以下が壊れていた:
1. 「利用申込」ラベルが空表示（`CONTRACT_STATUS_LABELS[undefined]`）
2. `isVacant` 判定が常に false → 空き区画の契約欄が「対象外」にならない（#181の意図が詳細画面で無効化）
3. terminated 契約の「契約を復活」ボタンが常に非表示 → manager のリカバリ操作不能

**修正**: `PlotDetailResponse` と一括突き合わせ、以下を追加
- `contractStatus` / `requestDate` / `graveKind` / `graveKubun` / `graveType` / `legacyGraveCd`
- `physicalPlot.mapId`
- `usageFee.billingType` / `usageFee.billingYears`（issue指摘の軽微な型不整合）
- `buriedPersons[].deathPlace` / `causeOfDeath` / `chiefMournerName` / `chiefMournerRelationship`

### #200: 一覧の contractStatus 検索パラメータが無視される
`plotSearchQuerySchema` が `contractStatus` を除去し、`getPlots` も参照していなかった。

**修正**: 方針A（フィルタ実装）を採用。ただし `z.enum(['active','terminated'])` に限定し、台帳問い合わせの vacant 非表示（#167）の意図と矛盾しないようにした（vacant の絞り込みは在庫系の責務）。これにより業務判断待ちなしで実装可能。

## テスト
- `getPlotById` のレスポンス検証を `expect.any(Object)` → 必須フィールドの `objectContaining` に強化（再発防止・issue指示）
- `contractStatus` フィルタの where 反映 / vacant 既定除外のテスト追加
- スキーマの active/terminated 受理・vacant 拒否テスト追加
- 全891テストpass、`tsc --noEmit` clean、lint clean、swagger valid

## 残課題（スコープ外）
- frontend: 契約状態フィルタの UI（select）は未実装。backend が受け付けるようになったため、要件確定後に frontend 側で追加可能
- 実APIモード E2E（plot-detail.spec 5-1 / plot-list.spec 4-5）の回帰確認は frontend 側で実施推奨

Closes #199
Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)