### PR TITLE
feat: 請求サマリー集計 GET /billings/summary を追加（frontend #225 対応）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=99414bbf9f6336a316fce8f3149b0b97d3a8bd09
+ARG TYPES_REF=67e6fe7ebf4a18591aca8091678c5f9b28835283
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
 import { ZodError } from 'zod';
+import type { BillingSummaryResponse } from '@komine/types';
 import prisma from '../db/prisma';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
 import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentStatusService';
@@ -8,6 +9,7 @@ import {
   createBillingSchema,
   updateBillingSchema,
   listBillingsQuerySchema,
+  billingSummaryQuerySchema,
 } from '../validations/billingValidation';
 
 type BillingWithRelations = Prisma.BillingGetPayload<{
@@ -115,6 +117,67 @@ export const getBillings = async (
         },
       },
     });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      next(new ValidationError(error.issues[0]?.message ?? 'Invalid query'));
+      return;
+    }
+    next(error);
+  }
+};
+
+/**
+ * 請求サマリー集計取得
+ *
+ * フィルタ一致の「全件」を集計する（GET /billings/summary）。
+ * 一覧はページネーションされるため、画面上部の請求総額/入金済/未入金/
+ * 延滞件数 StatCard をページ分の reduce で出すと誤読される
+ * （frontend #225）。サーバ側で aggregate して返す。
+ */
+export const getBillingsSummary = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const parsed = billingSummaryQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw new ValidationError(parsed.error.issues[0]?.message ?? 'Invalid query');
+    }
+    const q = parsed.data;
+
+    const where: Prisma.BillingWhereInput = { deleted_at: null };
+    if (q.contractPlotId) where.contract_plot_id = q.contractPlotId;
+    if (q.customerId) where.customer_id = q.customerId;
+    if (q.category) where.category = q.category;
+    if (q.status) where.status = q.status;
+    if (q.billingDateFrom || q.billingDateTo) {
+      where.billing_date = {
+        ...(q.billingDateFrom && { gte: new Date(`${q.billingDateFrom}T00:00:00Z`) }),
+        ...(q.billingDateTo && { lte: new Date(`${q.billingDateTo}T23:59:59Z`) }),
+      };
+    }
+
+    const [sums, totalCount, overdueCount] = await Promise.all([
+      prisma.billing.aggregate({
+        where,
+        _sum: { amount: true, paid_amount: true },
+      }),
+      prisma.billing.count({ where }),
+      prisma.billing.count({ where: { ...where, status: 'overdue' } }),
+    ]);
+
+    const totalAmount = sums._sum.amount ?? 0;
+    const paidAmount = sums._sum.paid_amount ?? 0;
+    const data: BillingSummaryResponse = {
+      totalAmount,
+      paidAmount,
+      unpaidAmount: totalAmount - paidAmount,
+      overdueCount,
+      totalCount,
+    };
+
+    res.status(200).json({ success: true, data });
   } catch (error) {
     if (error instanceof ZodError) {
       next(new ValidationError(error.issues[0]?.message ?? 'Invalid query'));

--- a/src/billings/billingRoutes.ts
+++ b/src/billings/billingRoutes.ts
@@ -4,6 +4,7 @@ import { requirePermission, ROLES } from '../middleware/permission';
 import { withLogging } from '../middleware/controllerLogger';
 import {
   getBillings,
+  getBillingsSummary,
   getBillingById,
   createBilling,
   updateBilling,
@@ -18,6 +19,15 @@ router.get(
   authenticate,
   requirePermission([ROLES.VIEWER, ROLES.OPERATOR, ROLES.MANAGER, ROLES.ADMIN]),
   withLogging('Billings', 'getList', getBillings)
+);
+
+// サマリー集計（viewer以上）
+// ※ '/:id' より先に登録すること（後だと 'summary' が :id にマッチする）
+router.get(
+  '/summary',
+  authenticate,
+  requirePermission([ROLES.VIEWER, ROLES.OPERATOR, ROLES.MANAGER, ROLES.ADMIN]),
+  withLogging('Billings', 'getSummary', getBillingsSummary)
 );
 
 // 詳細取得（viewer以上）

--- a/src/validations/billingValidation.ts
+++ b/src/validations/billingValidation.ts
@@ -80,3 +80,22 @@ export const listBillingsQuerySchema = z.object({
 });
 
 export type ListBillingsQuery = z.infer<typeof listBillingsQuerySchema>;
+
+// サマリー集計クエリ（一覧クエリからページネーション/ソートを除いたフィルタのみ。
+// フィルタ一致の全件を集計するため page/limit は受けない）
+export const billingSummaryQuerySchema = z.object({
+  contractPlotId: z.string().uuid().optional(),
+  customerId: z.string().uuid().optional(),
+  category: billingCategoryEnum.optional(),
+  status: billingStatusEnum.optional(),
+  billingDateFrom: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  billingDateTo: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+export type BillingSummaryQuery = z.infer<typeof billingSummaryQuerySchema>;

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -21,6 +21,7 @@ const mockPrisma = {
     findFirst: jest.fn(),
     findMany: jest.fn(),
     count: jest.fn(),
+    aggregate: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
   },
@@ -45,6 +46,7 @@ jest.mock('../../src/db/prisma', () => ({
 
 import {
   getBillings,
+  getBillingsSummary,
   getBillingById,
   createBilling,
   updateBilling,
@@ -188,6 +190,75 @@ describe('billingController', () => {
     it('rejects invalid query (non-uuid contractPlotId)', async () => {
       const req = buildRequest({ query: { contractPlotId: 'not-a-uuid' } });
       await getBillings(req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+    });
+  });
+
+  describe('getBillingsSummary', () => {
+    it('returns aggregated totals over all matching billings (frontend #225)', async () => {
+      mockPrisma.billing.aggregate.mockResolvedValue({
+        _sum: { amount: 500000, paid_amount: 320000 },
+      });
+      // 1回目: totalCount, 2回目: overdueCount
+      mockPrisma.billing.count.mockResolvedValueOnce(120).mockResolvedValueOnce(7);
+
+      const req = buildRequest({ query: {} });
+      await getBillingsSummary(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload).toEqual({
+        success: true,
+        data: {
+          totalAmount: 500000,
+          paidAmount: 320000,
+          unpaidAmount: 180000,
+          overdueCount: 7,
+          totalCount: 120,
+        },
+      });
+    });
+
+    it('applies filter conditions and adds overdue status for overdue count', async () => {
+      mockPrisma.billing.aggregate.mockResolvedValue({
+        _sum: { amount: null, paid_amount: null },
+      });
+      mockPrisma.billing.count.mockResolvedValue(0);
+
+      const req = buildRequest({
+        query: {
+          contractPlotId: PLOT_UUID,
+          category: 'management_fee',
+          status: 'billed',
+        },
+      });
+      await getBillingsSummary(req as Request, res as Response, next);
+
+      const aggWhere = mockPrisma.billing.aggregate.mock.calls[0][0].where;
+      expect(aggWhere).toMatchObject({
+        deleted_at: null,
+        contract_plot_id: PLOT_UUID,
+        category: 'management_fee',
+        status: 'billed',
+      });
+      // overdueCount 側は status が 'overdue' で上書きされる
+      const overdueWhere = mockPrisma.billing.count.mock.calls[1][0].where;
+      expect(overdueWhere).toMatchObject({ deleted_at: null, status: 'overdue' });
+
+      // SUM が null（0件）のとき 0 に丸める
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data).toEqual({
+        totalAmount: 0,
+        paidAmount: 0,
+        unpaidAmount: 0,
+        overdueCount: 0,
+        totalCount: 0,
+      });
+    });
+
+    it('rejects invalid query (non-uuid contractPlotId)', async () => {
+      const req = buildRequest({ query: { contractPlotId: 'not-a-uuid' } });
+      await getBillingsSummary(req as Request, res as Response, next);
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
     });
   });


### PR DESCRIPTION
## 概要
frontend #225（請求管理サマリーが現在ページ分のみの合計で誤読される）の根本修正の backend 側。フィルタ一致の**全件**を集計して返すサマリーエンドポイントを追加。

## 変更内容
- `GET /api/v1/billings/summary`（viewer 以上）
  - ルートは `'/:id'` より**先**に登録（'summary' が :id にマッチしないように）
  - クエリ: `contractPlotId` / `customerId` / `category` / `status` / `billingDateFrom` / `billingDateTo`（`billingSummaryQuerySchema` 新設）
  - 集計: `prisma.billing.aggregate`（amount / paid_amount の SUM）+ 総件数 + `status='overdue'` 件数
  - レスポンス: `{ totalAmount, paidAmount, unpaidAmount, overdueCount, totalCount }` — `@komine/types` の `BillingSummaryResponse`（zaitsu82/komine-types#33 マージ済み）で型を固定
- Dockerfile `TYPES_REF` を types main（`67e6fe7`）へ bump
- テスト3件追加

## 関連
- types: zaitsu82/komine-types#33（マージ済み）
- frontend 側（billing-management.tsx の StatCard 置換）は後続 PR

## テスト
- `npx tsc --noEmit` clean / `npm run lint` clean / `npm test` 904 passed（新規3件含む）

Refs zaitsu82/komine-crm-frontend#225

🤖 Generated with [Claude Code](https://claude.com/claude-code)