### PR TITLE
fix(dates): @db.Date列のJST前日ずれと和暦の元号境界誤判定を修正 (#214, #215)

### DIFF
--- a/src/collective-burials/utils.ts
+++ b/src/collective-burials/utils.ts
@@ -1,18 +1,19 @@
 import { PrismaClient, Prisma, CollectiveBurial } from '@prisma/client';
+import { todayJstAsUtcDate, addYearsUtc } from '../utils/dateUtils';
 
 /**
  * 請求予定日を計算
- * @param capacityReachedDate 上限到達日
+ * @param capacityReachedDate 上限到達日（UTC 00:00 正規化済みの Date を渡すこと #214）
  * @param validityPeriodYears 有効期間（年単位）
- * @returns 請求予定日
+ * @returns 請求予定日（UTC 00:00 を維持）
  */
 export const calculateBillingScheduledDate = (
   capacityReachedDate: Date,
   validityPeriodYears: number
 ): Date => {
-  const billingDate = new Date(capacityReachedDate);
-  billingDate.setFullYear(billingDate.getFullYear() + validityPeriodYears);
-  return billingDate;
+  // setFullYear（ローカル時刻ベース）は JST 環境で @db.Date 保存時に
+  // 前日へずれるため、UTC ベースで年加算する（#214）
+  return addYearsUtc(capacityReachedDate, validityPeriodYears);
 };
 
 /**
@@ -52,7 +53,8 @@ export const updateCollectiveBurialCount = async (
 
   if (capacityReached && !wasCapacityReached) {
     // 上限到達（初回）: 上限到達日と請求予定日を設定
-    const capacityReachedDate = new Date();
+    // @db.Date 列への保存のため JST 暦日を UTC 00:00 に正規化（#214）
+    const capacityReachedDate = todayJstAsUtcDate();
     updateData.capacity_reached_date = capacityReachedDate;
     updateData.billing_scheduled_date = calculateBillingScheduledDate(
       capacityReachedDate,
@@ -97,8 +99,9 @@ export const isCapacityReached = async (prisma: PrismaClient, plotId: string): P
  * @returns 請求対象の合祀情報リスト
  */
 export const getBillingTargets = async (prisma: PrismaClient) => {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0); // 時刻を0:00:00に設定
+  // billing_scheduled_date は @db.Date（UTC 00:00 として読まれる）のため、
+  // 比較基準日も JST 暦日の UTC 00:00 に正規化して境界を一致させる（#214）
+  const today = todayJstAsUtcDate();
 
   return await prisma.collectiveBurial.findMany({
     where: {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -28,38 +28,62 @@ export function parseDate(str: string | null | undefined): Date | null {
 }
 
 /**
- * 和暦変換（令和）
+ * 現在時刻（または指定時刻）を JST の暦日として解釈し、
+ * その暦日の UTC 00:00 を表す Date を返す（#214）。
+ *
+ * Prisma の @db.Date 列は UTC 基準で日付部分を切り出すため、
+ * 時刻付き Date（ローカル時刻）をそのまま書き込むと、
+ * JST 00:00〜08:59 の処理で保存日付が前日にずれる。
+ * @db.Date 列への保存値・比較基準日はこのヘルパで正規化すること。
+ */
+export function todayJstAsUtcDate(base: Date = new Date()): Date {
+  // en-CA ロケールは YYYY-MM-DD 形式を返す
+  const jstDateStr = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' }).format(base);
+  return new Date(`${jstDateStr}T00:00:00Z`);
+}
+
+/**
+ * UTC 00:00 正規化済みの Date に対して年だけを加算する（#214）。
+ * setFullYear（ローカル時刻ベース）と異なり UTC 00:00 を維持する。
+ */
+export function addYearsUtc(date: Date, years: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear() + years, date.getUTCMonth(), date.getUTCDate()));
+}
+
+// 元号の開始日（ローカル暦日比較用）
+const REIWA_START = new Date(2019, 4, 1); // 2019-05-01
+const HEISEI_START = new Date(1989, 0, 8); // 1989-01-08
+const SHOWA_START = new Date(1926, 11, 25); // 1926-12-25
+
+/**
+ * 日付から元号と元号年を判定する（#215）。
+ * 年単位でなく境界日で判定する（frontend formatDateWithEra と同一基準）。
+ * 元号適用外（昭和より前）は null を返す。
+ */
+function resolveJapaneseEra(date: Date): { era: string; eraYear: number } | null {
+  if (date >= REIWA_START) return { era: '令和', eraYear: date.getFullYear() - 2018 };
+  if (date >= HEISEI_START) return { era: '平成', eraYear: date.getFullYear() - 1988 };
+  if (date >= SHOWA_START) return { era: '昭和', eraYear: date.getFullYear() - 1925 };
+  return null;
+}
+
+/**
+ * 和暦変換（境界日判定: 令和=2019-05-01〜 / 平成=1989-01-08〜 / 昭和=1926-12-25〜）
  */
 export function toJapaneseDate(date: Date | null | undefined): string | null {
   if (!date) return null;
 
-  const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
+  const era = resolveJapaneseEra(date);
 
-  // 令和元年は2019年5月1日から
-  if (year >= 2019) {
-    const reiwaYear = year - 2018;
-    const yearStr = reiwaYear === 1 ? '元' : String(reiwaYear);
-    return `令和${yearStr}年${month}月${day}日`;
+  if (era) {
+    const yearStr = era.eraYear === 1 ? '元' : String(era.eraYear);
+    return `${era.era}${yearStr}年${month}月${day}日`;
   }
 
-  // 平成は1989年1月8日から2019年4月30日まで
-  if (year >= 1989) {
-    const heiseiYear = year - 1988;
-    const yearStr = heiseiYear === 1 ? '元' : String(heiseiYear);
-    return `平成${yearStr}年${month}月${day}日`;
-  }
-
-  // 昭和は1926年12月25日から1989年1月7日まで
-  if (year >= 1926) {
-    const showaYear = year - 1925;
-    const yearStr = showaYear === 1 ? '元' : String(showaYear);
-    return `昭和${yearStr}年${month}月${day}日`;
-  }
-
-  // それ以前は西暦で返す
-  return `${year}年${month}月${day}日`;
+  // 元号適用外は西暦で返す
+  return `${date.getFullYear()}年${month}月${day}日`;
 }
 
 /**
@@ -68,20 +92,14 @@ export function toJapaneseDate(date: Date | null | undefined): string | null {
 export function toJapaneseYearMonth(date: Date | null | undefined): string | null {
   if (!date) return null;
 
-  const year = date.getFullYear();
   const month = date.getMonth() + 1;
+  const era = resolveJapaneseEra(date);
 
-  if (year >= 2019) {
-    const reiwaYear = year - 2018;
-    return `令和${reiwaYear}年${month}月`;
+  if (era) {
+    return `${era.era}${era.eraYear}年${month}月`;
   }
 
-  if (year >= 1989) {
-    const heiseiYear = year - 1988;
-    return `平成${heiseiYear}年${month}月`;
-  }
-
-  return `${year}年${month}月`;
+  return `${date.getFullYear()}年${month}月`;
 }
 
 /**

--- a/tests/utils/collectiveBurialUtils.test.ts
+++ b/tests/utils/collectiveBurialUtils.test.ts
@@ -56,6 +56,59 @@ describe('collectiveBurialUtils', () => {
       expect(result.getMonth()).toBe(5); // June
       expect(result.getDate()).toBe(30);
     });
+
+    it('UTC 00:00 正規化済みの入力に対し UTC 00:00 を維持する (#214)', () => {
+      const capacityReachedDate = new Date('2026-06-05T00:00:00Z');
+
+      const result = calculateBillingScheduledDate(capacityReachedDate, 33);
+
+      // setFullYear（ローカル基準）だと TZ により時刻成分が混入しうるが、
+      // UTC ベース加算では暦日が厳密に維持される
+      expect(result.toISOString()).toBe('2059-06-05T00:00:00.000Z');
+    });
+  });
+
+  describe('@db.Date 列への JST 暦日正規化 (#214)', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('JST 早朝（年末年始境界）の上限到達で保存日付が前日・前年にずれない', async () => {
+      // UTC 2026-12-31 20:00 = JST 2027-01-01 05:00
+      jest.useFakeTimers().setSystemTime(new Date('2026-12-31T20:00:00Z'));
+
+      const mockCollectiveBurial = {
+        id: 'cb-1',
+        contract_plot_id: 'plot-1',
+        burial_capacity: 10,
+        current_burial_count: 9,
+        capacity_reached_date: null,
+        validity_period_years: 3,
+        deleted_at: null,
+      };
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue(mockCollectiveBurial);
+      mockPrisma.buriedPerson.count.mockResolvedValue(10);
+      mockPrisma.collectiveBurial.update.mockResolvedValue({ ...mockCollectiveBurial });
+
+      await updateCollectiveBurialCount(mockPrisma as any, 'plot-1');
+
+      const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
+      // JST の暦日 2027-01-01 が UTC 00:00 で保存される（2026-12-31 にならない）
+      expect(updateCall.data.capacity_reached_date.toISOString()).toBe('2027-01-01T00:00:00.000Z');
+      expect(updateCall.data.billing_scheduled_date.toISOString()).toBe('2030-01-01T00:00:00.000Z');
+    });
+
+    it('getBillingTargets の基準日も JST 暦日の UTC 00:00 に正規化される', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-12-31T20:00:00Z'));
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      await getBillingTargets(mockPrisma as any);
+
+      const callArgs = mockPrisma.collectiveBurial.findMany.mock.calls[0][0];
+      expect(callArgs.where.billing_scheduled_date.lte.toISOString()).toBe(
+        '2027-01-01T00:00:00.000Z'
+      );
+    });
   });
 
   describe('updateCollectiveBurialCount', () => {

--- a/tests/utils/dateUtils.test.ts
+++ b/tests/utils/dateUtils.test.ts
@@ -1,0 +1,103 @@
+/**
+ * dateUtils のテスト
+ * - #214: @db.Date 列向けの JST 暦日 → UTC 00:00 正規化
+ * - #215: 和暦変換の元号境界日判定
+ */
+import {
+  formatDate,
+  parseDate,
+  todayJstAsUtcDate,
+  addYearsUtc,
+  toJapaneseDate,
+  toJapaneseYearMonth,
+} from '../../src/utils/dateUtils';
+
+describe('dateUtils', () => {
+  describe('todayJstAsUtcDate (#214)', () => {
+    it('JST 早朝（UTC では前日）の時刻を JST の暦日の UTC 00:00 に正規化する', () => {
+      // UTC 2026-06-04 20:00 = JST 2026-06-05 05:00
+      const base = new Date('2026-06-04T20:00:00Z');
+      expect(todayJstAsUtcDate(base).toISOString()).toBe('2026-06-05T00:00:00.000Z');
+    });
+
+    it('年末年始の境界（JST 元日早朝）でも年がずれない', () => {
+      // UTC 2026-12-31 20:00 = JST 2027-01-01 05:00
+      const base = new Date('2026-12-31T20:00:00Z');
+      expect(todayJstAsUtcDate(base).toISOString()).toBe('2027-01-01T00:00:00.000Z');
+    });
+
+    it('JST 日中はそのままの暦日になる', () => {
+      // UTC 2026-06-05 03:00 = JST 2026-06-05 12:00
+      const base = new Date('2026-06-05T03:00:00Z');
+      expect(todayJstAsUtcDate(base).toISOString()).toBe('2026-06-05T00:00:00.000Z');
+    });
+  });
+
+  describe('addYearsUtc (#214)', () => {
+    it('UTC 00:00 を維持したまま年を加算する', () => {
+      const base = new Date('2026-06-05T00:00:00Z');
+      expect(addYearsUtc(base, 33).toISOString()).toBe('2059-06-05T00:00:00.000Z');
+    });
+
+    it('うるう日は翌日へ繰り上がる（JS Date仕様）', () => {
+      const base = new Date('2024-02-29T00:00:00Z');
+      expect(addYearsUtc(base, 1).toISOString()).toBe('2025-03-01T00:00:00.000Z');
+    });
+  });
+
+  describe('toJapaneseDate (#215 元号境界)', () => {
+    it('2019年1〜4月は平成31年（令和ではない）', () => {
+      expect(toJapaneseDate(new Date(2019, 2, 1))).toBe('平成31年3月1日');
+      expect(toJapaneseDate(new Date(2019, 3, 30))).toBe('平成31年4月30日');
+    });
+
+    it('令和は2019年5月1日から', () => {
+      expect(toJapaneseDate(new Date(2019, 4, 1))).toBe('令和元年5月1日');
+      expect(toJapaneseDate(new Date(2026, 5, 5))).toBe('令和8年6月5日');
+    });
+
+    it('1989年1月初週は昭和64年（平成ではない）', () => {
+      expect(toJapaneseDate(new Date(1989, 0, 7))).toBe('昭和64年1月7日');
+    });
+
+    it('平成は1989年1月8日から', () => {
+      expect(toJapaneseDate(new Date(1989, 0, 8))).toBe('平成元年1月8日');
+    });
+
+    it('昭和は1926年12月25日から', () => {
+      expect(toJapaneseDate(new Date(1926, 11, 25))).toBe('昭和元年12月25日');
+      expect(toJapaneseDate(new Date(1926, 11, 24))).toBe('1926年12月24日'); // 大正は西暦表記
+    });
+
+    it('null/undefined は null を返す', () => {
+      expect(toJapaneseDate(null)).toBeNull();
+      expect(toJapaneseDate(undefined)).toBeNull();
+    });
+  });
+
+  describe('toJapaneseYearMonth (#215 元号境界)', () => {
+    it('2019年4月は平成31年4月', () => {
+      expect(toJapaneseYearMonth(new Date(2019, 3, 15))).toBe('平成31年4月');
+    });
+
+    it('2019年5月は令和元年5月', () => {
+      expect(toJapaneseYearMonth(new Date(2019, 4, 15))).toBe('令和1年5月');
+    });
+
+    it('昭和の年月も変換できる（従来は分岐が欠落していた）', () => {
+      expect(toJapaneseYearMonth(new Date(1980, 5, 15))).toBe('昭和55年6月');
+    });
+  });
+
+  describe('formatDate / parseDate（既存動作の確認）', () => {
+    it('formatDate は YYYY-MM-DD を返す', () => {
+      expect(formatDate(new Date('2026-06-05T00:00:00Z'))).toBe('2026-06-05');
+      expect(formatDate(null)).toBeNull();
+    });
+
+    it('parseDate は不正文字列で null を返す', () => {
+      expect(parseDate('not-a-date')).toBeNull();
+      expect(parseDate('2026-06-05')?.toISOString()).toBe('2026-06-05T00:00:00.000Z');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
バグ監査起票の日付系2件をまとめて修正。

### #214: 合祀系の日付が JST 早朝に前日へずれる（3箇所同根）
`@db.Date` 列に時刻付き `new Date()`（ローカル時刻）を書き込むと PostgreSQL が UTC 基準で日付を切り出すため、JST 00:00〜08:59 の処理で保存日付が前日（年末なら**前年**）になる。請求予定年の集計・ゆうちょ請求対象抽出が1年丸ごと別年に計上されうる。

**修正**（issue修正方針どおり）:
- `dateUtils` に `todayJstAsUtcDate()`（JST暦日→UTC 00:00正規化）/ `addYearsUtc()`（UTCベース年加算）を新設
- `collective-burials/utils.ts`:
  1. `updateCollectiveBurialCount` の `capacity_reached_date = new Date()` → `todayJstAsUtcDate()`
  2. `calculateBillingScheduledDate` の `setFullYear`（ローカル基準）→ `addYearsUtc`
  3. `getBillingTargets` の基準日 `setHours(0,0,0,0)`（JST午前0時=前日UTC15時）→ JST暦日のUTC 00:00 正規化（保存値と比較境界を一致）
- 読み出し・集計側（yuchoService の UTC 範囲フィルタ / getUTCMonth / getStatsByYear）は UTC 解釈のため**変更しない**（issue指示: 触ると二重補正）
- controller 側の同根コード（syncBurialCount のインライン日付計算）は **PR #245** が `updateCollectiveBurialCount` への委譲で置き換えるため本PRでは触らない（コンフリクト回避・どちらの順でマージしても最終状態は正しい）

### #215: 和暦変換が元号を年だけで判定
`toJapaneseDate` が 2019年1〜4月を「令和元年」（正: 平成31年）、1989年1月初週を「平成元年」（正: 昭和64年）と誤変換。

**修正**: 境界日比較（令和=2019-05-01〜 / 平成=1989-01-08〜 / 昭和=1926-12-25〜）へ変更し frontend `formatDateWithEra` と基準を統一。元号判定を `resolveJapaneseEra()` に一本化し、`toJapaneseYearMonth` の昭和分岐欠落も解消。現状未使用関数だが書類生成での将来利用に備え修正（削除でなく修正を選択）。

## テスト
- 固定時刻（`2026-12-31T20:00Z` = JST 2027-01-01 05:00）で capacity_reached_date が `2027-01-01T00:00:00Z`、billing_scheduled_date が `2030-01-01T00:00:00Z` になること
- `getBillingTargets` の lte 基準日正規化
- 元号境界（平成31年4月 / 令和元年5月1日 / 昭和64年1月7日 / 平成元年1月8日 / 昭和元年）
- `tests/utils/dateUtils.test.ts` 新設、全906テストpass、tsc clean、lint clean

Closes #214
Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
