### PR TITLE
fix(plots): 在庫計算を active 契約限定にし、面積超過時の負残数を防止 (#205, #209)

### DIFF
--- a/src/plots/controllers/getPlotInventory.ts
+++ b/src/plots/controllers/getPlotInventory.ts
@@ -26,6 +26,7 @@ export const getPlotInventory = async (req: Request, res: Response): Promise<Res
           select: {
             id: true,
             contract_area_sqm: true,
+            contract_status: true,
             saleContractRoles: {
               where: { deleted_at: null, role: 'contractor' },
               select: {
@@ -52,11 +53,14 @@ export const getPlotInventory = async (req: Request, res: Response): Promise<Res
     }
 
     // 在庫計算
+    // 割当済面積は active（契約中）のみで算定する（#209）。
+    // vacant の器契約（空き区画の表現方式）・terminated（解約済み）を含めると、
+    // 空き区画が sold_out と誤判定され、calculateAvailableArea /
+    // validateContractArea（utils.ts）の active 限定基準とも矛盾する。
     const totalArea = physicalPlot.area_sqm.toNumber();
-    const allocatedArea = physicalPlot.contractPlots.reduce(
-      (sum, contract) => sum + contract.contract_area_sqm.toNumber(),
-      0
-    );
+    const allocatedArea = physicalPlot.contractPlots
+      .filter((contract) => contract.contract_status === 'active')
+      .reduce((sum, contract) => sum + contract.contract_area_sqm.toNumber(), 0);
     const availableArea = totalArea - allocatedArea;
     const utilizationRate = totalArea > 0 ? (allocatedArea / totalArea) * 100 : 0;
 
@@ -86,6 +90,8 @@ export const getPlotInventory = async (req: Request, res: Response): Promise<Res
           utilizationRate: Math.round(utilizationRate * 100) / 100,
           status: inventoryStatus,
         },
+        // 表示用の契約一覧は在庫計算と用途が異なるため全契約（vacant/terminated含む）を返し、
+        // 区別できるよう contractStatus を付与する
         contracts: physicalPlot.contractPlots.map((contract) => {
           // 主契約者を取得（role='contractor'）
           const primaryRole = contract.saleContractRoles?.[0];
@@ -94,6 +100,7 @@ export const getPlotInventory = async (req: Request, res: Response): Promise<Res
           return {
             id: contract.id,
             contractAreaSqm: contract.contract_area_sqm.toNumber(),
+            contractStatus: contract.contract_status,
             customerName: primaryCustomer?.name || null,
           };
         }),

--- a/src/plots/services/inventoryService.ts
+++ b/src/plots/services/inventoryService.ts
@@ -103,6 +103,27 @@ interface GetInventoryOptions {
 type DbClient = PrismaClient | Prisma.TransactionClient;
 
 /**
+ * 在庫集計に算入する契約区画の取得条件（#209）。
+ * vacant の器契約（空き区画の表現方式）と terminated（解約済み）を
+ * 契約済み面積から除外し、calculateAvailableArea / validateContractArea
+ * （plots/utils.ts）と母数を統一する。
+ */
+const ACTIVE_CONTRACT_PLOTS_INCLUDE = {
+  where: { deleted_at: null, contract_status: 'active' },
+  select: { contract_area_sqm: true },
+} as const;
+
+/**
+ * partially_sold 区画の使用割合を算出する（#205）。
+ * 移行データ等で契約面積合計が物理面積を超えても 1 を上限にクランプし、
+ * usedCount > totalCount による残数の負値化を防ぐ。
+ */
+function clampedUsedPortion(contractedArea: number, plotArea: number): number {
+  if (plotArea <= 0) return 0;
+  return Math.min(1, contractedArea / plotArea);
+}
+
+/**
  * 全体サマリーを取得
  */
 export async function getOverallSummary(prisma: DbClient): Promise<InventorySummaryData> {
@@ -110,10 +131,7 @@ export async function getOverallSummary(prisma: DbClient): Promise<InventorySumm
   const physicalPlots = await prisma.physicalPlot.findMany({
     where: { deleted_at: null },
     include: {
-      contractPlots: {
-        where: { deleted_at: null },
-        select: { contract_area_sqm: true },
-      },
+      contractPlots: ACTIVE_CONTRACT_PLOTS_INCLUDE,
     },
   });
 
@@ -138,10 +156,10 @@ export async function getOverallSummary(prisma: DbClient): Promise<InventorySumm
       usedCount += 1;
       usedAreaSqm += plotArea;
     } else if (plot.status === 'partially_sold' && contractedArea > 0) {
-      // 部分的に売却されている場合、面積比率で計算
-      usedAreaSqm += contractedArea;
+      // 部分的に売却されている場合、面積比率で計算（物理面積を上限にクランプ #205）
+      usedAreaSqm += Math.min(plotArea, contractedArea);
       // カウントは部分的としてカウント
-      usedCount += contractedArea / plotArea;
+      usedCount += clampedUsedPortion(contractedArea, plotArea);
     }
   }
 
@@ -149,8 +167,8 @@ export async function getOverallSummary(prisma: DbClient): Promise<InventorySumm
   // （別経路でMath.roundするとused + remaining ≠ totalになるケースがある）
   const roundedTotalCount = Math.round(totalCount);
   const roundedUsedCount = Math.round(usedCount);
-  const remainingCount = roundedTotalCount - roundedUsedCount;
-  const remainingAreaSqm = totalAreaSqm - usedAreaSqm;
+  const remainingCount = Math.max(0, roundedTotalCount - roundedUsedCount);
+  const remainingAreaSqm = Math.max(0, totalAreaSqm - usedAreaSqm);
   const usageRate = totalCount > 0 ? (usedCount / totalCount) * 100 : 0;
 
   return {
@@ -182,10 +200,7 @@ export async function getPeriodSummaries(
       area_name: { in: periodsToQuery },
     },
     include: {
-      contractPlots: {
-        where: { deleted_at: null },
-        select: { contract_area_sqm: true },
-      },
+      contractPlots: ACTIVE_CONTRACT_PLOTS_INCLUDE,
     },
   });
 
@@ -213,7 +228,7 @@ export async function getPeriodSummaries(
     if (plot.status === 'sold_out') {
       periodData.usedCount += 1;
     } else if (plot.status === 'partially_sold' && contractedArea > 0) {
-      periodData.usedCount += contractedArea / plotArea;
+      periodData.usedCount += clampedUsedPortion(contractedArea, plotArea);
     }
   }
 
@@ -223,7 +238,7 @@ export async function getPeriodSummaries(
     // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出
     const roundedTotalCount = Math.round(data.totalCount);
     const roundedUsedCount = Math.round(data.usedCount);
-    const remainingCount = roundedTotalCount - roundedUsedCount;
+    const remainingCount = Math.max(0, roundedTotalCount - roundedUsedCount);
     const usageRate = data.totalCount > 0 ? (data.usedCount / data.totalCount) * 100 : 0;
 
     return {
@@ -271,10 +286,7 @@ export async function getSectionInventory(
   const physicalPlots = await prisma.physicalPlot.findMany({
     where: whereClause,
     include: {
-      contractPlots: {
-        where: { deleted_at: null },
-        select: { contract_area_sqm: true },
-      },
+      contractPlots: ACTIVE_CONTRACT_PLOTS_INCLUDE,
     },
   });
 
@@ -304,7 +316,7 @@ export async function getSectionInventory(
     if (plot.status === 'sold_out') {
       usedPortion = 1;
     } else if (plot.status === 'partially_sold' && contractedArea > 0) {
-      usedPortion = contractedArea / plotArea;
+      usedPortion = clampedUsedPortion(contractedArea, plotArea);
     }
 
     if (sectionMap.has(key)) {
@@ -327,7 +339,7 @@ export async function getSectionInventory(
     // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出
     const roundedTotalCount = Math.round(item.totalCount);
     const roundedUsedCount = Math.round(item.usedCount);
-    const remainingCount = roundedTotalCount - roundedUsedCount;
+    const remainingCount = Math.max(0, roundedTotalCount - roundedUsedCount);
     const usageRate = item.totalCount > 0 ? (item.usedCount / item.totalCount) * 100 : 0;
 
     return {
@@ -410,10 +422,7 @@ export async function getAreaInventory(
   const physicalPlots = await prisma.physicalPlot.findMany({
     where: whereClause,
     include: {
-      contractPlots: {
-        where: { deleted_at: null },
-        select: { contract_area_sqm: true },
-      },
+      contractPlots: ACTIVE_CONTRACT_PLOTS_INCLUDE,
     },
   });
 
@@ -448,8 +457,8 @@ export async function getAreaInventory(
       usedPortion = 1;
       usedAreaForPlot = plotArea;
     } else if (plot.status === 'partially_sold' && contractedArea > 0) {
-      usedPortion = contractedArea / plotArea;
-      usedAreaForPlot = contractedArea;
+      usedPortion = clampedUsedPortion(contractedArea, plotArea);
+      usedAreaForPlot = Math.min(plotArea, contractedArea);
     }
 
     if (areaMap.has(key)) {
@@ -476,8 +485,8 @@ export async function getAreaInventory(
     // 丸め整合性のため、usedCountを先に丸めてremainingCountをそこから導出
     const roundedTotalCount = Math.round(item.totalCount);
     const roundedUsedCount = Math.round(item.usedCount);
-    const remainingCount = roundedTotalCount - roundedUsedCount;
-    const remainingAreaSqm = item.totalAreaSqm - item.usedAreaSqm;
+    const remainingCount = Math.max(0, roundedTotalCount - roundedUsedCount);
+    const remainingAreaSqm = Math.max(0, item.totalAreaSqm - item.usedAreaSqm);
 
     return {
       period: item.period,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3027,7 +3027,7 @@ components:
               example: partial
         contracts:
           type: array
-          description: 既存契約一覧
+          description: 既存契約一覧（vacant/terminated 含む。在庫計算は active のみで算定）
           items:
             type: object
             properties:
@@ -3037,11 +3037,13 @@ components:
               contractAreaSqm:
                 type: number
                 format: float
-              saleStatus:
+              contractStatus:
                 type: string
-                nullable: true
+                enum: [vacant, active, terminated]
+                description: 契約ステータス
               customerName:
                 type: string
+                nullable: true
 
     # ==================== リクエストスキーマ ====================
 

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -1539,6 +1539,7 @@ describe('Plot Controller (ContractPlot Model)', () => {
           {
             id: 'cp1',
             contract_area_sqm: new Prisma.Decimal(3.6),
+            contract_status: 'active',
             saleContractRoles: [
               {
                 id: 'scr1',
@@ -1567,6 +1568,87 @@ describe('Plot Controller (ContractPlot Model)', () => {
               allocatedArea: 3.6,
               availableArea: 3.6,
               utilizationRate: 50,
+              status: 'partial',
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should treat vacant placeholder contracts as available (#209)', async () => {
+      // 空き区画は ContractPlot 無しでなく contract_status='vacant' の器契約で表現される。
+      // vacant の面積を割当済みに含めると空き区画が sold_out と誤判定される。
+      const mockPhysicalPlot = {
+        id: 'pp1',
+        plot_number: 'A-01',
+        area_name: '一般墓地A',
+        area_sqm: new Prisma.Decimal(3.6),
+        status: 'available',
+        contractPlots: [
+          {
+            id: 'cp1',
+            contract_area_sqm: new Prisma.Decimal(3.6),
+            contract_status: 'vacant',
+            saleContractRoles: [],
+          },
+        ],
+      };
+
+      mockPrisma.physicalPlot.findUnique.mockResolvedValue(mockPhysicalPlot);
+      mockRequest.params = { id: 'pp1' };
+
+      await getPlotInventory(mockRequest as Request, mockResponse as Response);
+
+      expect(responseStatus).toHaveBeenCalledWith(200);
+      expect(responseJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            inventory: expect.objectContaining({
+              allocatedArea: 0,
+              availableArea: 3.6,
+              status: 'available',
+            }),
+            // 表示用一覧には vacant 契約も contractStatus 付きで含まれる
+            contracts: [expect.objectContaining({ id: 'cp1', contractStatus: 'vacant' })],
+          }),
+        })
+      );
+    });
+
+    it('should exclude terminated contracts from allocated area (#209)', async () => {
+      const mockPhysicalPlot = {
+        id: 'pp1',
+        plot_number: 'A-01',
+        area_name: '一般墓地A',
+        area_sqm: new Prisma.Decimal(7.2),
+        status: 'partial',
+        contractPlots: [
+          {
+            id: 'cp1',
+            contract_area_sqm: new Prisma.Decimal(3.6),
+            contract_status: 'active',
+            saleContractRoles: [],
+          },
+          {
+            id: 'cp2',
+            contract_area_sqm: new Prisma.Decimal(3.6),
+            contract_status: 'terminated',
+            saleContractRoles: [],
+          },
+        ],
+      };
+
+      mockPrisma.physicalPlot.findUnique.mockResolvedValue(mockPhysicalPlot);
+      mockRequest.params = { id: 'pp1' };
+
+      await getPlotInventory(mockRequest as Request, mockResponse as Response);
+
+      expect(responseJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            inventory: expect.objectContaining({
+              allocatedArea: 3.6, // active のみ
+              availableArea: 3.6,
               status: 'partial',
             }),
           }),

--- a/tests/plots/services/inventoryService.test.ts
+++ b/tests/plots/services/inventoryService.test.ts
@@ -191,6 +191,41 @@ describe('inventoryService', () => {
       expect(result.remainingCount).toBe(0);
       expect(result.usageRate).toBe(0);
     });
+
+    it('在庫集計クエリが active 契約のみを対象にすること (#209)', async () => {
+      mockPrisma.physicalPlot.findMany.mockResolvedValue([]);
+
+      await getOverallSummary(mockPrisma);
+
+      expect(mockPrisma.physicalPlot.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            contractPlots: expect.objectContaining({
+              where: { deleted_at: null, contract_status: 'active' },
+            }),
+          },
+        })
+      );
+    });
+
+    it('契約面積が物理面積を超えても残数・残面積が負にならないこと (#205)', async () => {
+      mockPrisma.physicalPlot.findMany.mockResolvedValue([
+        {
+          id: 'plot-1',
+          plot_number: 'A-1',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          // 移行データ等の異常: 契約面積合計が物理面積の2倍
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 7.2 } }],
+        },
+      ]);
+
+      const result = await getOverallSummary(mockPrisma);
+
+      expect(result.usedCount).toBe(1); // 2 にならずクランプ
+      expect(result.remainingCount).toBe(0); // 負値にならない
+      expect(result.remainingAreaSqm).toBe(0); // 使用面積も物理面積でクランプ
+    });
   });
 
   describe('getPeriodSummaries', () => {
@@ -297,6 +332,23 @@ describe('inventoryService', () => {
       expect(result[0].usedCount).toBe(51);
       expect(result[0].remainingCount).toBe(49);
       expect(result[0].usedCount + result[0].remainingCount).toBe(result[0].totalCount);
+    });
+
+    it('契約面積が物理面積を超えても残数が負にならないこと (#205)', async () => {
+      mockPrisma.physicalPlot.findMany.mockResolvedValue([
+        {
+          id: 'plot-1',
+          area_name: '第1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 7.2 } }],
+        },
+      ]);
+
+      const result = await getPeriodSummaries(mockPrisma, '第1期');
+
+      expect(result[0].usedCount).toBe(1);
+      expect(result[0].remainingCount).toBe(0);
     });
   });
 
@@ -502,6 +554,25 @@ describe('inventoryService', () => {
       expect(sectionA!.remainingCount).toBe(49);
       expect(sectionA!.usedCount + sectionA!.remainingCount).toBe(sectionA!.totalCount);
     });
+
+    it('契約面積が物理面積を超えても残数が負にならないこと (#205)', async () => {
+      mockPrisma.physicalPlot.findMany.mockResolvedValue([
+        {
+          id: 'plot-1',
+          plot_number: 'A-1',
+          area_name: '第1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 7.2 } }],
+        },
+      ]);
+
+      const result = await getSectionInventory(mockPrisma);
+      const sectionA = result.items.find((i) => i.section === 'A');
+
+      expect(sectionA!.usedCount).toBe(1);
+      expect(sectionA!.remainingCount).toBe(0);
+    });
   });
 
   describe('getAreaInventory', () => {
@@ -660,6 +731,26 @@ describe('inventoryService', () => {
       expect(item!.usedCount).toBe(51);
       expect(item!.remainingCount).toBe(49);
       expect(item!.usedCount + item!.remainingCount).toBe(item!.totalCount);
+    });
+
+    it('契約面積が物理面積を超えても残数・残面積が負にならないこと (#205)', async () => {
+      mockPrisma.physicalPlot.findMany.mockResolvedValue([
+        {
+          id: 'plot-1',
+          plot_number: 'A-1',
+          area_name: '第1期',
+          area_sqm: { toNumber: () => 3.6 },
+          status: 'partially_sold',
+          contractPlots: [{ contract_area_sqm: { toNumber: () => 7.2 } }],
+        },
+      ]);
+
+      const result = await getAreaInventory(mockPrisma);
+      const item = result.items.find((i) => i.areaSqm === 3.6);
+
+      expect(item!.usedCount).toBe(1);
+      expect(item!.remainingCount).toBe(0);
+      expect(item!.remainingAreaSqm).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## 概要
バグ監査起票の在庫系2件（同根=契約ステータス無視＋クランプ無し）をまとめて修正。

### #209: 在庫APIが contract_status を無視
空き区画は「ContractPlot無し」ではなく `contract_status='vacant'` の器契約で表現される（#165/#167 の前提）ため、vacant/terminated を割当済面積に合算すると:
- `GET /plots/:id/inventory` — vacant の器契約(3.6㎡)だけで `availableArea=0`・`status='sold_out'` と誤判定
- `inventoryService` 4集計関数 — active+terminated 混在で contractedArea が plotArea を超え、残数が負値化

**修正**:
- `getPlotInventory`: 在庫計算（allocatedArea/availableArea/status）を **active のみ**で算定。表示用 `contracts` 一覧は全契約を維持しつつ `contractStatus` を付与して出し分け可能に（issue指示どおり計算と表示を分離）
- `inventoryService`: 4関数の include 条件を `ACTIVE_CONTRACT_PLOTS_INCLUDE`（`deleted_at: null, contract_status: 'active'`）に共通化し、`calculateAvailableArea` / `validateContractArea`（utils.ts）と母数を統一

### #205: 面積超過データでの負残数（防御的クランプ）
- `clampedUsedPortion()` — partially_sold の使用割合を 1 上限にクランプ（plotArea<=0 ガード付き）
- usedAreaSqm を `Math.min(plotArea, contractedArea)` でクランプ
- remainingCount / remainingAreaSqm を `Math.max(0, ...)` で負値ガード（4関数一貫）

### swagger
- inventory `contracts` スキーマを実装に整合（実装が返していなかった `saleStatus` を `contractStatus` enum に置換）

## テスト
- getPlotInventory: vacant 器契約のみ → available/3.6㎡空き、terminated 混在 → active のみ算入、の2ケース追加（既存テストの contract_status 無視モックの穴も修正）
- inventoryService: where 条件検証 + 4関数すべてに面積超過クランプのケース追加
- 全894テストpass、tsc clean、lint clean、swagger valid

Closes #205
Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
