### PR TITLE
fix(collective-burials): 年別統計にサーバ側の金額集計を追加

### DIFF
--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -608,6 +608,8 @@ export const getStatsByYear = async (
 ): Promise<void> => {
   try {
     // 請求予定年ごとの集計
+    // 金額（total_amount / paid_amount）もサーバ側で集計し、
+    // ページ制限された items の reduce による過少表示を防ぐ（frontend #226）。
     const stats = await prisma.$queryRaw<
       Array<{
         year: number;
@@ -615,6 +617,8 @@ export const getStatsByYear = async (
         pending_count: bigint;
         billed_count: bigint;
         paid_count: bigint;
+        total_amount: bigint;
+        paid_amount: bigint;
       }>
     >`
       SELECT
@@ -622,7 +626,9 @@ export const getStatsByYear = async (
         COUNT(*)::bigint as count,
         COUNT(CASE WHEN billing_status = 'pending' THEN 1 END)::bigint as pending_count,
         COUNT(CASE WHEN billing_status = 'billed' THEN 1 END)::bigint as billed_count,
-        COUNT(CASE WHEN billing_status = 'paid' THEN 1 END)::bigint as paid_count
+        COUNT(CASE WHEN billing_status = 'paid' THEN 1 END)::bigint as paid_count,
+        COALESCE(SUM(billing_amount), 0)::bigint as total_amount,
+        COALESCE(SUM(CASE WHEN billing_status = 'paid' THEN billing_amount END), 0)::bigint as paid_amount
       FROM collective_burials
       WHERE deleted_at IS NULL
         AND billing_scheduled_date IS NOT NULL
@@ -638,6 +644,8 @@ export const getStatsByYear = async (
         pendingCount: Number(s.pending_count),
         billedCount: Number(s.billed_count),
         paidCount: Number(s.paid_count),
+        totalAmount: Number(s.total_amount),
+        paidAmount: Number(s.paid_amount),
       })),
     });
   } catch (error) {

--- a/tests/collective-burials/collectiveBurialController.test.ts
+++ b/tests/collective-burials/collectiveBurialController.test.ts
@@ -21,6 +21,7 @@ const mockPrisma: any = {
     findFirst: jest.fn(),
     count: jest.fn(),
   },
+  $queryRaw: jest.fn(),
 };
 
 jest.mock('../../src/db/prisma', () => ({
@@ -36,6 +37,7 @@ jest.mock('@prisma/client', () => ({
 import {
   getCollectiveBurialList,
   getCollectiveBurialById,
+  getStatsByYear,
 } from '../../src/collective-burials/collectiveBurialController';
 
 describe('collectiveBurialController — 契約者名フォールバック (issue #50)', () => {
@@ -184,6 +186,117 @@ describe('collectiveBurialController — 契約者名フォールバック (issu
 
       const payload = responseJson.mock.calls[0][0];
       expect(payload.data.applicant.name).toBe('申込太郎');
+    });
+  });
+
+  describe('getStatsByYear — 金額集計 (frontend #226)', () => {
+    it('金額（totalAmount/paidAmount）をサーバ集計の値として返す', async () => {
+      // $queryRaw はサーバ側で集計済みの bigint を返す
+      mockPrisma.$queryRaw.mockResolvedValue([
+        {
+          year: 2027,
+          count: 100n,
+          pending_count: 60n,
+          billed_count: 25n,
+          paid_count: 15n,
+          total_amount: 5000000n,
+          paid_amount: 1200000n,
+        },
+      ]);
+
+      await getStatsByYear(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.success).toBe(true);
+      const row = payload.data[0];
+      // 件数は既存どおり
+      expect(row.year).toBe(2027);
+      expect(row.count).toBe(100);
+      expect(row.pendingCount).toBe(60);
+      expect(row.billedCount).toBe(25);
+      expect(row.paidCount).toBe(15);
+      // 金額は bigint → number に変換して返す
+      expect(row.totalAmount).toBe(5000000);
+      expect(row.paidAmount).toBe(1200000);
+      expect(typeof row.totalAmount).toBe('number');
+      expect(typeof row.paidAmount).toBe('number');
+    });
+
+    it('集計が0件（金額がCOALESCEで0）の場合も number 0 を返す', async () => {
+      mockPrisma.$queryRaw.mockResolvedValue([
+        {
+          year: 2028,
+          count: 3n,
+          pending_count: 3n,
+          billed_count: 0n,
+          paid_count: 0n,
+          total_amount: 0n,
+          paid_amount: 0n,
+        },
+      ]);
+
+      await getStatsByYear(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const row = responseJson.mock.calls[0][0].data[0];
+      expect(row.totalAmount).toBe(0);
+      expect(row.paidAmount).toBe(0);
+    });
+
+    it('複数年でもそれぞれ金額を集計して返す', async () => {
+      mockPrisma.$queryRaw.mockResolvedValue([
+        {
+          year: 2027,
+          count: 2n,
+          pending_count: 2n,
+          billed_count: 0n,
+          paid_count: 0n,
+          total_amount: 200000n,
+          paid_amount: 0n,
+        },
+        {
+          year: 2028,
+          count: 1n,
+          pending_count: 0n,
+          billed_count: 0n,
+          paid_count: 1n,
+          total_amount: 300000n,
+          paid_amount: 300000n,
+        },
+      ]);
+
+      await getStatsByYear(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      const data = responseJson.mock.calls[0][0].data;
+      expect(data).toHaveLength(2);
+      expect(data[0].totalAmount).toBe(200000);
+      expect(data[0].paidAmount).toBe(0);
+      expect(data[1].totalAmount).toBe(300000);
+      expect(data[1].paidAmount).toBe(300000);
+    });
+
+    it('クエリエラー時は next に渡す', async () => {
+      const error = new Error('db error');
+      mockPrisma.$queryRaw.mockRejectedValue(error);
+
+      await getStatsByYear(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext as NextFunction
+      );
+
+      expect(mockNext).toHaveBeenCalledWith(error);
     });
   });
 });


### PR DESCRIPTION
## 概要

合祀一覧（frontend）の当年サマリーで、件数はサーバ集計（`getStatsByYear`）だが、金額（請求総額/入金済/未収）はページ制限された `items`（先頭50件）の `reduce` で算出していたため、**50件超で過少表示**になっていた。

backend 側の `getStatsByYear` でサーバ集計するよう金額集計列を追加して根本対応する。

## 変更内容

`src/collective-burials/collectiveBurialController.ts` の `getStatsByYear` の生SQLに金額集計列を追加:

- `COALESCE(SUM(billing_amount), 0)::bigint AS total_amount`
- `COALESCE(SUM(CASE WHEN billing_status = 'paid' THEN billing_amount END), 0)::bigint AS paid_amount`

レスポンスの各行に `totalAmount` / `paidAmount` を `number` で追加（既存の `count` と同じく `Number()` で BigInt→Number 変換）。

- 既存のレスポンス形状・フィールド（`year`/`count`/`pendingCount`/`billedCount`/`paidCount`）は変更なし、**後方互換の追加のみ**。
- 既存の `WHERE deleted_at IS NULL AND billing_scheduled_date IS NOT NULL` はそのまま維持。

### レスポンス形状（frontend 実装用）

```jsonc
{
  "success": true,
  "data": [
    {
      "year": 2027,
      "count": 100,
      "pendingCount": 60,
      "billedCount": 25,
      "paidCount": 15,
      "totalAmount": 5000000,  // 追加: その年の請求金額合計（円）
      "paidAmount": 1200000    // 追加: その年の入金済（paid）請求金額合計（円）
    }
  ]
}
```

- `totalAmount` = その年（請求予定年）の `billing_amount` 合計
- `paidAmount` = うち `billing_status = 'paid'` の `billing_amount` 合計
- 未収は frontend 側で `totalAmount - paidAmount` 等で導出可能（本PRでは値追加に留める）

## frontend 側

frontend 側（`YearlyStats` 型への `totalAmount`/`paidAmount` 追加 + ListView の `statsRow` 優先化）は**別途メインエージェントが対応**します。

## テスト

`tests/collective-burials/collectiveBurialController.test.ts` に `getStatsByYear` の金額集計テストを追加:
- 金額（totalAmount/paidAmount）を bigint→number に変換して返す
- COALESCE で 0 のケース
- 複数年集計
- クエリエラー時は `next` に渡す

全 891 テスト pass、`tsc --noEmit` clean、`npm run lint` clean。

Refs zaitsu82/komine-crm-frontend#226

🤖 Generated with [Claude Code](https://claude.com/claude-code)