### PR TITLE
fix(staff): 論理削除済みメールの重複検知と最後のadmin保護を追加 (#204, #208)

### DIFF
--- a/src/staff/staffController.ts
+++ b/src/staff/staffController.ts
@@ -33,6 +33,28 @@ interface StaffDetail extends StaffListItem {
 }
 
 /**
+ * 最後の有効な admin を失う操作（降格・無効化・削除）を防ぐ（#208）。
+ * admin が0人になると staff 管理・マスタ更新等の admin 専用操作が全て不能になり、
+ * 復旧に bootstrap script の実行が必要になるため、対象スタッフを除いて
+ * is_active な admin が存在しない場合は操作を拒否する。
+ */
+const assertNotLastActiveAdmin = async (staffId: number, operationLabel: string): Promise<void> => {
+  const otherActiveAdmins = await prisma.staff.count({
+    where: {
+      role: 'admin',
+      is_active: true,
+      deleted_at: null,
+      id: { not: staffId },
+    },
+  });
+  if (otherActiveAdmins === 0) {
+    throw new ValidationError(
+      `最後の有効な管理者のため${operationLabel}できません。先に別のスタッフへ管理者権限を付与してください`
+    );
+  }
+};
+
+/**
  * スタッフ一覧取得
  * GET /staff
  */
@@ -172,14 +194,21 @@ export const createStaff = async (
     const normalizedEmail = email.trim().toLowerCase();
 
     // メールアドレスの重複チェック
+    // Staff.email は deleted_at を含まない DB レベルの @unique 制約のため、
+    // 論理削除済みスタッフのメールでも create が P2002 になる（#204）。
+    // 削除済みヒットは P2002 に当たる前に専用メッセージで弾く。
     const existingStaff = await prisma.staff.findFirst({
       where: {
         email: normalizedEmail,
-        deleted_at: null,
       },
     });
 
     if (existingStaff) {
+      if (existingStaff.deleted_at) {
+        throw new ConflictError(
+          'このメールアドレスは過去に削除されたスタッフで使用されています。別のメールアドレスを使用してください'
+        );
+      }
       throw new ConflictError('このメールアドレスは既に使用されています');
     }
 
@@ -381,17 +410,29 @@ export const updateStaff = async (
     };
     const normalizedEmail = email ? email.trim().toLowerCase() : undefined;
 
+    // 最後の有効な admin の降格・無効化を防ぐ（#208）
+    const demoting = role !== undefined && ['viewer', 'operator', 'manager'].includes(role);
+    const deactivating = isActive === false;
+    if (existingStaff.role === 'admin' && existingStaff.is_active && (demoting || deactivating)) {
+      await assertNotLastActiveAdmin(staffId, demoting ? '権限を変更' : '無効化');
+    }
+
     // メールアドレスの重複チェック
     if (normalizedEmail && normalizedEmail !== existingStaff.email) {
       const emailExists = await prisma.staff.findFirst({
         where: {
           email: normalizedEmail,
           id: { not: staffId },
-          deleted_at: null,
         },
       });
 
       if (emailExists) {
+        // 論理削除済みでも email @unique（deleted_at 非考慮）に当たるため弾く（#204 と同根）
+        if (emailExists.deleted_at) {
+          throw new ConflictError(
+            'このメールアドレスは過去に削除されたスタッフで使用されています。別のメールアドレスを使用してください'
+          );
+        }
         throw new ConflictError('このメールアドレスは既に使用されています');
       }
 
@@ -491,6 +532,12 @@ export const deleteStaff = async (
       throw new ValidationError('自分自身を削除することはできません');
     }
 
+    // 最後の有効な admin の削除を防ぐ（#208）
+    // Supabase アカウント削除より前に判定する（認証アカウントだけ消える事故を防ぐ）
+    if (existingStaff.role === 'admin' && existingStaff.is_active) {
+      await assertNotLastActiveAdmin(staffId, '削除');
+    }
+
     let supabaseDeleted = false;
 
     // Supabaseユーザーの削除（pending_で始まる仮UIDは除外）
@@ -561,6 +608,11 @@ export const toggleStaffActive = async (
     // 自分自身を無効化しようとしていないかチェック
     if (req.user && req.user.id === staffId && existingStaff.is_active) {
       throw new ValidationError('自分自身を無効化することはできません');
+    }
+
+    // 最後の有効な admin の無効化を防ぐ（#208）
+    if (existingStaff.role === 'admin' && existingStaff.is_active) {
+      await assertNotLastActiveAdmin(staffId, '無効化');
     }
 
     // 有効/無効を切り替え

--- a/tests/staff/staffController.test.ts
+++ b/tests/staff/staffController.test.ts
@@ -236,6 +236,29 @@ describe('Staff Controller', () => {
         expect(error.message).toBe('このメールアドレスは既に使用されています');
       });
 
+      it('論理削除済みスタッフのメールの場合、P2002前に専用メッセージで弾く (#204)', async () => {
+        mockRequest.body = {
+          name: 'Test Staff',
+          email: 'deleted@example.com',
+          role: 'viewer',
+        };
+
+        mockPrisma.staff.findFirst.mockResolvedValue({
+          id: 9,
+          email: 'deleted@example.com',
+          deleted_at: new Date('2026-01-01'),
+        });
+
+        await createStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('過去に削除されたスタッフ');
+        // Supabase 招待や create（P2002の発生源）まで到達しないこと
+        expect(mockSupabaseAdminAuth.inviteUserByEmail).not.toHaveBeenCalled();
+        expect(mockPrisma.staff.create).not.toHaveBeenCalled();
+      });
+
       it('Supabaseアカウント作成に失敗した場合、エラーを返す', async () => {
         mockRequest.body = {
           name: 'Test Staff',
@@ -382,6 +405,30 @@ describe('Staff Controller', () => {
         );
       });
 
+      it('最後の有効なadminの削除はValidationErrorになる (#208)', async () => {
+        mockRequest.params = { id: '2' };
+        mockRequest.query = {};
+
+        mockPrisma.staff.findFirst.mockResolvedValue({
+          id: 2,
+          name: 'Last Admin',
+          email: 'lastadmin@example.com',
+          role: 'admin',
+          is_active: true,
+          supabase_uid: 'last-admin-uid',
+        });
+        mockPrisma.staff.count.mockResolvedValue(0); // 他に有効なadminなし
+
+        await deleteStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('最後の有効な管理者');
+        // Supabase アカウント削除・論理削除まで到達しないこと
+        expect(mockSupabaseAdminAuth.deleteUser).not.toHaveBeenCalled();
+        expect(mockPrisma.staff.update).not.toHaveBeenCalled();
+      });
+
       it('deleteSupabaseAccount=falseの場合、Supabaseユーザーを削除しない', async () => {
         mockRequest.params = { id: '2' };
         mockRequest.query = { deleteSupabaseAccount: 'false' };
@@ -509,6 +556,87 @@ describe('Staff Controller', () => {
             success: true,
           })
         );
+      });
+
+      it('最後の有効なadminの降格はValidationErrorになる (#208)', async () => {
+        mockRequest.params = { id: '1' };
+        mockRequest.body = { role: 'viewer' };
+
+        mockPrisma.staff.findFirst.mockResolvedValue({
+          id: 1,
+          name: 'Admin',
+          email: 'admin@example.com',
+          role: 'admin',
+          is_active: true,
+          supabase_uid: 'admin-uid',
+        });
+        mockPrisma.staff.count.mockResolvedValue(0); // 他に有効なadminなし
+
+        await updateStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockPrisma.staff.count).toHaveBeenCalledWith({
+          where: {
+            role: 'admin',
+            is_active: true,
+            deleted_at: null,
+            id: { not: 1 },
+          },
+        });
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('最後の有効な管理者');
+        expect(mockPrisma.staff.update).not.toHaveBeenCalled();
+      });
+
+      it('最後の有効なadminの無効化(isActive=false)はValidationErrorになる (#208)', async () => {
+        mockRequest.params = { id: '1' };
+        mockRequest.body = { isActive: false };
+
+        mockPrisma.staff.findFirst.mockResolvedValue({
+          id: 1,
+          name: 'Admin',
+          email: 'admin@example.com',
+          role: 'admin',
+          is_active: true,
+          supabase_uid: 'admin-uid',
+        });
+        mockPrisma.staff.count.mockResolvedValue(0);
+
+        await updateStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('最後の有効な管理者');
+        expect(mockPrisma.staff.update).not.toHaveBeenCalled();
+      });
+
+      it('他に有効なadminがいればadminの降格は成功する (#208)', async () => {
+        mockRequest.params = { id: '1' };
+        mockRequest.body = { role: 'viewer' };
+
+        const mockExistingStaff = {
+          id: 1,
+          name: 'Admin',
+          email: 'admin@example.com',
+          role: 'admin',
+          is_active: true,
+          supabase_uid: 'admin-uid',
+          last_login_at: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        };
+        mockPrisma.staff.findFirst.mockResolvedValue(mockExistingStaff);
+        mockPrisma.staff.count.mockResolvedValue(1); // 他に有効なadminあり
+        mockPrisma.staff.update.mockResolvedValue({ ...mockExistingStaff, role: 'viewer' });
+
+        await updateStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockPrisma.staff.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ role: 'viewer' }),
+          })
+        );
+        expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
       });
     });
 
@@ -871,6 +999,50 @@ describe('Staff Controller', () => {
           data: expect.objectContaining({
             isActive: false,
           }),
+        })
+      );
+    });
+
+    it('最後の有効なadminの無効化はValidationErrorになる (#208)', async () => {
+      mockRequest.params = { id: '2' };
+
+      mockPrisma.staff.findFirst.mockResolvedValue({
+        id: 2,
+        name: 'Last Admin',
+        email: 'lastadmin@example.com',
+        role: 'admin',
+        is_active: true,
+      });
+      mockPrisma.staff.count.mockResolvedValue(0); // 他に有効なadminなし
+
+      await toggleStaffActive(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      const error = (mockNext as jest.Mock).mock.calls[0][0];
+      expect(error.message).toContain('最後の有効な管理者');
+      expect(mockPrisma.staff.update).not.toHaveBeenCalled();
+    });
+
+    it('無効化済みadminの有効化は最後の1人でも成功する (#208)', async () => {
+      mockRequest.params = { id: '2' };
+
+      const mockExistingStaff = {
+        id: 2,
+        name: 'Inactive Admin',
+        email: 'inactiveadmin@example.com',
+        role: 'admin',
+        is_active: false, // 有効化方向
+      };
+      mockPrisma.staff.findFirst.mockResolvedValue(mockExistingStaff);
+      mockPrisma.staff.update.mockResolvedValue({ ...mockExistingStaff, is_active: true });
+
+      await toggleStaffActive(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.staff.count).not.toHaveBeenCalled();
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ isActive: true }),
         })
       );
     });


### PR DESCRIPTION
## 概要
バグ監査起票のスタッフ系2件（staffController同根）をまとめて修正。

### #204: メール重複チェックがソフトデリート済みを除外して P2002 になる
- `Staff.email` は deleted_at を含まない DBレベル `@unique` のため、過去に削除したスタッフのメールで再作成すると重複チェック（`deleted_at: null`）を通過後、`staff.create` が P2002 → 汎用 conflict になっていた
- **修正**: 重複チェックから `deleted_at: null` を外し（email は unique なので最大1件）、削除済みヒットは「過去に削除されたスタッフで使用されています」の専用 ConflictError で **Supabase 招待送信よりも前に** 弾く
- updateStaff のメール変更時の重複チェックも同根のため同様に修正
- 根本対処（部分ユニークインデックス化）は migration を伴うため見送り、issue 記載の第一選択（チェック修正）を採用

### #208: 最後の admin を降格/無効化/削除できてしまう（全管理機能ロックアウト）
- **修正**: `assertNotLastActiveAdmin(staffId, operation)` ヘルパを追加し、対象スタッフを除く `role: admin, is_active: true, deleted_at: null` が0人なら ValidationError
- 適用箇所（issue指示の3箇所）:
  1. `updateStaff` — admin の降格（viewer/operator/manager への変更）または `isActive: false`
  2. `toggleStaffActive` — admin の無効化方向のみ（有効化はガード不要）
  3. `deleteStaff` — **Supabase アカウント削除より前** に判定（認証アカウントだけ消える事故を防止）

## テスト
- #204: 削除済みメールで専用メッセージ＆Supabase招待/createに到達しないこと
- #208: 最後のadminの降格/無効化(update)/無効化(toggle)/削除が ValidationError、他にadminがいれば降格成功、無効化済みadminの有効化はガード対象外、の7ケース追加
- 全894テストpass、tsc clean、lint clean

Closes #204
Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
