### PR TITLE
fix(plots): 契約復活時に物理区画ステータスを再計算する (#210)

### DIFF
--- a/src/plots/controllers/restoreContract.ts
+++ b/src/plots/controllers/restoreContract.ts
@@ -12,6 +12,7 @@ import prisma from '../../db/prisma';
 import { NotFoundError, ConflictError } from '../../middleware/errorHandler';
 import { recordEntityUpdated } from '../services/historyService';
 import { contractStatusService } from '../services/contractStatusService';
+import { updatePhysicalPlotStatus } from '../utils';
 import type { RestoreContractRequest } from '../../validations/plotValidation';
 
 export const restoreContract = async (
@@ -48,6 +49,12 @@ export const restoreContract = async (
         where: { id },
         data: { contract_status: ContractStatus.active },
       });
+
+      // 物理区画ステータスを再計算する（#210）。
+      // 解約時に available 等へ戻った PhysicalPlot.status を据え置くと、
+      // 在庫サマリー（plot.status 基準で集計）に復活分が反映されず過大表示になる。
+      // create/update/delete 系コントローラと同様に復活でも再計算する。
+      await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id);
 
       await recordEntityUpdated(tx, {
         entityType: 'ContractPlot',

--- a/tests/plots/controllers/restoreContract.test.ts
+++ b/tests/plots/controllers/restoreContract.test.ts
@@ -53,6 +53,11 @@ jest.mock('../../../src/plots/services/historyService', () => ({
   recordEntityUpdated: (...args: unknown[]) => mockRecordEntityUpdated(...args),
 }));
 
+const mockUpdatePhysicalPlotStatus = jest.fn();
+jest.mock('../../../src/plots/utils', () => ({
+  updatePhysicalPlotStatus: (...args: unknown[]) => mockUpdatePhysicalPlotStatus(...args),
+}));
+
 import { restoreContract } from '../../../src/plots/controllers/restoreContract';
 import { NotFoundError, ConflictError } from '../../../src/middleware/errorHandler';
 
@@ -110,6 +115,8 @@ describe('restoreContract', () => {
         where: { id: 'cp-1' },
         data: { contract_status: 'active' },
       });
+      // 物理区画ステータスの再計算がトランザクション内で呼ばれること（#210）
+      expect(mockUpdatePhysicalPlotStatus).toHaveBeenCalledWith(mockPrisma, 'pp-1');
       expect(mockRecordEntityUpdated).toHaveBeenCalledTimes(1);
       const historyCall = mockRecordEntityUpdated.mock.calls[0]?.[1] as Record<string, unknown>;
       expect(historyCall).toMatchObject({


### PR DESCRIPTION
## 概要
`POST /plots/:id/restore` が `contract_status` を terminated→active に更新するだけで `updatePhysicalPlotStatus` を呼んでおらず、解約時に available/partially_sold へ戻った `PhysicalPlot.status` が据え置かれるバグ（#210）の修正。

在庫サマリー（inventoryService）は `plot.status` 基準で usedCount/usedAreaSqm を判定するため、復活した active 契約が使用済みにカウントされず在庫が過大表示されていた。createPlot / createPlotContract / updatePlot / deletePlot は全て再計算を呼んでおり、restore だけ漏れていた。

## 修正
- restoreContract のトランザクション内（contractPlot.update 直後）に `await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id)` を追加（issue修正方針どおり）

## テスト
- restoreContract.test.ts に `updatePhysicalPlotStatus` がトランザクションクライアント＋物理区画IDで呼ばれるアサートを追加
- 全887テストpass、tsc clean、lint clean

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)