### PR TITLE
fix(billings,payments,yucho): 請求status再計算・金額パーサ堅牢化・入金区画整合 (#211, #212, #213)

### DIFF
--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -4,6 +4,7 @@ import { ZodError } from 'zod';
 import prisma from '../db/prisma';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
 import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentStatusService';
+import { recalculateBillingPayments } from './billingService';
 import {
   createBillingSchema,
   updateBillingSchema,
@@ -268,15 +269,23 @@ export const updateBilling = async (
     if (input.notes !== undefined) data.notes = input.notes;
 
     const updated = await prisma.$transaction(async (tx) => {
-      const billing = await tx.billing.update({
+      await tx.billing.update({
         where: { id },
         data,
+      });
+      // 請求額・解約フラグの変更で paid/partial_paid/terminated 等の status が
+      // 変わりうるため、入金合計から status・paid_amount・last_payment_date を
+      // 再算出する（#211）。内部で ContractPlot の payment_status 再計算（#162）も行う。
+      // written_off / overdue の手動ステータスは computeBillingStatus 側で尊重される。
+      await recalculateBillingPayments(tx, existing.id);
+      // status が再書き込みされるため、レスポンスは再計算後の値を取得し直す
+      return tx.billing.findFirst({
+        where: { id: existing.id },
         include: includeRelations,
       });
-      // 請求額・解約フラグの変更が入金状況に影響しうるので再計算（#162）
-      await recalculateContractPlotPaymentStatus(tx, existing.contract_plot_id);
-      return billing;
     });
+
+    if (!updated) throw new NotFoundError('請求が見つかりません');
 
     res.status(200).json({ success: true, data: formatBilling(updated) });
   } catch (error) {

--- a/src/payments/paymentController.ts
+++ b/src/payments/paymentController.ts
@@ -187,12 +187,23 @@ export const createPayment = async (
     const input = parsed.data;
 
     // 紐付け先の存在チェック
+    let billing: { id: string; contract_plot_id: string; customer_id: string | null } | null = null;
     if (input.billingId) {
-      const billing = await prisma.billing.findFirst({
+      billing = await prisma.billing.findFirst({
         where: { id: input.billingId, deleted_at: null },
-        select: { id: true },
+        select: { id: true, contract_plot_id: true, customer_id: true },
       });
       if (!billing) throw new NotFoundError('指定の請求が見つかりません');
+
+      // 入金集計は Billing 経由（billing.contract_plot_id）で行われるため、
+      // Payment 側に別区画/別顧客を記録すると表示と集計が乖離する（#213）。
+      // 不一致は明示エラーとし、未指定時は billing 側の値で正規化する。
+      if (input.contractPlotId && input.contractPlotId !== billing.contract_plot_id) {
+        throw new ValidationError('指定された契約区画が請求の契約区画と一致しません');
+      }
+      if (input.customerId && billing.customer_id && input.customerId !== billing.customer_id) {
+        throw new ValidationError('指定された顧客が請求の顧客と一致しません');
+      }
     }
     if (input.customerId) {
       const customer = await prisma.customer.findFirst({
@@ -213,8 +224,10 @@ export const createPayment = async (
       const payment = await tx.payment.create({
         data: {
           billing_id: input.billingId ?? null,
-          customer_id: input.customerId ?? null,
-          contract_plot_id: input.contractPlotId ?? null,
+          // billing 紐付け時は billing 側の値で正規化（区画コンテキストの
+          // 入金一覧と集計の一致を不変条件として強制する #213）
+          customer_id: billing ? billing.customer_id : (input.customerId ?? null),
+          contract_plot_id: billing ? billing.contract_plot_id : (input.contractPlotId ?? null),
           scheduled_date: toDateOrNull(input.scheduledDate),
           scheduled_amount: input.scheduledAmount ?? null,
           payment_date: toDateOrNull(input.paymentDate),
@@ -264,6 +277,38 @@ export const updatePayment = async (
     const existing = await prisma.payment.findFirst({ where: { id, deleted_at: null } });
     if (!existing) throw new NotFoundError('入金が見つかりません');
 
+    // billing 紐付けの設定/変更時は、区画・顧客の整合を検証し billing 側へ正規化する（#213）
+    let connectedBilling: {
+      id: string;
+      contract_plot_id: string;
+      customer_id: string | null;
+    } | null = null;
+    if (input.billingId) {
+      connectedBilling = await prisma.billing.findFirst({
+        where: { id: input.billingId, deleted_at: null },
+        select: { id: true, contract_plot_id: true, customer_id: true },
+      });
+      if (!connectedBilling) throw new NotFoundError('指定の請求が見つかりません');
+
+      const effectiveContractPlotId =
+        input.contractPlotId !== undefined ? input.contractPlotId : existing.contract_plot_id;
+      if (
+        effectiveContractPlotId &&
+        effectiveContractPlotId !== connectedBilling.contract_plot_id
+      ) {
+        throw new ValidationError('指定された契約区画が請求の契約区画と一致しません');
+      }
+      const effectiveCustomerId =
+        input.customerId !== undefined ? input.customerId : existing.customer_id;
+      if (
+        effectiveCustomerId &&
+        connectedBilling.customer_id &&
+        effectiveCustomerId !== connectedBilling.customer_id
+      ) {
+        throw new ValidationError('指定された顧客が請求の顧客と一致しません');
+      }
+    }
+
     const data: Prisma.PaymentUpdateInput = {};
     if (input.billingId !== undefined) {
       data.billing = input.billingId ? { connect: { id: input.billingId } } : { disconnect: true };
@@ -277,6 +322,13 @@ export const updatePayment = async (
       data.contractPlot = input.contractPlotId
         ? { connect: { id: input.contractPlotId } }
         : { disconnect: true };
+    }
+    // billing 紐付け時は区画・顧客を billing 側の値で正規化（未指定でも揃える）
+    if (connectedBilling) {
+      data.contractPlot = { connect: { id: connectedBilling.contract_plot_id } };
+      if (connectedBilling.customer_id) {
+        data.customer = { connect: { id: connectedBilling.customer_id } };
+      }
     }
     if (input.scheduledDate !== undefined) data.scheduled_date = toDateOrNull(input.scheduledDate);
     if (input.scheduledAmount !== undefined) data.scheduled_amount = input.scheduledAmount;

--- a/src/yucho/yuchoService.ts
+++ b/src/yucho/yuchoService.ts
@@ -7,6 +7,7 @@
 
 import { PaymentStatus } from '@prisma/client';
 import prisma from '../db/prisma';
+import { getRequestLogger } from '../utils/logger';
 import type { YuchoBillingItem, YuchoBillingResponse } from '../validations/yuchoValidation';
 import { isExportableBillingItem } from './yuchoCsv';
 
@@ -29,14 +30,28 @@ const parseBillingMonth = (value: string | null | undefined): number | null => {
 };
 
 /**
- * 文字列の管理料金額を整数(円)に変換。"10,000" や "10000円" などの表記も許容。
+ * 文字列の管理料金額を整数(円)に変換。"10,000" や "10000円" などの表記を許容。
+ *
+ * 金額は円単位の正整数であるべきため、数字以外（小数点・ハイフン含む）は
+ * すべて除去する（#212）。旧実装はハイフン・小数を温存していたため、
+ * '-1000'→-1000（負額）、'3.6'→4（四捨五入誤額）がゆうちょ振替の
+ * 引落金額に出力されうる問題があった。
+ * 数字以外を含む値は異常データ検知のため warn ログを出す（黙って出力しない）。
  */
-const parseManagementFeeAmount = (value: string | null | undefined): number => {
+const parseManagementFeeAmount = (value: string | null | undefined, sourceId?: string): number => {
   if (!value) return 0;
-  const cleaned = value.replace(/[^\d.-]/g, '');
+  // 桁区切りカンマと円表記のみ正常系として無警告で除去
+  const normalized = value.replace(/[,，円\s]/g, '');
+  const cleaned = normalized.replace(/[^\d]/g, '');
+  if (cleaned !== normalized) {
+    getRequestLogger().warn(
+      { managementFeeId: sourceId, rawValue: value },
+      '管理料金額に数字以外の文字が含まれています（数字のみ抽出して処理）'
+    );
+  }
   if (!cleaned) return 0;
-  const num = parseFloat(cleaned);
-  return isNaN(num) ? 0 : Math.round(num);
+  const num = parseInt(cleaned, 10);
+  return isNaN(num) ? 0 : num;
 };
 
 type PayerCustomer = {
@@ -130,7 +145,7 @@ const fetchManagementBillingItems = async (params: FetchParams): Promise<YuchoBi
     // 月指定なし(年単位)の場合は billing_month が設定されているもののみ
     if (month == null && billingMonth == null) continue;
 
-    const amount = parseManagementFeeAmount(fee.management_fee);
+    const amount = parseManagementFeeAmount(fee.management_fee, fee.id);
     if (amount <= 0) continue;
 
     const payer = pickPayer(fee.contractPlot.saleContractRoles);

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -43,6 +43,12 @@ jest.mock('../../src/db/prisma', () => ({
   prisma: mockPrisma,
 }));
 
+// updateBilling から呼ばれる再集計（#211）。ロジック自体は billingService.test.ts で検証。
+const recalculateBillingPaymentsMock = jest.fn();
+jest.mock('../../src/billings/billingService', () => ({
+  recalculateBillingPayments: (...args: unknown[]) => recalculateBillingPaymentsMock(...args),
+}));
+
 import {
   getBillings,
   getBillingById,
@@ -309,10 +315,13 @@ describe('billingController', () => {
   });
 
   describe('updateBilling', () => {
-    it('partially updates a billing', async () => {
-      mockPrisma.billing.findFirst.mockResolvedValue({ id: VALID_UUID });
+    it('partially updates a billing and recalculates status (#211)', async () => {
+      // 1回目: 存在チェック / 2回目: 再計算後のレスポンス用再取得
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({ id: VALID_UUID, contract_plot_id: PLOT_UUID })
+        .mockResolvedValueOnce(buildBillingRow({ amount: 15000, status: 'partial_paid' }));
       mockPrisma.billing.update.mockResolvedValue(
-        buildBillingRow({ amount: 15000, status: 'partial_paid' })
+        buildBillingRow({ amount: 15000, status: 'paid' })
       );
 
       const req = buildRequest({
@@ -325,6 +334,11 @@ describe('billingController', () => {
       const updateCall = mockPrisma.billing.update.mock.calls[0][0];
       expect(updateCall.where).toEqual({ id: VALID_UUID });
       expect(updateCall.data).toEqual({ amount: 15000 });
+      // 請求額変更後に status / paid_amount を入金合計から再算出すること（#211）
+      expect(recalculateBillingPaymentsMock).toHaveBeenCalledWith(mockPrisma, VALID_UUID);
+      // レスポンスは再計算後の値（status: partial_paid）であること
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data.status).toBe('partial_paid');
     });
 
     it('returns NotFoundError when billing does not exist', async () => {

--- a/tests/payments/paymentController.test.ts
+++ b/tests/payments/paymentController.test.ts
@@ -248,6 +248,59 @@ describe('paymentController', () => {
 
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'NotFoundError' }));
     });
+
+    it('billingの区画と異なるcontractPlotIdはValidationErrorになる (#213)', async () => {
+      mockPrisma.billing.findFirst.mockResolvedValue({
+        id: BILLING_UUID,
+        contract_plot_id: PLOT_UUID,
+        customer_id: CUSTOMER_UUID,
+      });
+      const otherPlotId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: otherPlotId });
+
+      const req = buildRequest({
+        body: {
+          billingId: BILLING_UUID,
+          contractPlotId: otherPlotId,
+          paymentAmount: 10000,
+        },
+      });
+      await createPayment(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('billing紐付け時は区画・顧客がbilling側の値で正規化される (#213)', async () => {
+      mockPrisma.billing.findFirst.mockResolvedValue({
+        id: BILLING_UUID,
+        contract_plot_id: PLOT_UUID,
+        customer_id: CUSTOMER_UUID,
+      });
+      const txMock = {
+        payment: { create: jest.fn().mockResolvedValue(buildPaymentRow()) },
+      };
+      mockPrisma.$transaction.mockImplementation(async (cb) => cb(txMock));
+
+      const req = buildRequest({
+        body: {
+          billingId: BILLING_UUID,
+          paymentAmount: 10000,
+        },
+      });
+      await createPayment(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(txMock.payment.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            billing_id: BILLING_UUID,
+            contract_plot_id: PLOT_UUID,
+            customer_id: CUSTOMER_UUID,
+          }),
+        })
+      );
+    });
   });
 
   describe('updatePayment', () => {
@@ -255,6 +308,11 @@ describe('paymentController', () => {
       mockPrisma.payment.findFirst.mockResolvedValue({
         id: PAYMENT_UUID,
         billing_id: BILLING_UUID,
+      });
+      mockPrisma.billing.findFirst.mockResolvedValue({
+        id: ANOTHER_BILLING_UUID,
+        contract_plot_id: PLOT_UUID,
+        customer_id: CUSTOMER_UUID,
       });
       const txMock = {
         payment: {
@@ -274,6 +332,62 @@ describe('paymentController', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(recalculateBillingPaymentsMock).toHaveBeenCalledWith(txMock, BILLING_UUID);
       expect(recalculateBillingPaymentsMock).toHaveBeenCalledWith(txMock, ANOTHER_BILLING_UUID);
+      // billing 紐付け時は区画・顧客が billing 側の値へ正規化される（#213）
+      expect(txMock.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            contractPlot: { connect: { id: PLOT_UUID } },
+            customer: { connect: { id: CUSTOMER_UUID } },
+          }),
+        })
+      );
+    });
+
+    it('billingの区画と異なるcontractPlotId指定はValidationErrorになる (#213)', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue({
+        id: PAYMENT_UUID,
+        billing_id: null,
+        contract_plot_id: null,
+        customer_id: null,
+      });
+      mockPrisma.billing.findFirst.mockResolvedValue({
+        id: BILLING_UUID,
+        contract_plot_id: PLOT_UUID,
+        customer_id: CUSTOMER_UUID,
+      });
+      const otherPlotId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
+      const req = buildRequest({
+        params: { id: PAYMENT_UUID },
+        body: { billingId: BILLING_UUID, contractPlotId: otherPlotId },
+      });
+      await updatePayment(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('billingの区画と異なる既存contract_plot_idもValidationErrorになる (#213)', async () => {
+      const otherPlotId = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+      mockPrisma.payment.findFirst.mockResolvedValue({
+        id: PAYMENT_UUID,
+        billing_id: null,
+        contract_plot_id: otherPlotId, // 既存の区画が billing と不一致
+        customer_id: null,
+      });
+      mockPrisma.billing.findFirst.mockResolvedValue({
+        id: BILLING_UUID,
+        contract_plot_id: PLOT_UUID,
+        customer_id: CUSTOMER_UUID,
+      });
+
+      const req = buildRequest({
+        params: { id: PAYMENT_UUID },
+        body: { billingId: BILLING_UUID },
+      });
+      await updatePayment(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
     });
 
     it('disconnects billing when billingId set to null', async () => {

--- a/tests/yucho/yuchoController.test.ts
+++ b/tests/yucho/yuchoController.test.ts
@@ -237,6 +237,50 @@ describe('yuchoController', () => {
       expect(payload.data.items).toHaveLength(0);
     });
 
+    it('管理料の金額パースで負額・小数丸めを発生させない (#212)', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '-', // 未設定の意味のハイフン → 0 として除外
+          contractPlot: buildContractPlot(),
+        },
+        {
+          id: 'f2',
+          contract_plot_id: 'cp-2',
+          billing_month: '4',
+          management_fee: '-1000', // 負号混入 → 負額にしない
+          contractPlot: buildContractPlot({ id: 'cp-2' }),
+        },
+        {
+          id: 'f3',
+          contract_plot_id: 'cp-3',
+          billing_month: '4',
+          management_fee: '10,000円', // 正常系の表記ゆれ
+          contractPlot: buildContractPlot({ id: 'cp-3' }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      const amounts = payload.data.items.map(
+        (i: { sourceId: string; billingAmount: number }) => i.billingAmount
+      );
+      // 負の金額は一切含まれない
+      expect(amounts.every((a: number) => a > 0)).toBe(true);
+      // '10,000円' は 10000 として正常にパースされる
+      const f3 = payload.data.items.find((i: { sourceId: string }) => i.sourceId === 'f3');
+      expect(f3.billingAmount).toBe(10000);
+      // '-' は除外される
+      expect(
+        payload.data.items.find((i: { sourceId: string }) => i.sourceId === 'f1')
+      ).toBeUndefined();
+    });
+
     it('honours category=collective by skipping management fee query', async () => {
       mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
 


### PR DESCRIPTION
## 概要
バグ監査起票の請求・入金系3件をまとめて修正。

### #211: Billing 更新で status が再計算されない
`updateBilling` は data の列だけ更新し、`recalculateBillingPayments`/`computeBillingStatus` を呼んでいなかった。paid_amount=10000 の請求の amount を 15000 に増額しても status='paid' のまま、`terminated: true` を送っても status が旧値のまま残り、請求一覧のステータスバッジ・絞り込みが誤っていた。

**修正**（issue修正方針どおり）:
- `tx.billing.update` 直後に `recalculateBillingPayments(tx, id)` を呼ぶ（内部で ContractPlot の payment_status 再計算 #162 も実行されるため、既存の単独呼び出しは削除）
- status が再書き込みされるため、レスポンスは `tx.billing.findFirst` で再取得してから `formatBilling`
- `written_off` / `overdue` の手動ステータスは `computeBillingStatus` 側で尊重される（既存ロジック）

### #212: 管理料金額パーサがハイフン・小数を温存
`parseManagementFeeAmount` が `/[^\d.-]/g` で `-1000`→-1000（負額）、`3.6`→4（丸め誤額）を生み、ゆうちょ振替CSVの引落金額に出力されうる。

**修正**: 数字のみ抽出（金額は円単位の正整数）に変更し、カンマ・円表記・空白以外の文字が混入していた場合は `managementFeeId` 付きで warn ログを出して運用側が異常データを検知できるようにした。0以下は既存の除外ロジックで弾かれる。

### #213: 入金の contract_plot_id と Billing の不一致が素通り
`POST /payments { billingId: A区画の請求, contractPlotId: B区画 }` が通り、B区画の入金一覧に表示されるのに入金はA区画の payment_status に反映される乖離が発生。

**修正**（issue推奨の billing 連動方式 + 明示エラーの併用）:
- create/update とも billingId 指定時に billing の `contract_plot_id`/`customer_id` を取得
- 明示指定が billing と**不一致なら ValidationError**（クライアントバグの検出）
- **未指定なら billing 側の値で正規化**して保存（「区画コンテキストの入金一覧と集計が常に一致する」不変条件を強制）
- updatePayment は既存レコードの値との整合も検証

## テスト
- #211: 再計算呼び出し＋再取得後レスポンスのアサート（既存テストをissue指示どおり status 据え置き許容しない形に更新）
- #212: `-`（除外）/`-1000`（負額にしない）/`10,000円`（10000に正常パース）のケース追加
- #213: create/update の不一致 ValidationError ＋ billing 値への正規化のケース5件追加
- 全892テストpass、tsc clean、lint clean

Closes #211
Closes #212
Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
