### PR TITLE
fix(plots): 契約更新の roles 配列送信時に申込者ロールが消える問題を修正 (#201)

### DIFF
--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -205,10 +205,20 @@ export async function updatePlotCore(
 
   // 3. 顧客役割の更新
   if (input.saleContract?.roles !== undefined) {
+    // 申込者(applicant)ロールの正規管理経路はセクション6.5（input.applicant）。
+    // roles 配列には通常 contractor 系しか含まれないため、applicant を含まない
+    // roles を送られた場合に既存 applicant まで削除して消滅させない（#201）。
+    // roles に applicant が明示的に含まれる場合のみ従来どおり全件入替の対象にする。
+    const inputContainsApplicant = input.saleContract.roles.some(
+      (roleData) => roleData.role === ContractRole.applicant
+    );
+    const roleScope = inputContainsApplicant ? {} : { role: { not: ContractRole.applicant } };
+
     const existingRoles = await tx.saleContractRole.findMany({
       where: {
         contract_plot_id: id,
         deleted_at: null,
+        ...roleScope,
       },
     });
 
@@ -216,6 +226,7 @@ export async function updatePlotCore(
       where: {
         contract_plot_id: id,
         deleted_at: null,
+        ...roleScope,
       },
       data: {
         deleted_at: new Date(),

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -41,6 +41,7 @@ const mockPrisma: any = {
     create: jest.fn(),
     findMany: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
   },
   customer: {
     create: jest.fn(),
@@ -121,6 +122,7 @@ jest.mock('../../src/plots/services/historyService', () => ({
   recordEntityCreated: jest.fn(),
   recordEntityUpdated: jest.fn(),
   recordEntityDeleted: jest.fn(),
+  recordHistoryBatch: jest.fn(),
 }));
 
 import {
@@ -1194,6 +1196,131 @@ describe('Plot Controller (ContractPlot Model)', () => {
           data: expect.objectContaining({ deleted_at: expect.any(Date) }),
         })
       );
+    });
+
+    it('should preserve applicant role when roles array without applicant is sent (#201)', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+          {
+            id: 'scr2',
+            role: 'applicant',
+            customer: { id: 'c2', name: '山田花子' },
+            customer_id: 'c2',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.saleContractRole.findMany.mockResolvedValue([
+        {
+          id: 'scr1',
+          role: 'contractor',
+          customer_id: 'c1',
+        },
+      ]);
+      mockPrisma.saleContractRole.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.saleContractRole.create.mockResolvedValue({
+        id: 'scr3',
+        role: 'contractor',
+        customer_id: 'c3',
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        saleContract: {
+          roles: [{ role: 'contractor', customerId: 'c3' }],
+        },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // applicant を除外した削除・再作成になっていること
+      expect(mockPrisma.saleContractRole.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contract_plot_id: 'cp1',
+            deleted_at: null,
+            role: { not: 'applicant' },
+          }),
+        })
+      );
+      expect(mockPrisma.saleContractRole.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            role: { not: 'applicant' },
+          }),
+        })
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should replace all roles including applicant when roles array contains applicant (#201)', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.saleContractRole.findMany.mockResolvedValue([]);
+      mockPrisma.saleContractRole.updateMany.mockResolvedValue({ count: 0 });
+      mockPrisma.saleContractRole.create.mockResolvedValue({
+        id: 'scr2',
+        role: 'applicant',
+        customer_id: 'c2',
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        saleContract: {
+          roles: [
+            { role: 'contractor', customerId: 'c1' },
+            { role: 'applicant', customerId: 'c2' },
+          ],
+        },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // applicant を含む場合は従来どおり全件入替（role 条件なし）
+      expect(mockPrisma.saleContractRole.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            contract_plot_id: 'cp1',
+            deleted_at: null,
+          },
+        })
+      );
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledTimes(2);
+      expect(mockNext).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## 概要
PUT /plots/:id で `saleContract.roles=[{role:'contractor',...}]` のみ送信（applicant 未指定）すると、既存の applicant ロールがソフトデリートされたまま再作成されず黙って消滅するバグ（#201）の修正。

## 根因
updatePlot セクション3の delete/recreate が `contract_plot_id` + `deleted_at:null` の **全ロール** を対象にしていた。applicant の正規管理経路はセクション6.5（`input.applicant`）であり、roles 配列には通常 contractor 系しか含まれない。

## 修正
issue 修正方針(2)を採用:
- roles に applicant が**含まれない**場合 → findMany / updateMany の where に `role: { not: ContractRole.applicant }` を追加し applicant を温存
- roles に applicant が**含まれる**場合 → 従来どおり全件入替（後方互換維持）

## テスト
- 回帰テスト2件追加（applicant 温存 / applicant 込み全件入替）
- mock に `saleContractRole.updateMany` / `recordHistoryBatch` を補完（従来 roles 経路が未テストだった）
- 全889テストpass、tsc clean、lint clean

## 影響範囲
- 合祀の請求対象抽出（yuchoService.pickPayer）・合祀一覧の申込者表示の安定化

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
