### PR TITLE
fix(security): 入力サニタイザのデータ破壊廃止とミドルウェア順序を修正 (#218, #219, #226)

### DIFF
--- a/scripts/fix-html-escaped-data.ts
+++ b/scripts/fix-html-escaped-data.ts
@@ -1,0 +1,205 @@
+/**
+ * HTMLエスケープ済みデータの一括是正スクリプト（#218）
+ *
+ * 旧 sanitizeInput が入力時に HTML エスケープ（& < > " ' /）した値を
+ * DB へ永続化していたため、既存データに &amp; &#x27; &#x2F; 等の
+ * HTMLエンティティが混入している。本スクリプトはそれらを元の文字へ復号する。
+ *
+ * 使い方:
+ *   npx ts-node scripts/fix-html-escaped-data.ts            # dry-run（件数と変更例の表示のみ）
+ *   npx ts-node scripts/fix-html-escaped-data.ts --apply    # 実際に更新
+ *
+ * 二重エスケープ（&amp;amp; 等）にも対応するため、変化しなくなるまで
+ * （最大5回）復号を繰り返す。
+ */
+
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+const APPLY = process.argv.includes('--apply');
+
+/** 旧 sanitizeString が生成していたエンティティのみを対象に復号する */
+const decodeOnce = (value: string): string =>
+  value
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&'); // & は最後に戻す（順序重要）
+
+const decodeFully = (value: string): string => {
+  let current = value;
+  for (let i = 0; i < 5; i++) {
+    const next = decodeOnce(current);
+    if (next === current) break;
+    current = next;
+  }
+  return current;
+};
+
+/** エンティティ混入の検出パターン（旧 sanitizeString が生成する6種） */
+const ENTITY_PATTERN = /&(amp|lt|gt|quot|#x27|#x2F);/;
+
+/**
+ * 是正対象のモデルとテキスト系フィールド。
+ * ゆうちょCSV・帳票に乗る列（顧客名義・口座情報）を最優先に、
+ * ユーザー入力由来の自由記述フィールドを広めにカバーする。
+ */
+const TARGETS: Array<{ model: string; idField: string; fields: string[] }> = [
+  {
+    model: 'customer',
+    idField: 'id',
+    fields: [
+      'name',
+      'name_kana',
+      'address',
+      'address_line_2',
+      'registered_address',
+      'email',
+      'notes',
+      'bank_name',
+      'branch_name',
+      'account_number',
+      'account_holder',
+    ],
+  },
+  {
+    model: 'familyContact',
+    idField: 'id',
+    fields: [
+      'name',
+      'name_kana',
+      'address',
+      'registered_address',
+      'email',
+      'work_company_name',
+      'work_company_name_kana',
+      'work_address',
+      'notes',
+    ],
+  },
+  {
+    model: 'buriedPerson',
+    idField: 'id',
+    fields: [
+      'name',
+      'name_kana',
+      'posthumous_name',
+      'relationship',
+      'religion',
+      'death_place',
+      'cause_of_death',
+      'chief_mourner_name',
+      'chief_mourner_relationship',
+      'notes',
+    ],
+  },
+  { model: 'physicalPlot', idField: 'id', fields: ['notes'] },
+  {
+    model: 'contractPlot',
+    idField: 'id',
+    fields: ['location_description', 'staff_in_charge', 'agent_name', 'notes'],
+  },
+  {
+    model: 'gravestoneInfo',
+    idField: 'id',
+    fields: [
+      'gravestone_base',
+      'enclosure_position',
+      'gravestone_dealer',
+      'gravestone_type',
+      'surrounding_area',
+      'gravestone_inscription',
+    ],
+  },
+  { model: 'constructionInfo', idField: 'id', fields: ['construction_type', 'notes'] },
+  { model: 'collectiveBurial', idField: 'id', fields: ['notes'] },
+  { model: 'workInfo', idField: 'id', fields: ['company_name', 'work_address', 'notes'] },
+  { model: 'staff', idField: 'id', fields: ['name'] },
+  { model: 'document', idField: 'id', fields: ['name', 'description', 'notes'] },
+  { model: 'billing', idField: 'id', fields: ['notes'] },
+  { model: 'payment', idField: 'id', fields: ['staff_in_charge', 'notes'] },
+];
+
+interface ModelDelegate {
+  findMany(args: unknown): Promise<Record<string, unknown>[]>;
+  update(args: unknown): Promise<unknown>;
+}
+
+async function main(): Promise<void> {
+  const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+  const prisma = new PrismaClient({ adapter });
+
+  console.log(`=== HTMLエスケープ済みデータの是正 (${APPLY ? 'APPLY' : 'DRY-RUN'}) ===`);
+
+  let totalRows = 0;
+  let totalFields = 0;
+
+  try {
+    for (const target of TARGETS) {
+      const delegate = (prisma as unknown as Record<string, ModelDelegate>)[target.model];
+      if (!delegate) {
+        console.warn(`! モデル ${target.model} が見つかりません（スキップ）`);
+        continue;
+      }
+
+      // エンティティ混入の可能性がある行のみ取得（contains は近似フィルタ、最終判定は正規表現）
+      const rows = await delegate.findMany({
+        where: {
+          OR: target.fields.map((f) => ({ [f]: { contains: '&' } })),
+        },
+        select: Object.fromEntries(
+          [target.idField, ...target.fields].map((f) => [f, true])
+        ) as Record<string, boolean>,
+      });
+
+      let modelRows = 0;
+      for (const row of rows) {
+        const data: Record<string, string> = {};
+        for (const field of target.fields) {
+          const value = row[field];
+          if (typeof value !== 'string' || !ENTITY_PATTERN.test(value)) continue;
+          const decoded = decodeFully(value);
+          if (decoded !== value) {
+            data[field] = decoded;
+          }
+        }
+        if (Object.keys(data).length === 0) continue;
+
+        modelRows += 1;
+        totalFields += Object.keys(data).length;
+
+        const id = row[target.idField];
+        if (APPLY) {
+          await delegate.update({ where: { [target.idField]: id }, data });
+        } else {
+          // dry-run: 変更内容のサンプル表示
+          for (const [field, decoded] of Object.entries(data)) {
+            console.log(
+              `  [${target.model}.${field}] id=${String(id)}: ${JSON.stringify(row[field])} -> ${JSON.stringify(decoded)}`
+            );
+          }
+        }
+      }
+
+      if (modelRows > 0) {
+        totalRows += modelRows;
+        console.log(`${target.model}: ${modelRows} 行 ${APPLY ? '更新' : '是正対象'}`);
+      }
+    }
+
+    console.log(`=== 合計: ${totalRows} 行 / ${totalFields} フィールド ===`);
+    if (!APPLY && totalRows > 0) {
+      console.log('実際に更新するには --apply を付けて再実行してください');
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,22 @@ app.set('trust proxy', 1);
 // セキュリティミドルウェアの設定（最初に適用）
 app.use(getHelmetOptions()); // Helmet: セキュリティヘッダー
 app.use(cors(getCorsOptions())); // CORS設定（厳格化）
-app.use(hppProtection); // HTTP Parameter Pollution対策
+
+// Rate Limiting（全体）
+// ボディパーサより前に適用する（#226）。パーサ後に置くと、壊れたJSONや
+// サイズ超過のリクエストがパーサ段階で例外になり Limiter に到達せず、
+// レート制限を消費しないDoS増幅経路になる。keyGenerator は req.ip ベースで
+// ボディに依存しないためパーサ前でも安全。/health は limiter 側の skip で除外。
+app.use(createRateLimiter());
 
 // ボディパーサー
 app.use(express.json({ limit: '10mb' })); // JSONパーサー（サイズ制限付き）
 app.use(express.urlencoded({ extended: true, limit: '10mb' })); // URLエンコードされたボディのパーサー
+
+// HTTP Parameter Pollution対策
+// req.body を検査するためボディパーサの後に適用する（#219）。
+// パーサ前に置くと req.body が未パースでボディ側のHPP保護が無効だった。
+app.use(hppProtection);
 
 // Cookieパーサー（HttpOnly Cookie認証用）
 app.use(cookieParser());
@@ -55,7 +66,7 @@ app.use(cookieParser());
 // 入力サニタイゼーション（パーサーの後に適用）
 app.use(sanitizeInput);
 
-// ヘルスチェックエンドポイント（Rate Limiterの前に配置 — Renderヘルスチェックが429で失敗するのを防止）
+// ヘルスチェックエンドポイント（Rate Limiter は skip 設定で /health を除外済み — Renderヘルスチェックが429で失敗するのを防止）
 app.get('/health', async (_req, res) => {
   try {
     await prisma.$queryRaw`SELECT 1`;
@@ -80,9 +91,6 @@ app.get('/health', async (_req, res) => {
     });
   }
 });
-
-// Rate Limiting（全体）
-app.use(createRateLimiter());
 
 // リクエストID付与（requestLoggerの前に配置）
 app.use(requestIdMiddleware);

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -79,6 +79,9 @@ export const createRateLimiter = () => {
     },
     standardHeaders: true, // `RateLimit-*` ヘッダーを返す
     legacyHeaders: false, // `X-RateLimit-*` ヘッダーを無効化
+    // ボディパーサより前に適用するため（#226）、/health は明示的に除外する
+    // （Render等のヘルスチェックが429で失敗するのを防止）
+    skip: (req) => req.path === '/health',
     // デフォルトのkeyGeneratorを使用（IPv6対応済み）
   });
 };
@@ -171,12 +174,22 @@ export const getHelmetOptions = () => {
 /**
  * HTTP Parameter Pollution (HPP) 対策
  * 重複したクエリパラメータやボディパラメータを防止
+ *
+ * 注意: req.body を検査するためボディパーサより後に適用すること（#219）。
+ * 本APIは JSON 主体のため実効はほぼ query 側だが、urlencoded ボディの
+ * 重複パラメータ除去もパーサ後配置で機能する。
  */
 export const hppProtection = hpp();
 
 /**
  * 入力サニタイゼーションミドルウェア
- * XSS攻撃を防ぐため、危険な文字をエスケープ
+ *
+ * 方針変更（#218）: 旧実装は全入力文字列を HTML エスケープ（& < > " ' /）して
+ * DB に永続化していたため、顧客名・住所・口座名義等の元データを破壊し、
+ * ゆうちょ振替CSVの名義不正や帳票出力時の二重エスケープ（&amp;amp;）を
+ * 引き起こしていた。XSS 対策は出力時エスケープ（React の既定エスケープ＋
+ * documentService.escapeHtml）に一本化し、入力側は保存値を変えない無害化
+ * （制御文字の除去）のみに限定する。
  */
 export const sanitizeInput = (req: Request, _res: Response, next: NextFunction) => {
   // リクエストボディのサニタイゼーション
@@ -221,18 +234,17 @@ const sanitizeObject = (obj: unknown): unknown => {
 
 /**
  * 文字列のサニタイゼーション
- * XSS攻撃に使用される可能性のある文字をエスケープ
+ *
+ * 保存値を変えない無害化のみ行う（#218）:
+ * - C0/C1 制御文字（タブ・改行・復帰を除く）の除去
+ * HTML エスケープは行わない（出力時エスケープに一本化。入力時に行うと
+ * DB 保存値が破壊され、CSV/帳票出力の名義不正・二重エスケープの実害が出る）。
  */
 const sanitizeString = (str: string): string => {
   if (typeof str !== 'string') {
     return str;
   }
 
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-    .replace(/\//g, '&#x2F;');
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g, '');
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -246,13 +246,36 @@ describe('Server Index', () => {
   it('should register all middleware and routes correctly', () => {
     require('../src/index');
 
-    // セキュリティミドルウェア（helmet, cors, hpp, json, urlencoded, cookieParser, sanitizeInput, rateLimiter）
+    // セキュリティミドルウェア（helmet, cors, rateLimiter, json, urlencoded, hpp, cookieParser, sanitizeInput）
     // + requestIdMiddleware + ログミドルウェア（requestLogger, securityHeaders）
     // + Swagger UI + 9 API routes (auth, plots, masters, staff, collective-burials, documents, yucho, billings, payments)
     // + notFoundHandler + errorHandler = 23 use calls
     expect(mockApp.use).toHaveBeenCalledTimes(23);
     // 1 health check endpoint
     expect(mockApp.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('should wire rate limiter before body parsers and hpp after them (#226, #219)', () => {
+    require('../src/index');
+
+    const useArgs = (mockApp.use as jest.Mock).mock.calls.map((call) => call[0]);
+    const security = jest.requireMock('../src/middleware/security');
+    const rateLimiterInstance = (security.createRateLimiter as jest.Mock).mock.results[0]?.value;
+
+    const rateLimiterIdx = useArgs.indexOf(rateLimiterInstance);
+    const jsonIdx = useArgs.indexOf('json-middleware');
+    const urlencodedIdx = useArgs.indexOf('urlencoded-middleware');
+    const hppIdx = useArgs.indexOf(security.hppProtection);
+    const sanitizeIdx = useArgs.indexOf(security.sanitizeInput);
+
+    // Rate Limiter はボディパーサより前（壊れボディ/サイズ超過でも制限を消費させる #226）
+    expect(rateLimiterIdx).toBeGreaterThanOrEqual(0);
+    expect(rateLimiterIdx).toBeLessThan(jsonIdx);
+    // HPP はボディパーサより後（req.body 検査を有効化する #219）
+    expect(hppIdx).toBeGreaterThan(jsonIdx);
+    expect(hppIdx).toBeGreaterThan(urlencodedIdx);
+    // sanitizeInput もパーサ後
+    expect(sanitizeIdx).toBeGreaterThan(jsonIdx);
   });
 
   it('should initialize Sentry', () => {

--- a/tests/middleware/security.test.ts
+++ b/tests/middleware/security.test.ts
@@ -121,61 +121,72 @@ describe('Security Middleware', () => {
   });
 
   describe('sanitizeInput', () => {
-    it('リクエストボディの文字列をサニタイズすること', () => {
+    // 方針変更（#218）: HTML エスケープは行わず保存値を維持する。
+    // XSS 対策は出力時エスケープ（React 既定 + documentService.escapeHtml）に一本化。
+    it('リクエストボディの文字列をHTMLエスケープしないこと（保存値を破壊しない #218）', () => {
       mockRequest.body = {
-        name: '<script>alert("XSS")</script>',
+        name: "O'Brien & Sons / 丸&商店",
         email: 'user@example.com',
       };
 
       sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockRequest.body.name).toBe(
-        '&lt;script&gt;alert(&quot;XSS&quot;)&lt;&#x2F;script&gt;'
-      );
+      expect(mockRequest.body.name).toBe("O'Brien & Sons / 丸&商店");
       expect(mockRequest.body.email).toBe('user@example.com');
       expect(mockNext).toHaveBeenCalled();
     });
 
-    it('クエリパラメータをサニタイズすること', () => {
+    it('制御文字は除去すること', () => {
+      mockRequest.body = {
+        name: 'テスト\u0000名前\u0007',
+        memo: '行1\n行2\tタブ', // タブ・改行は許容
+      };
+
+      sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockRequest.body.name).toBe('テスト名前');
+      expect(mockRequest.body.memo).toBe('行1\n行2\tタブ');
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('クエリパラメータの値も変更しないこと', () => {
       mockRequest.query = {
         search: '<img src=x onerror=alert(1)>',
       };
 
       sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockRequest.query.search).toBe('&lt;img src=x onerror=alert(1)&gt;');
+      expect(mockRequest.query.search).toBe('<img src=x onerror=alert(1)>');
       expect(mockNext).toHaveBeenCalled();
     });
 
-    it('ネストされたオブジェクトをサニタイズすること', () => {
+    it('ネストされたオブジェクトも値を維持すること', () => {
       mockRequest.body = {
         user: {
           name: '<b>Bold</b>',
           address: {
-            street: '<a href="#">Link</a>',
+            street: 'A/B棟 1-2-3',
           },
         },
       };
 
       sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockRequest.body.user.name).toBe('&lt;b&gt;Bold&lt;&#x2F;b&gt;');
-      expect(mockRequest.body.user.address.street).toBe(
-        '&lt;a href=&quot;#&quot;&gt;Link&lt;&#x2F;a&gt;'
-      );
+      expect(mockRequest.body.user.name).toBe('<b>Bold</b>');
+      expect(mockRequest.body.user.address.street).toBe('A/B棟 1-2-3');
       expect(mockNext).toHaveBeenCalled();
     });
 
-    it('配列内の文字列をサニタイズすること', () => {
+    it('配列内の文字列も値を維持すること', () => {
       mockRequest.body = {
-        tags: ['<script>evil</script>', 'normal', '<div>html</div>'],
+        tags: ['<script>evil</script>', 'normal', '制御\u0001文字'],
       };
 
       sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockRequest.body.tags[0]).toBe('&lt;script&gt;evil&lt;&#x2F;script&gt;');
+      expect(mockRequest.body.tags[0]).toBe('<script>evil</script>');
       expect(mockRequest.body.tags[1]).toBe('normal');
-      expect(mockRequest.body.tags[2]).toBe('&lt;div&gt;html&lt;&#x2F;div&gt;');
+      expect(mockRequest.body.tags[2]).toBe('制御文字');
       expect(mockNext).toHaveBeenCalled();
     });
 
@@ -207,14 +218,14 @@ describe('Security Middleware', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
-    it('特殊文字をすべてエスケープすること', () => {
+    it('特殊文字（& < > \" \' /）をエスケープせず維持すること（#218）', () => {
       mockRequest.body = {
         text: '& < > " \' /',
       };
 
       sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockRequest.body.text).toBe('&amp; &lt; &gt; &quot; &#x27; &#x2F;');
+      expect(mockRequest.body.text).toBe('& < > " \' /');
       expect(mockNext).toHaveBeenCalled();
     });
 
@@ -235,14 +246,14 @@ describe('Security Middleware', () => {
 
       sanitizeInput(mockRequest as Request, mockResponse as Response, mockNext);
 
-      expect(mockRequest.body.mixed.string).toBe('&lt;script&gt;');
+      expect(mockRequest.body.mixed.string).toBe('<script>');
       expect(mockRequest.body.mixed.number).toBe(123);
       expect(mockRequest.body.mixed.boolean).toBe(true);
       expect(mockRequest.body.mixed.nullValue).toBeNull();
-      expect(mockRequest.body.mixed.array[0]).toBe('&lt;b&gt;test&lt;&#x2F;b&gt;');
+      expect(mockRequest.body.mixed.array[0]).toBe('<b>test</b>');
       expect(mockRequest.body.mixed.array[1]).toBe(456);
       expect(mockRequest.body.mixed.array[2]).toBe(false);
-      expect(mockRequest.body.mixed.nested.html).toBe('&lt;div&gt;content&lt;&#x2F;div&gt;');
+      expect(mockRequest.body.mixed.nested.html).toBe('<div>content</div>');
       expect(mockRequest.body.mixed.nested.count).toBe(42);
       expect(mockNext).toHaveBeenCalled();
     });


### PR DESCRIPTION
## 概要
バグ監査起票のミドルウェア入力系3件（index.ts/security.ts同根）をまとめて修正。**#218は監査の目玉issue。**

### #218: 入力サニタイザが DB 保存値を HTML エスケープしデータ破壊
全リクエストの body/query を `&`→`&amp;`、`'`→`&#x27;`、`/`→`&#x2F;` 等に書き換えて永続化していたため:
1. 顧客名 `O'Brien`・住所 `A/B`・`丸&商店` が壊れて保存される
2. ゆうちょ振替CSVの口座名義・請求書PDFの宛名が不正になる
3. 帳票生成の出力時 `escapeHtml` と組み合わさり `&amp;amp;` の二重エスケープが発生

**修正**（issue方針1のバランス案）:
- `sanitizeString` を**保存値を変えない無害化**（C0/C1制御文字の除去のみ、タブ・改行・復帰は許容）に変更。ミドルウェア自体は残し、HTML エスケープを全廃
- XSS 対策は**出力時エスケープに一本化**（React の既定エスケープ + `documentService.escapeHtml`（出力時、実装済・維持））
- **既存DB是正スクリプト** `scripts/fix-html-escaped-data.ts` を新設（issue方針4）:
  - dry-run 既定 / `--apply` で更新、変化しなくなるまで復号（二重エスケープ `&amp;amp;` 対応）
  - Customer の口座系（ゆうちょCSV列）を最優先に、13モデルのユーザー入力フィールドを対象
  - Prisma v7 driver adapter 対応（#235 の轍を踏まない）

### #226: パーサ段階のエラーが Rate Limiter を完全バイパス
壊れJSON・10MB超ボディは `express.json()` で例外になり Limiter 未到達 → カウント消費なしで無制限送信可能（DoS増幅経路）。
**修正**: `createRateLimiter()` を helmet/cors 直後・ボディパーサ前へ移動（issue推奨案）。express-rate-limit の keyGenerator は req.ip ベースでボディ非依存のため安全。`/health` は limiter の `skip` で除外し、Render ヘルスチェック429対策を維持。

### #219: HPP がボディパーサより前で req.body 検査が無効
**修正**: `hppProtection` をボディパーサ直後へ移動。query 側の保護は維持、urlencoded ボディの重複パラメータ除去が機能するように。

## 新しいミドルウェア順序
```
Helmet → CORS → Rate Limiter → JSON/URLencoded パーサ → HPP → cookieParser → sanitizeInput(無害化のみ) → /health → requestId → ログ → Routes → 404 → errorHandler
```

## テスト
- ミドルウェア配線順序の回帰テスト（limiter < parser < hpp/sanitize）
- サニタイザ新方針: 特殊文字維持・制御文字除去・ネスト/配列維持の各ケース
- 全889テストpass、tsc clean、lint clean

## 運用メモ（マージ後）
- 本番DBに対し `npx ts-node scripts/fix-html-escaped-data.ts` で dry-run 確認 → `--apply` で是正
- CLAUDE.md のミドルウェアスタック順の記述は別途更新可（軽微）

Closes #218
Closes #219
Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)