### PR TITLE
fix(masters): 区画名マスタ作成時の period 必須バリデーションを追加

### DIFF
--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -3,6 +3,7 @@ import prisma from '../db/prisma';
 import { getRequestLogger } from '../utils/logger';
 import {
   createMasterSchema,
+  createSectionNameMasterSchema,
   updateMasterSchema,
   isValidMasterType,
   MasterType,
@@ -551,7 +552,10 @@ export const createMaster = async (req: Request, res: Response): Promise<void> =
     return;
   }
 
-  const parsed = createMasterSchema.safeParse(req.body);
+  // section-name は period が NOT NULL のため作成時のみ専用スキーマで必須チェックし、
+  // 欠落時に 500 ではなく details 付きの 400 VALIDATION_ERROR を返す。
+  const schema = masterType === 'section-name' ? createSectionNameMasterSchema : createMasterSchema;
+  const parsed = schema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({
       success: false,

--- a/src/validations/masterValidation.ts
+++ b/src/validations/masterValidation.ts
@@ -10,6 +10,16 @@ export const createMasterSchema = z.object({
   period: z.string().min(1).max(20).optional(),
 });
 
+/**
+ * 区画名（section-name）マスタ作成専用スキーマ。
+ * schema.prisma 上 section_name_master.period は NOT NULL のため、
+ * 共通スキーマ（period 任意）のままだと未指定で Prisma の NOT NULL 違反になり
+ * 一律 500 になってしまう。作成時のみ period を必須にして 400 VALIDATION_ERROR を返す。
+ */
+export const createSectionNameMasterSchema = createMasterSchema.extend({
+  period: z.string().min(1, '期は必須です').max(20, '期は20文字以内で入力してください'),
+});
+
 export const updateMasterSchema = z.object({
   code: z
     .string()
@@ -29,6 +39,7 @@ export const updateMasterSchema = z.object({
 });
 
 export type CreateMasterInput = z.infer<typeof createMasterSchema>;
+export type CreateSectionNameMasterInput = z.infer<typeof createSectionNameMasterSchema>;
 export type UpdateMasterInput = z.infer<typeof updateMasterSchema>;
 
 export const VALID_MASTER_TYPES = [

--- a/tests/masters/masterCrud.test.ts
+++ b/tests/masters/masterCrud.test.ts
@@ -238,6 +238,87 @@ describe('Master CRUD Controller', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(500);
     });
+
+    describe('区画名マスタ（section-name）の period 必須バリデーション', () => {
+      it('period 無しで作成しようとすると 400 VALIDATION_ERROR（details に period）を返すこと', async () => {
+        mockRequest.params = { masterType: 'section-name' };
+        mockRequest.body = { code: '1ki', name: '1期' };
+
+        await createMaster(mockRequest as Request, mockResponse as Response);
+
+        // Prisma NOT NULL 違反による 500 ではなく、明示的な 400 を返す
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        const jsonCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+        expect(jsonCall.error.code).toBe('VALIDATION_ERROR');
+        expect(jsonCall.error.details.some((d: { field?: string }) => d.field === 'period')).toBe(
+          true
+        );
+        // バリデーション段階で弾くため create は呼ばれない
+        expect(mockPrisma.sectionNameMaster.create).not.toHaveBeenCalled();
+      });
+
+      it('空文字の period では 400 VALIDATION_ERROR を返すこと', async () => {
+        mockRequest.params = { masterType: 'section-name' };
+        mockRequest.body = { code: '1ki', name: '1期', period: '' };
+
+        await createMaster(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        const jsonCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+        expect(jsonCall.error.code).toBe('VALIDATION_ERROR');
+        expect(jsonCall.error.details.some((d: { field?: string }) => d.field === 'period')).toBe(
+          true
+        );
+        expect(mockPrisma.sectionNameMaster.create).not.toHaveBeenCalled();
+      });
+
+      it('period ありで作成できること', async () => {
+        mockRequest.params = { masterType: 'section-name' };
+        mockRequest.body = { code: '1ki', name: '1期', period: '1期' };
+
+        mockPrisma.sectionNameMaster.create.mockResolvedValue({
+          id: 1,
+          code: '1ki',
+          name: '1期',
+          description: null,
+          sort_order: null,
+          is_active: true,
+          period: '1期',
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+
+        await createMaster(mockRequest as Request, mockResponse as Response);
+
+        expect(mockPrisma.sectionNameMaster.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({ period: '1期' }),
+        });
+        expect(mockResponse.status).toHaveBeenCalledWith(201);
+        const jsonCall = (mockResponse.json as jest.Mock).mock.calls[0][0];
+        expect(jsonCall.data.period).toBe('1期');
+      });
+
+      it('section-name 以外のマスタは period 無しでも作成できること', async () => {
+        mockRequest.params = { masterType: 'relationship' };
+        mockRequest.body = { code: 'parent', name: '親' };
+
+        mockPrisma.relationshipMaster.create.mockResolvedValue({
+          id: 1,
+          code: 'parent',
+          name: '親',
+          description: null,
+          sort_order: null,
+          is_active: true,
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+
+        await createMaster(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(201);
+        expect(mockPrisma.relationshipMaster.create).toHaveBeenCalled();
+      });
+    });
   });
 
   describe('updateMaster', () => {


### PR DESCRIPTION
## 概要

`schema.prisma` 上、`section_name_master.period` は **NOT NULL** だが、`masterValidation.ts` の共通スキーマ（`createMasterSchema`）は `period` を全 `masterType` 共通で `.optional()` にしていた。

そのため section-name 作成時に `period` 欠落だと **Prisma の NOT NULL 違反** → `catch` で一律 **500「区画名マスタの作成に失敗しました」** になり、原因がユーザーに伝わらなかった。

issue の**修正方針3**を採用し、section-name 作成時のみ `period` を必須化して `details` 付きの **400 VALIDATION_ERROR** を返すようにする。

## 変更内容

- `src/validations/masterValidation.ts`
  - `createSectionNameMasterSchema = createMasterSchema.extend({ period: z.string().min(1, '期は必須です').max(20) })` を追加
  - `CreateSectionNameMasterInput` 型も export
- `src/masters/masterController.ts`
  - `createMaster` 内で `masterType === 'section-name'` のとき専用スキーマで `safeParse` するよう分岐
  - これにより `period` 欠落・空文字は **500 ではなく 400 VALIDATION_ERROR**（`details` に `period`）で返る
- `updateMaster` は部分更新のため必須化せず**既存挙動を維持**

## frontend 側

frontend 側の即弾き（フォーム側バリデーション）は **frontend PR #236 で対応済み**。

## テスト

`tests/masters/masterCrud.test.ts` に以下を追加:
- section-name を `period` 無しで作成 → 400 VALIDATION_ERROR（`details` に `period`）、`create` は未呼び出し
- `period` 空文字 → 400 VALIDATION_ERROR
- `period` ありで作成 → 201 成功
- section-name 以外（relationship）は `period` 無しでも 201 で作成可

全 891 テスト pass、`tsc --noEmit` clean、`npm run lint` clean。

Refs zaitsu82/komine-crm-frontend#227

🤖 Generated with [Claude Code](https://claude.com/claude-code)