### PR TITLE
fix(middleware): エラーレスポンスの内部情報漏洩・誤分類・ヘッダ不整合・入力リフレクションを修正 (#217, #225, #227, #228)

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -13,7 +13,33 @@ interface HandledError {
   status?: number;
   code?: string;
   details?: unknown[];
+  /** body-parser (http-errors) が設定するエラー種別（例: 'entity.parse.failed'） */
+  type?: string;
 }
+
+/** 4xx ステータスをクライアントエラーコードへマップする（#225） */
+const clientErrorCodeForStatus = (status: number): string => {
+  switch (status) {
+    case 400:
+      return 'BAD_REQUEST';
+    case 401:
+      return 'UNAUTHORIZED';
+    case 403:
+      return 'FORBIDDEN';
+    case 404:
+      return 'NOT_FOUND';
+    case 409:
+      return 'CONFLICT';
+    case 413:
+      return 'PAYLOAD_TOO_LARGE';
+    case 415:
+      return 'UNSUPPORTED_MEDIA_TYPE';
+    case 429:
+      return 'TOO_MANY_REQUESTS';
+    default:
+      return 'BAD_REQUEST';
+  }
+};
 
 /**
  * グローバルエラーハンドラー
@@ -87,12 +113,50 @@ export const errorHandler = (error: unknown, req: Request, res: Response, _next:
   }
 
   if (error instanceof Prisma.PrismaClientValidationError) {
+    // error.message にはテーブル名・カラム名・期待型等のスキーマ情報が含まれるため
+    // クライアントには返さない（#217）。詳細はサーバログ・Sentryに記録済み。
     return res.status(400).json({
       success: false,
       error: {
         code: 'VALIDATION_ERROR',
         message: 'データベースバリデーションエラー',
-        details: [{ message: error.message }],
+        details: [],
+      },
+    });
+  }
+
+  // body-parser / Express 由来のエラー（#225）
+  // これらは status を持つが code を持たず、message に内部実装文言
+  // （送信ボディ断片を含む）が入るため、固定文言・適切なコードへ変換する。
+  if (err.type === 'entity.too.large' || err.status === 413) {
+    return res.status(413).json({
+      success: false,
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+        message: 'リクエストボディが大きすぎます',
+        details: [],
+      },
+    });
+  }
+
+  if (err.type === 'entity.parse.failed' || (error instanceof SyntaxError && err.status === 400)) {
+    return res.status(400).json({
+      success: false,
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'リクエストボディの形式が不正です',
+        details: [],
+      },
+    });
+  }
+
+  if (error instanceof URIError) {
+    return res.status(400).json({
+      success: false,
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'リクエストURLの形式が不正です',
+        details: [],
       },
     });
   }
@@ -154,6 +218,20 @@ export const errorHandler = (error: unknown, req: Request, res: Response, _next:
   }
 
   // デフォルトのエラーレスポンス
+  // 未知の 4xx（http-errors 由来等）は INTERNAL_SERVER_ERROR と誤分類せず、
+  // ステータスに応じたクライアントエラーコード＋汎用文言へ安全側に倒す（#225）。
+  // 生の err.message は内部実装情報を含みうるためクライアントへ返さない。
+  if (err.status && err.status >= 400 && err.status < 500) {
+    return res.status(err.status).json({
+      success: false,
+      error: {
+        code: err.code || clientErrorCodeForStatus(err.status),
+        message: 'リクエストを処理できませんでした',
+        details: [],
+      },
+    });
+  }
+
   return res.status(err.status || 500).json({
     success: false,
     error: {
@@ -248,6 +326,8 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
         },
       });
 
+    // 以下の分岐では error.message（テーブル名・制約名等のDB内部情報を含む）を
+    // クライアントへ返さない（#217）。詳細はサーバログ・Sentryに記録済み。
     case 'P2003':
       // Foreign key constraint violation
       return res.status(400).json({
@@ -255,7 +335,7 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
         error: {
           code: 'VALIDATION_ERROR',
           message: '関連するデータが存在しません',
-          details: [{ message: error.message }],
+          details: [],
         },
       });
 
@@ -266,7 +346,7 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
         error: {
           code: 'VALIDATION_ERROR',
           message: 'リレーションの制約違反',
-          details: [{ message: error.message }],
+          details: [],
         },
       });
 
@@ -276,7 +356,7 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
         error: {
           code: 'DATABASE_ERROR',
           message: 'データベースエラーが発生しました',
-          details: [{ message: error.message }],
+          details: [],
         },
       });
   }
@@ -286,12 +366,14 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
  * 404エラーハンドラー
  * ルートが見つからない場合に実行される
  */
-export const notFoundHandler = (req: Request, res: Response) => {
+export const notFoundHandler = (_req: Request, res: Response) => {
+  // req.path はクライアント任意の文字列のためレスポンスに反映しない（#228、入力リフレクション対策）。
+  // パスは requestLogger が構造化ログ（method/path フィールド）で記録済み。
   return res.status(404).json({
     success: false,
     error: {
       code: 'NOT_FOUND',
-      message: `ルート ${req.method} ${req.path} が見つかりません`,
+      message: 'リクエストされたルートが見つかりません',
       details: [],
     },
   });

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -42,6 +42,11 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
 /**
  * セキュリティヘッダーミドルウェア
  * セキュリティ関連のHTTPヘッダーを設定
+ *
+ * 注意: X-XSS-Protection は helmet（xssFilter: true → `0`）へ一本化した（#227）。
+ * 旧来ここで `1; mode=block` を上書きしていたが、これは非推奨値であり、
+ * かつボディパーサ段階のエラー応答では本ミドルウェアを通らず helmet 値が
+ * 返るため、応答間でヘッダが不整合になっていた。
  */
 export const securityHeaders = (req: Request, res: Response, next: NextFunction) => {
   // X-Content-Type-Options
@@ -49,9 +54,6 @@ export const securityHeaders = (req: Request, res: Response, next: NextFunction)
 
   // X-Frame-Options
   res.setHeader('X-Frame-Options', 'DENY');
-
-  // X-XSS-Protection
-  res.setHeader('X-XSS-Protection', '1; mode=block');
 
   // Strict-Transport-Security (HTTPSの場合のみ)
   if (req.secure) {

--- a/tests/middleware/errorHandler.test.ts
+++ b/tests/middleware/errorHandler.test.ts
@@ -272,7 +272,8 @@ describe('Error Handler Middleware', () => {
           error: {
             code: 'VALIDATION_ERROR',
             message: '関連するデータが存在しません',
-            details: [{ message: error.message }],
+            // 内部スキーマ情報を含む error.message は返さない（#217）
+            details: [],
           },
         });
       });
@@ -291,7 +292,8 @@ describe('Error Handler Middleware', () => {
           error: {
             code: 'VALIDATION_ERROR',
             message: 'リレーションの制約違反',
-            details: [{ message: error.message }],
+            // 内部スキーマ情報を含む error.message は返さない（#217）
+            details: [],
           },
         });
       });
@@ -310,7 +312,8 @@ describe('Error Handler Middleware', () => {
           error: {
             code: 'DATABASE_ERROR',
             message: 'データベースエラーが発生しました',
-            details: [{ message: error.message }],
+            // 内部スキーマ情報を含む error.message は返さない（#217）
+            details: [],
           },
         });
       });
@@ -328,7 +331,8 @@ describe('Error Handler Middleware', () => {
           error: {
             code: 'VALIDATION_ERROR',
             message: 'データベースバリデーションエラー',
-            details: [{ message: error.message }],
+            // 内部スキーマ情報を含む error.message は返さない（#217）
+            details: [],
           },
         });
       });
@@ -529,7 +533,8 @@ describe('Error Handler Middleware', () => {
           success: false,
           error: {
             code: 'TEAPOT',
-            message: 'カスタムエラー',
+            // 4xx は raw な err.message を返さず汎用文言に置換（#225）
+            message: 'リクエストを処理できませんでした',
             details: [],
           },
         });
@@ -567,6 +572,96 @@ describe('Error Handler Middleware', () => {
         });
       });
     });
+
+    describe('body-parser / Express 由来エラー処理 (#225)', () => {
+      it('JSONパース失敗（entity.parse.failed）は 400 BAD_REQUEST 固定文言になること', () => {
+        const error: any = new SyntaxError(
+          `Unexpected token 'b', "{"email": broken" is not valid JSON`
+        );
+        error.status = 400;
+        error.type = 'entity.parse.failed';
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'リクエストボディの形式が不正です',
+            details: [],
+          },
+        });
+      });
+
+      it('サイズ超過（entity.too.large）は 413 PAYLOAD_TOO_LARGE 固定文言になること', () => {
+        const error: any = new Error('request entity too large');
+        error.status = 413;
+        error.type = 'entity.too.large';
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(413);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'PAYLOAD_TOO_LARGE',
+            message: 'リクエストボディが大きすぎます',
+            details: [],
+          },
+        });
+      });
+
+      it('URIデコード失敗（URIError）は 400 BAD_REQUEST 固定文言になること', () => {
+        const error = new URIError("Failed to decode param '%E0%A4%A'");
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'リクエストURLの形式が不正です',
+            details: [],
+          },
+        });
+      });
+
+      it('コードを持たない未知の 4xx はステータスに応じたコードへマップされること', () => {
+        const error: any = new Error('some internal http-errors message');
+        error.status = 415;
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(415);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'UNSUPPORTED_MEDIA_TYPE',
+            message: 'リクエストを処理できませんでした',
+            details: [],
+          },
+        });
+      });
+
+      it('5xx は従来どおり INTERNAL_SERVER_ERROR を返すこと', () => {
+        const error: any = new Error('upstream failure');
+        error.status = 502;
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(502);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'upstream failure',
+            details: [],
+          },
+        });
+      });
+    });
   });
 
   describe('notFoundHandler', () => {
@@ -583,7 +678,8 @@ describe('Error Handler Middleware', () => {
         success: false,
         error: {
           code: 'NOT_FOUND',
-          message: 'ルート POST /api/nonexistent が見つかりません',
+          // リクエストパスを反映しない固定文言（#228 入力リフレクション対策）
+          message: 'リクエストされたルートが見つかりません',
           details: [],
         },
       });

--- a/tests/middleware/logger.test.ts
+++ b/tests/middleware/logger.test.ts
@@ -203,8 +203,16 @@ describe('Logger Middleware', () => {
 
       expect(mockResponse.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff');
       expect(mockResponse.setHeader).toHaveBeenCalledWith('X-Frame-Options', 'DENY');
-      expect(mockResponse.setHeader).toHaveBeenCalledWith('X-XSS-Protection', '1; mode=block');
       expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('X-XSS-Protection は設定しないこと（helmet の xssFilter へ一本化 #227）', () => {
+      securityHeaders(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockResponse.setHeader).not.toHaveBeenCalledWith(
+        'X-XSS-Protection',
+        expect.any(String)
+      );
     });
 
     it('HTTPSリクエストの場合、Strict-Transport-Securityヘッダーを設定すること', () => {


### PR DESCRIPTION
## 概要
バグ監査起票のエラーレスポンス系4件（errorHandler.ts / logger.ts に閉じた同根グループ）をまとめて修正。

### #217: Prisma 生エラーメッセージの漏洩（スキーマ情報開示）
`PrismaClientValidationError` / P2003 / P2014 / default(DATABASE_ERROR) の4分岐が `details: [{ message: error.message }]` でテーブル名・カラム名・制約名・期待型をクライアントへ返していた。
**修正**: 全環境で `details: []` に変更（issue方針どおり、NODE_ENV分岐ではなく原則非返却）。サーバログ（prismaCode/prismaMeta 付き）と Sentry への記録は既存のままで調査性は損なわれない。

### #225: パーサ段階のエラーが `INTERNAL_SERVER_ERROR` ＋ 内部メッセージ漏洩
壊れJSON / 不正%エンコード / 10MB超ボディで、HTTPステータスは 400/413 なのにコードが `INTERNAL_SERVER_ERROR`、message に `Unexpected token ... is not valid JSON`（送信ボディ断片を含む）等が漏れていた。
**修正**:
- `entity.too.large` → **413 PAYLOAD_TOO_LARGE**「リクエストボディが大きすぎます」
- `entity.parse.failed` / SyntaxError+400 → **400 BAD_REQUEST**「リクエストボディの形式が不正です」
- `URIError` → **400 BAD_REQUEST**「リクエストURLの形式が不正です」
- 保険: 未知の 4xx は `clientErrorCodeForStatus()` でステータス対応コードへマップし、raw な `err.message` は返さず汎用文言へ（5xx は従来どおり）

### #227: X-XSS-Protection のエラー応答間不整合
issue推奨の **(1) helmet 一本化** を採用。securityHeaders の `X-XSS-Protection: 1; mode=block`（非推奨値）setHeader を削除し、helmet の `xssFilter`（→`0`、推奨値）に統一。全応答でヘッダが一貫する。

### #228: 404ハンドラの入力リフレクション
`ルート GET /api/v1/<script>... が見つかりません` のようにデコード済みパスがレスポンスに反映されていた。**固定文言化**（issue最小修正どおり）。パスは requestLogger の構造化ログで記録済み。

## テスト
- 既存テストの期待値を新方針へ更新（details空・固定文言・4xx汎用文言）
- 新規: entity.parse.failed / entity.too.large / URIError / 未知4xxマップ / 5xx従来動作 / X-XSS-Protection非設定 の6ケース
- 全893テストpass、tsc clean、lint clean

## 残課題（スコープ外）
- #217 の根治案（collective-burials ルートへの Zod validate 追加）は別途検討（PrismaClientValidationError 自体の発火防止）

Closes #217
Closes #225
Closes #227
Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
