### PR TITLE
fix(collective-burials): 再作成不可・日付残存・削除済み役割ヒットを修正 (#202, #203, #206)

### DIFF
--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -6,6 +6,7 @@ import { Request, Response, NextFunction } from 'express';
 import { BillingStatus } from '@prisma/client';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
 import prisma from '../db/prisma';
+import { updateCollectiveBurialCount } from './utils';
 
 /** リクエストボディの型（Express の req.body は any のため、境界で明示的に型付けする） */
 interface CreateCollectiveBurialBody {
@@ -87,6 +88,8 @@ export const getCollectiveBurialList = async (
           {
             saleContractRoles: {
               some: {
+                // 論理削除済みの旧役割（解約・差し替えで外れた顧客）を検索対象から除外（#206）
+                deleted_at: null,
                 customer: {
                   OR: [
                     { name: { contains: search as string, mode: 'insensitive' } },
@@ -301,32 +304,51 @@ export const createCollectiveBurial = async (
     // 契約区画の存在確認
     const contractPlot = await prisma.contractPlot.findFirst({
       where: { id: contractPlotId, deleted_at: null },
-      include: {
-        collectiveBurial: true,
-      },
     });
 
     if (!contractPlot) {
       throw new NotFoundError('契約区画が見つかりません');
     }
 
-    // 既存の合祀情報がないか確認
-    if (contractPlot.collectiveBurial) {
+    // 既存の合祀情報の確認
+    // contract_plot_id は deleted_at を含まない単独 @unique のため、
+    // ソフトデリート済みの行が残っていると create が P2002 になる（#202）。
+    // 生きている行のみ重複エラーとし、ソフトデリート済み行は復活させる。
+    const existingCollectiveBurial = await prisma.collectiveBurial.findUnique({
+      where: { contract_plot_id: contractPlotId },
+    });
+
+    if (existingCollectiveBurial && !existingCollectiveBurial.deleted_at) {
       throw new ValidationError('この契約区画には既に合祀情報が登録されています');
     }
 
-    // 合祀情報作成
-    const collectiveBurial = await prisma.collectiveBurial.create({
-      data: {
-        contract_plot_id: contractPlotId,
-        burial_capacity: burialCapacity,
-        current_burial_count: 0,
-        validity_period_years: validityPeriodYears,
-        billing_status: 'pending',
-        billing_amount: billingAmount || null,
-        notes: notes || null,
-      },
-    });
+    // 合祀情報作成（ソフトデリート済み行があれば新規値で復活させる）
+    const collectiveBurial = existingCollectiveBurial
+      ? await prisma.collectiveBurial.update({
+          where: { id: existingCollectiveBurial.id },
+          data: {
+            burial_capacity: burialCapacity,
+            current_burial_count: 0,
+            validity_period_years: validityPeriodYears,
+            capacity_reached_date: null,
+            billing_scheduled_date: null,
+            billing_status: 'pending',
+            billing_amount: billingAmount || null,
+            notes: notes || null,
+            deleted_at: null,
+          },
+        })
+      : await prisma.collectiveBurial.create({
+          data: {
+            contract_plot_id: contractPlotId,
+            burial_capacity: burialCapacity,
+            current_burial_count: 0,
+            validity_period_years: validityPeriodYears,
+            billing_status: 'pending',
+            billing_amount: billingAmount || null,
+            notes: notes || null,
+          },
+        });
 
     res.status(201).json({
       success: true,
@@ -543,44 +565,22 @@ export const syncBurialCount = async (
     // 合祀情報取得
     const collectiveBurial = await prisma.collectiveBurial.findFirst({
       where: { id, deleted_at: null },
-      include: {
-        contractPlot: {
-          include: {
-            buriedPersons: {
-              where: { deleted_at: null },
-            },
-          },
-        },
-      },
     });
 
     if (!collectiveBurial) {
       throw new NotFoundError('合祀情報が見つかりません');
     }
 
-    const newCount = collectiveBurial.contractPlot.buriedPersons.length;
-    const capacityReached = newCount >= collectiveBurial.burial_capacity;
+    // 集計・上限判定・日付セット/リセットは utils の単一実装へ委譲する（#203）。
+    // 旧実装は上限到達時のセットのみで、人数が上限を下回った際に
+    // capacity_reached_date / billing_scheduled_date をリセットせず、
+    // ゆうちょ請求対象抽出（billing_scheduled_date ベース）に誤って載っていた。
+    const updated = await updateCollectiveBurialCount(prisma, collectiveBurial.contract_plot_id);
 
-    // 更新データ
-    const updateData: Record<string, unknown> = {
-      current_burial_count: newCount,
-    };
-
-    // 上限到達時の処理
-    if (capacityReached && !collectiveBurial.capacity_reached_date) {
-      const now = new Date();
-      updateData['capacity_reached_date'] = now;
-      // 請求予定日を計算（上限到達日 + 有効期間）
-      const billingDate = new Date(now);
-      billingDate.setFullYear(billingDate.getFullYear() + collectiveBurial.validity_period_years);
-      updateData['billing_scheduled_date'] = billingDate;
+    if (!updated) {
+      // 直前に存在確認済みのため通常到達しない（競合削除時の保険）
+      throw new NotFoundError('合祀情報が見つかりません');
     }
-
-    // 更新
-    const updated = await prisma.collectiveBurial.update({
-      where: { id },
-      data: updateData,
-    });
 
     res.status(200).json({
       success: true,
@@ -588,7 +588,7 @@ export const syncBurialCount = async (
         id: updated.id,
         currentBurialCount: updated.current_burial_count,
         burialCapacity: updated.burial_capacity,
-        capacityReached,
+        capacityReached: updated.current_burial_count >= updated.burial_capacity,
         capacityReachedDate: updated.capacity_reached_date?.toISOString().split('T')[0] || null,
         billingScheduledDate: updated.billing_scheduled_date?.toISOString().split('T')[0] || null,
       },

--- a/tests/collective-burials/collectiveBurialFixes.test.ts
+++ b/tests/collective-burials/collectiveBurialFixes.test.ts
@@ -1,0 +1,269 @@
+/**
+ * 合祀バグ修正の回帰テスト
+ * - #202: ソフトデリート後の同一区画での再作成
+ * - #203: syncBurialCount の上限割れ時の日付リセット（utils 実装へ委譲）
+ * - #206: 一覧検索で論理削除済み役割の顧客名を除外
+ */
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma: any = {
+  collectiveBurial: {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    count: jest.fn(),
+  },
+  contractPlot: {
+    findFirst: jest.fn(),
+  },
+  buriedPerson: {
+    count: jest.fn(),
+  },
+};
+
+jest.mock('../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+jest.mock('@prisma/client', () => ({
+  BillingStatus: { pending: 'pending', billed: 'billed', paid: 'paid' },
+  PrismaClient: jest.fn(),
+}));
+
+import {
+  createCollectiveBurial,
+  syncBurialCount,
+  getCollectiveBurialList,
+} from '../../src/collective-burials/collectiveBurialController';
+import { ValidationError } from '../../src/middleware/errorHandler';
+
+const CB_ROW = {
+  id: 'cb1',
+  contract_plot_id: 'cp1',
+  burial_capacity: 10,
+  current_burial_count: 0,
+  capacity_reached_date: null,
+  validity_period_years: 33,
+  billing_scheduled_date: null,
+  billing_status: 'pending',
+  billing_amount: null,
+  notes: null,
+  deleted_at: null,
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-01'),
+};
+
+describe('collectiveBurialController — バグ修正回帰', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseJson: jest.Mock;
+  let responseStatus: jest.Mock;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    responseJson = jest.fn().mockReturnThis();
+    responseStatus = jest.fn().mockReturnThis();
+    mockResponse = { status: responseStatus, json: responseJson };
+    mockNext = jest.fn();
+    mockRequest = { params: {}, body: {}, query: {} };
+  });
+
+  describe('createCollectiveBurial (#202)', () => {
+    const validBody = {
+      contractPlotId: 'cp1',
+      burialCapacity: 10,
+      validityPeriodYears: 33,
+    };
+
+    it('生きている合祀が既に存在する場合は ValidationError', async () => {
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: 'cp1' });
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue({ ...CB_ROW, deleted_at: null });
+
+      mockRequest.body = validBody;
+      await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(ValidationError));
+      expect(mockPrisma.collectiveBurial.create).not.toHaveBeenCalled();
+      expect(mockPrisma.collectiveBurial.update).not.toHaveBeenCalled();
+    });
+
+    it('ソフトデリート済みの合祀が残っている場合は新規値で復活させる（P2002回避）', async () => {
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: 'cp1' });
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue({
+        ...CB_ROW,
+        current_burial_count: 5,
+        capacity_reached_date: new Date('2025-01-01'),
+        billing_scheduled_date: new Date('2058-01-01'),
+        billing_status: 'billed',
+        deleted_at: new Date('2026-05-01'),
+      });
+      mockPrisma.collectiveBurial.update.mockResolvedValue({
+        ...CB_ROW,
+        burial_capacity: 20,
+        validity_period_years: 30,
+      });
+
+      mockRequest.body = { ...validBody, burialCapacity: 20, validityPeriodYears: 30 };
+      await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.create).not.toHaveBeenCalled();
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledWith({
+        where: { id: 'cb1' },
+        data: expect.objectContaining({
+          burial_capacity: 20,
+          current_burial_count: 0,
+          validity_period_years: 30,
+          capacity_reached_date: null,
+          billing_scheduled_date: null,
+          billing_status: 'pending',
+          deleted_at: null,
+        }),
+      });
+      expect(responseStatus).toHaveBeenCalledWith(201);
+    });
+
+    it('既存が無ければ従来どおり create する', async () => {
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: 'cp1' });
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue(null);
+      mockPrisma.collectiveBurial.create.mockResolvedValue(CB_ROW);
+
+      mockRequest.body = validBody;
+      await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          contract_plot_id: 'cp1',
+          burial_capacity: 10,
+        }),
+      });
+      expect(responseStatus).toHaveBeenCalledWith(201);
+    });
+  });
+
+  describe('syncBurialCount (#203)', () => {
+    it('上限到達後に人数が減ったら上限到達日・請求予定日がリセットされる', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue({
+        ...CB_ROW,
+        current_burial_count: 10,
+        capacity_reached_date: new Date('2025-01-01'),
+        billing_scheduled_date: new Date('2058-01-01'),
+      });
+      // updateCollectiveBurialCount（utils）内の取得
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue({
+        ...CB_ROW,
+        current_burial_count: 10,
+        capacity_reached_date: new Date('2025-01-01'),
+        billing_scheduled_date: new Date('2058-01-01'),
+      });
+      mockPrisma.buriedPerson.count.mockResolvedValue(9); // 上限(10)を下回った
+      mockPrisma.collectiveBurial.update.mockResolvedValue({
+        ...CB_ROW,
+        current_burial_count: 9,
+        capacity_reached_date: null,
+        billing_scheduled_date: null,
+      });
+
+      mockRequest.params = { id: 'cb1' };
+      await syncBurialCount(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            current_burial_count: 9,
+            capacity_reached_date: null,
+            billing_scheduled_date: null,
+          }),
+        })
+      );
+      expect(responseJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            currentBurialCount: 9,
+            capacityReached: false,
+            capacityReachedDate: null,
+            billingScheduledDate: null,
+          }),
+        })
+      );
+    });
+
+    it('上限到達（初回）で上限到達日・請求予定日がセットされる', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue(CB_ROW);
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue(CB_ROW);
+      mockPrisma.buriedPerson.count.mockResolvedValue(10);
+      mockPrisma.collectiveBurial.update.mockResolvedValue({
+        ...CB_ROW,
+        current_burial_count: 10,
+        capacity_reached_date: new Date('2026-06-05'),
+        billing_scheduled_date: new Date('2059-06-05'),
+      });
+
+      mockRequest.params = { id: 'cb1' };
+      await syncBurialCount(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            current_burial_count: 10,
+            capacity_reached_date: expect.any(Date),
+            billing_scheduled_date: expect.any(Date),
+          }),
+        })
+      );
+      expect(responseJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ capacityReached: true }),
+        })
+      );
+    });
+  });
+
+  describe('getCollectiveBurialList 検索 (#206)', () => {
+    it('顧客名検索の some 句に deleted_at: null が付与される', async () => {
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+      mockPrisma.collectiveBurial.count.mockResolvedValue(0);
+
+      mockRequest.query = { search: '山田' };
+      await getCollectiveBurialList(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            contractPlot: expect.objectContaining({
+              OR: expect.arrayContaining([
+                expect.objectContaining({
+                  saleContractRoles: {
+                    some: expect.objectContaining({
+                      deleted_at: null,
+                    }),
+                  },
+                }),
+              ]),
+            }),
+          }),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 概要
バグ監査起票の合祀系3件（同モジュール同根）をまとめて修正。

### #202: ソフトデリート後に同一区画で合祀を再作成できない
- 重複チェックが `include:{collectiveBurial:true}`（deleted_atフィルタ無し）の真偽判定だったため、ソフトデリート済みの行でも「既に登録されています」で弾かれていた
- 修正: 生きている行のみ重複エラーとし、ソフトデリート済み行は **新規値で復活**（`current_burial_count: 0` / `billing_status: 'pending'` / 上限到達日・請求予定日リセット / `deleted_at: null`）。`contract_plot_id` 単独 `@unique` 制約による P2002 も回避（issue修正方針(1)(2)を採用、schema変更なし）

### #203: syncBurialCount が人数減少時に日付をリセットしない
- utils の `updateCollectiveBurialCount` はリセットするが、controller の `syncBurialCount` は上限到達時のセットのみで実装が乖離
- 修正: issue推奨の**根本対処（実装一本化）**を採用し、`syncBurialCount` の集計ロジックを撤廃して `updateCollectiveBurialCount` へ委譲。埋葬取消後の再syncで `billing_scheduled_date` が残存し、ゆうちょ請求対象抽出に誤って載る問題を解消

### #206: 合祀一覧検索で論理削除済み役割の旧顧客名がヒット
- 検索の `saleContractRoles.some` に `deleted_at: null` を追加し、表示用 include（deleted_at:null絞り込み済み）と検索対象を一致させた

## テスト
- 回帰テスト6件追加（`tests/collective-burials/collectiveBurialFixes.test.ts`）
  - #202: 生存行で409相当 / ソフトデリート行の復活（リセット内容検証）/ 新規create
  - #203: 上限割れで日付リセット / 上限到達で日付セット
  - #206: 検索someへの deleted_at:null 付与
- 全893テストpass、tsc clean、lint clean

Closes #202
Closes #203
Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
