### PR TITLE
fix(migration): 移行ステップの冪等性・truncate漏れ・検証の上振れ検出・dry-run resume を修正 (#220-#224)

### DIFF
--- a/prisma/migrations/20260605120000_add_legacy_idempotency_keys/migration.sql
+++ b/prisma/migrations/20260605120000_add_legacy_idempotency_keys/migration.sql
@@ -1,0 +1,25 @@
+-- #220/#221: レガシー移行の冪等キーと申込者識別カラムを追加
+-- FamilyContact / BuriedPerson / ConstructionInfo はレガシー自然キーを保持して
+-- 再実行時の重複INSERTを防ぎ（billing/payment の legacy_*_cd と同形）、
+-- Customer は申込者（契約者と別人）として作成された行を識別できるようにする。
+
+-- AlterTable
+ALTER TABLE "family_contacts" ADD COLUMN "legacy_family_cd" INTEGER;
+
+-- AlterTable
+ALTER TABLE "buried_persons" ADD COLUMN "legacy_maisou_cd" INTEGER;
+
+-- AlterTable
+ALTER TABLE "construction_infos" ADD COLUMN "legacy_construction_id" INTEGER;
+
+-- AlterTable
+ALTER TABLE "customers" ADD COLUMN "legacy_applicant_danka_cd" INTEGER;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "family_contacts_legacy_family_cd_key" ON "family_contacts"("legacy_family_cd");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "buried_persons_legacy_maisou_cd_key" ON "buried_persons"("legacy_maisou_cd");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "construction_infos_legacy_construction_id_key" ON "construction_infos"("legacy_construction_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -218,31 +218,34 @@ model ContractPlot {
 
 // 顧客マスタ: 人物情報を一元管理（役割はSaleContractRoleで管理）
 model Customer {
-  id                     String    @id @default(uuid()) @map("customer_id")
-  name                   String    @db.VarChar(100) // 氏名
-  name_kana              String    @db.VarChar(100) // 氏名カナ
-  birth_date             DateTime? @db.Date // 生年月日
-  gender                 Gender? // 性別
-  postal_code            String    @db.VarChar(7) // 郵便番号
-  address                String    @db.VarChar(200) // 住所
-  address_line_2         String?   @db.VarChar(200) // 住所2（2行目）
-  registered_postal_code String?   @db.VarChar(7) // 本籍郵便番号（レガシー t_danka.honseki_zip）
-  registered_address     String?   @db.VarChar(200) // 本籍地
-  phone_number           String?   @db.VarChar(11) // 電話番号（nullable: レガシー実データに欠損あり）
-  fax_number             String?   @db.VarChar(11) // FAX番号
-  email                  String?   @db.VarChar(254) // メールアドレス（RFC 5321準拠）
+  id                        String    @id @default(uuid()) @map("customer_id")
+  name                      String    @db.VarChar(100) // 氏名
+  name_kana                 String    @db.VarChar(100) // 氏名カナ
+  birth_date                DateTime? @db.Date // 生年月日
+  gender                    Gender? // 性別
+  postal_code               String    @db.VarChar(7) // 郵便番号
+  address                   String    @db.VarChar(200) // 住所
+  address_line_2            String?   @db.VarChar(200) // 住所2（2行目）
+  registered_postal_code    String?   @db.VarChar(7) // 本籍郵便番号（レガシー t_danka.honseki_zip）
+  registered_address        String?   @db.VarChar(200) // 本籍地
+  phone_number              String?   @db.VarChar(11) // 電話番号（nullable: レガシー実データに欠損あり）
+  fax_number                String?   @db.VarChar(11) // FAX番号
+  email                     String?   @db.VarChar(254) // メールアドレス（RFC 5321準拠）
   // 振込先情報（ゆうちょ自動払込CSV 出力用。レガシーで0件運用、新システムで入力していく）
-  bank_name              String?   @db.VarChar(50) // 銀行名
-  branch_name            String?   @db.VarChar(50) // 支店名
-  account_type           String?   @db.VarChar(10) // 預金種目（ordinary/current/savings）
-  account_number         String?   @db.VarChar(20) // 口座番号
-  account_holder         String?   @db.VarChar(100) // 口座名義
-  notes                  String?   @db.Text // 備考
-  staff_id               Int? // 担当スタッフFK（レガシー tancd → matant）
-  legacy_danka_cd        Int? // 移行用（レガシー t_danka.danka_cd）
-  created_at             DateTime  @default(now())
-  updated_at             DateTime  @updatedAt
-  deleted_at             DateTime?
+  bank_name                 String?   @db.VarChar(50) // 銀行名
+  branch_name               String?   @db.VarChar(50) // 支店名
+  account_type              String?   @db.VarChar(10) // 預金種目（ordinary/current/savings）
+  account_number            String?   @db.VarChar(20) // 口座番号
+  account_holder            String?   @db.VarChar(100) // 口座名義
+  notes                     String?   @db.Text // 備考
+  staff_id                  Int? // 担当スタッフFK（レガシー tancd → matant）
+  legacy_danka_cd           Int? // 移行用（レガシー t_danka.danka_cd）
+  // 申込者（契約者と別人）として移行時に作成された Customer の識別用（#221）。
+  // truncate / cleanup の削除条件と step06 の冪等チェックに使う。
+  legacy_applicant_danka_cd Int?
+  created_at                DateTime  @default(now())
+  updated_at                DateTime  @updatedAt
+  deleted_at                DateTime?
 
   // Relations
   staff             Staff?             @relation(fields: [staff_id], references: [id], onDelete: SetNull)
@@ -404,6 +407,8 @@ model ConstructionInfo {
   updated_at           DateTime  @updatedAt
   deleted_at           DateTime?
 
+  legacy_construction_id Int? @unique // レガシー t_foundlog.construction_id（移行の冪等キー #220）
+
   // Relations
   contractPlot ContractPlot @relation(fields: [contract_plot_id], references: [id], onDelete: Cascade)
 
@@ -439,6 +444,8 @@ model FamilyContact {
   updated_at             DateTime     @updatedAt
   deleted_at             DateTime?
 
+  legacy_family_cd Int? @unique // レガシー t_family.family_cd（移行の冪等キー #220）
+
   // Relations
   contractPlot ContractPlot @relation(fields: [contract_plot_id], references: [id], onDelete: Cascade)
   customer     Customer?    @relation(fields: [customer_id], references: [id], onDelete: SetNull)
@@ -471,6 +478,8 @@ model BuriedPerson {
   created_at                 DateTime  @default(now())
   updated_at                 DateTime  @updatedAt
   deleted_at                 DateTime?
+
+  legacy_maisou_cd Int? @unique // レガシー t_maisou.maisou_cd（移行の冪等キー #220）
 
   // Relations
   contractPlot ContractPlot @relation(fields: [contract_plot_id], references: [id], onDelete: Cascade)

--- a/scripts/cleanup-legacy-data.ts
+++ b/scripts/cleanup-legacy-data.ts
@@ -37,7 +37,10 @@ async function main(): Promise<void> {
     const paymentWhere = { legacy_nyukin_cd: { not: null } } as const;
     const billingWhere = { legacy_seikyu_cd: { not: null } } as const;
     const contractPlotWhere = { legacy_grave_cd: { not: null } } as const;
-    const customerWhere = { legacy_danka_cd: { not: null } } as const;
+    // 申込者として移行作成された Customer（legacy_applicant_danka_cd）も対象に含める（#221）
+    const customerWhere = {
+      OR: [{ legacy_danka_cd: { not: null } }, { legacy_applicant_danka_cd: { not: null } }],
+    } as const;
     const physicalPlotWhere = { plot_number: { startsWith: 'legacy-' } } as const;
     const staffWhere = { supabase_uid: { startsWith: 'legacy-tancd-' } } as const;
     const relationshipMasterWhere = { code: { startsWith: '2009-' } } as const;

--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -98,7 +98,8 @@ export const stepContractPlot: MigrationStep = {
   name: 'contractPlot',
   dependsOn: ['physicalPlot'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) await rebuildIdMap(prisma, idMaps, 'physicalPlot', logger);
+    // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op #224）
+    await rebuildIdMap(prisma, idMaps, 'physicalPlot', logger);
     assertIdMapsReady('contractPlot', idMaps, ['physicalPlot']);
 
     const rows = await legacyQuery<BochiContractRow>(

--- a/scripts/legacy-migration/steps/06-sale-contract-role.ts
+++ b/scripts/legacy-migration/steps/06-sale-contract-role.ts
@@ -34,10 +34,9 @@ export const stepSaleContractRole: MigrationStep = {
   name: 'saleContractRole',
   dependsOn: ['customer', 'contractPlot'],
   async run({ prisma, logger, idMaps, dryRun }) {
-    if (!dryRun) {
-      await rebuildIdMap(prisma, idMaps, 'customer', logger);
-      await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
-    }
+    // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op #224）
+    await rebuildIdMap(prisma, idMaps, 'customer', logger);
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
     assertIdMapsReady('saleContractRole', idMaps, ['customer', 'contractPlot']);
 
     const rows = await legacyQuery<DankaRoleRow>(
@@ -163,6 +162,21 @@ export const stepSaleContractRole: MigrationStep = {
         continue;
       }
 
+      // 冪等性（#222）: 1契約に applicant は1名の業務前提に基づき、
+      // 既に applicant ロールが存在すれば申込者 Customer の生成ごとスキップする
+      // （同一人物パスと同様のガードを別人パスにも適用）
+      const existingApplicantRole = await prisma.saleContractRole.findFirst({
+        where: {
+          contract_plot_id: contractPlotId,
+          role: 'applicant',
+          deleted_at: null,
+        },
+      });
+      if (existingApplicantRole) {
+        applicantInserted++;
+        continue;
+      }
+
       const applicantCustomer = await prisma.customer.create({
         data: {
           name: requestName,
@@ -171,6 +185,8 @@ export const stepSaleContractRole: MigrationStep = {
           address: reqAddress,
           phone_number: reqPhone,
           notes: `legacy applicant of danka_cd=${row.danka_cd}`,
+          // 申込者として移行作成された Customer の識別用（truncate/cleanup で削除可能にする #221）
+          legacy_applicant_danka_cd: row.danka_cd,
         },
       });
 

--- a/scripts/legacy-migration/steps/07-family-contact.ts
+++ b/scripts/legacy-migration/steps/07-family-contact.ts
@@ -66,6 +66,7 @@ export const stepFamilyContact: MigrationStep = {
 
     let inserted = 0;
     let skipped = 0;
+    let skipExisting = 0;
     let skipMissingName = 0;
     let skipDankaNotMapped = 0;
     let skipContractPlotNotMapped = 0;
@@ -107,10 +108,21 @@ export const stepFamilyContact: MigrationStep = {
         continue;
       }
 
+      // 冪等性（#220）: 再実行時は legacy_family_cd で既存をスキップ
+      const existing = await prisma.familyContact.findUnique({
+        where: { legacy_family_cd: row.family_cd },
+      });
+      if (existing) {
+        skipped++;
+        skipExisting++;
+        continue;
+      }
+
       await prisma.familyContact.create({
         data: {
           contract_plot_id: contractPlotId,
           customer_id: customerId,
+          legacy_family_cd: row.family_cd,
           name,
           name_kana: joinName(row.family_sei_kana, row.family_mei_kana),
           birth_date: parseLegacyDate(row.birthday),
@@ -142,6 +154,7 @@ export const stepFamilyContact: MigrationStep = {
         skip_missing_name: skipMissingName,
         skip_danka_not_mapped: skipDankaNotMapped,
         skip_contract_plot_not_mapped: skipContractPlotNotMapped,
+        skip_existing: skipExisting,
       },
     };
   },

--- a/scripts/legacy-migration/steps/08-buried-person.ts
+++ b/scripts/legacy-migration/steps/08-buried-person.ts
@@ -57,6 +57,7 @@ export const stepBuriedPerson: MigrationStep = {
 
     let inserted = 0;
     let skipped = 0;
+    let skipExisting = 0;
     let skipMissingName = 0;
     let skipNoGraveCd = 0;
     let skipContractPlotNotMapped = 0;
@@ -87,9 +88,20 @@ export const stepBuriedPerson: MigrationStep = {
         continue;
       }
 
+      // 冪等性（#220）: 再実行時は legacy_maisou_cd で既存をスキップ
+      const existing = await prisma.buriedPerson.findUnique({
+        where: { legacy_maisou_cd: row.maisou_cd },
+      });
+      if (existing) {
+        skipped++;
+        skipExisting++;
+        continue;
+      }
+
       await prisma.buriedPerson.create({
         data: {
           contract_plot_id: contractPlotId,
+          legacy_maisou_cd: row.maisou_cd,
           name,
           name_kana: joinName(row.maisousha_sei_kana, row.maisousha_mei_kana),
           birth_date: parseLegacyDate(row.birthday),
@@ -118,6 +130,7 @@ export const stepBuriedPerson: MigrationStep = {
         source_rows: rows.length,
         skip_missing_name: skipMissingName,
         skip_no_grave_cd: skipNoGraveCd,
+        skip_existing: skipExisting,
         skip_contract_plot_not_mapped: skipContractPlotNotMapped,
       },
     };

--- a/scripts/legacy-migration/steps/09-construction-info.ts
+++ b/scripts/legacy-migration/steps/09-construction-info.ts
@@ -68,6 +68,7 @@ export const stepConstructionInfo: MigrationStep = {
 
     let inserted = 0;
     let skipped = 0;
+    let skipExisting = 0;
 
     for (const row of rows) {
       const contractPlotId = idMaps.contractPlot.get(row.grave_cd);
@@ -82,9 +83,20 @@ export const stepConstructionInfo: MigrationStep = {
         continue;
       }
 
+      // 冪等性（#220）: 再実行時は legacy_construction_id で既存をスキップ
+      const existing = await prisma.constructionInfo.findUnique({
+        where: { legacy_construction_id: row.construction_id },
+      });
+      if (existing) {
+        skipped++;
+        skipExisting++;
+        continue;
+      }
+
       await prisma.constructionInfo.create({
         data: {
           contract_plot_id: contractPlotId,
+          legacy_construction_id: row.construction_id,
           construction_type: cleanStr(row.construction_type),
           start_date: parseLegacyDate(row.construction_start),
           completion_date: parseLegacyDate(row.construction_end),
@@ -102,7 +114,11 @@ export const stepConstructionInfo: MigrationStep = {
     return {
       inserted,
       skipped,
-      notes: { source_rows: rows.length, contractor_masters_upserted: mastersUpserted },
+      notes: {
+        source_rows: rows.length,
+        contractor_masters_upserted: mastersUpserted,
+        skip_existing: skipExisting,
+      },
     };
   },
 };

--- a/scripts/migrate-from-legacy.ts
+++ b/scripts/migrate-from-legacy.ts
@@ -131,7 +131,12 @@ async function truncateNewDb(prisma: PrismaClient): Promise<void> {
     prisma.contractPlot.deleteMany(),
     prisma.physicalPlot.deleteMany(),
     prisma.workInfo.deleteMany(),
-    prisma.customer.deleteMany({ where: { legacy_danka_cd: { not: null } } }),
+    // 申込者として移行作成された Customer（legacy_applicant_danka_cd）も削除対象に含める（#221）
+    prisma.customer.deleteMany({
+      where: {
+        OR: [{ legacy_danka_cd: { not: null } }, { legacy_applicant_danka_cd: { not: null } }],
+      },
+    }),
     prisma.relationshipMaster.deleteMany({ where: { code: { startsWith: '2009-' } } }),
     // Staff は admin が手動で作るので残す（supabase_uid 'legacy-tancd-*' のみ削除）
     prisma.staff.deleteMany({ where: { supabase_uid: { startsWith: 'legacy-tancd-' } } }),

--- a/scripts/verify-migration.ts
+++ b/scripts/verify-migration.ts
@@ -120,7 +120,7 @@ function parseArgs(argv: string[]): Options {
 type Judgment = '✅' | '⚠️' | '❌';
 
 /** 新件数とレガシー/ベースライン件数から判定する */
-function judgeCount(
+export function judgeCount(
   actual: number,
   legacy: number | null,
   expectedInserted: number | null
@@ -131,6 +131,11 @@ function judgeCount(
   if (reference > 0 && actual < reference * 0.5) return '❌'; // 大幅不足(投入失敗の疑い)
   // ベースラインがあれば ±2% を許容、なければレガシー比 90% 以上で OK
   const target = expectedInserted ?? reference;
+  // 上振れ検出（#223）: 冪等性バグ等による重複投入（件数倍増）を見逃さない。
+  // skip により target < legacy となるステップがあるため、上限基準は
+  // target 単体でなく Math.max(target, reference) を取る（正常上限は通し、~2x は弾く）。
+  const upper = Math.max(target, reference);
+  if (reference > 0 && actual > upper * 1.05) return '❌';
   const tolerance = Math.max(5, Math.round(target * 0.02));
   if (Math.abs(actual - target) <= tolerance) return '✅';
   if (actual >= reference * 0.9) return '✅';
@@ -570,7 +575,7 @@ function buildReport(args: {
   }
   lines.push('');
   lines.push(
-    '> ❌ = 新システム件数が 0 または期待の 50% 未満（投入失敗の疑い）。⚠️ = 許容差を超える乖離。✅ = ベースライン ±2% またはレガシー比 90% 以上。'
+    '> ❌ = 新システム件数が 0、期待の 50% 未満（投入失敗の疑い）、または期待の 105% 超（重複投入の疑い）。⚠️ = 許容差を超える乖離。✅ = ベースライン ±2% またはレガシー比 90% 以上。'
   );
   lines.push('');
 
@@ -686,7 +691,10 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err: unknown) => {
-  console.error(err);
-  process.exit(1);
-});
+// テストから judgeCount 等を import できるよう、直接実行時のみ main を起動する
+if (require.main === module) {
+  main().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/scripts/legacy-migration/steps/idempotency.test.ts
+++ b/tests/scripts/legacy-migration/steps/idempotency.test.ts
@@ -1,0 +1,318 @@
+/**
+ * 回帰テスト: 移行ステップの冪等性（#220, #221, #222）
+ *
+ * step07/08/09 はレガシー自然キー（legacy_family_cd / legacy_maisou_cd /
+ * legacy_construction_id）で既存をスキップし、step06 の別人申込者パスは
+ * applicant ロールの存在で Customer 生成ごとスキップする。
+ * --truncate なしの再実行で重複INSERTされないことを検証する。
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepFamilyContact } from '../../../../scripts/legacy-migration/steps/07-family-contact';
+import { stepBuriedPerson } from '../../../../scripts/legacy-migration/steps/08-buried-person';
+import { stepConstructionInfo } from '../../../../scripts/legacy-migration/steps/09-construction-info';
+import { stepSaleContractRole } from '../../../../scripts/legacy-migration/steps/06-sale-contract-role';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+describe('移行ステップの冪等性 (#220)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  it('stepFamilyContact: legacy_family_cd が既存ならスキップし重複INSERTしない', async () => {
+    const familyContactCreate = jest.fn();
+    const prisma = {
+      customer: { findMany: jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]) },
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      familyContact: {
+        create: familyContactCreate,
+        findUnique: jest.fn().mockResolvedValue({ id: 'fc-existing', legacy_family_cd: 1 }),
+      },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      .mockResolvedValueOnce([
+        {
+          family_cd: 1,
+          danka_cd: 100,
+          family_sei: '山田',
+          family_mei: '太郎',
+          addr1: null,
+          addr2: null,
+          addr3: null,
+          job_addr1: null,
+          job_addr2: null,
+          job_addr3: null,
+        },
+      ]);
+
+    const idMaps = createIdMaps();
+    const result = await stepFamilyContact.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: false,
+    });
+
+    expect(familyContactCreate).not.toHaveBeenCalled();
+    expect(result.inserted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.notes?.['skip_existing']).toBe(1);
+  });
+
+  it('stepBuriedPerson: legacy_maisou_cd が既存ならスキップし重複INSERTしない', async () => {
+    const buriedPersonCreate = jest.fn();
+    const prisma = {
+      customer: { findMany: jest.fn().mockResolvedValue([]) },
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      buriedPerson: {
+        create: buriedPersonCreate,
+        findUnique: jest.fn().mockResolvedValue({ id: 'bp-existing', legacy_maisou_cd: 7 }),
+      },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([
+      {
+        maisou_cd: 7,
+        danka_cd: 100,
+        grave_cd: 500,
+        maisousha_sei: '山田',
+        maisousha_mei: '花子',
+      },
+    ]);
+
+    const idMaps = createIdMaps();
+    const result = await stepBuriedPerson.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: false,
+    });
+
+    expect(buriedPersonCreate).not.toHaveBeenCalled();
+    expect(result.inserted).toBe(0);
+    expect(result.notes?.['skip_existing']).toBe(1);
+  });
+
+  it('stepConstructionInfo: legacy_construction_id が既存ならスキップし重複INSERTしない', async () => {
+    const constructionInfoCreate = jest.fn();
+    const prisma = {
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      constructionInfo: {
+        create: constructionInfoCreate,
+        findUnique: jest.fn().mockResolvedValue({ id: 'ci-existing', legacy_construction_id: 9 }),
+      },
+      contractorMaster: { upsert: jest.fn() },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([
+      {
+        construction_id: 9,
+        grave_cd: 500,
+        danka_cd: 100,
+        gyousha_cd: null,
+        construction_type: null,
+      },
+    ]);
+
+    const idMaps = createIdMaps();
+    const result = await stepConstructionInfo.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: false,
+    });
+
+    expect(constructionInfoCreate).not.toHaveBeenCalled();
+    expect(result.inserted).toBe(0);
+    expect(result.notes?.['skip_existing']).toBe(1);
+  });
+});
+
+describe('step06 別人申込者パスの冪等性 (#221, #222)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  const buildPrisma = (overrides: Record<string, unknown> = {}) =>
+    ({
+      customer: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]),
+        create: jest.fn().mockResolvedValue({ id: 'applicant-1' }),
+      },
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      saleContractRole: {
+        upsert: jest.fn().mockResolvedValue({}),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({}),
+      },
+      ...overrides,
+    }) as unknown as PrismaClient;
+
+  // 契約者(owner)と申込者(request)が別人の行
+  const differentPersonRow = {
+    danka_cd: 100,
+    grave_cd: 500,
+    request_sei: '佐藤',
+    request_sei_kana: 'サトウ',
+    request_mei: '次郎',
+    request_mei_kana: 'ジロウ',
+    request_zip: 1500001,
+    request_addr1: '東京都',
+    request_addr2: '渋谷区',
+    request_addr3: null,
+    request_tel1: '0312345678',
+    owner_sei: '山田',
+    owner_mei: '太郎',
+  };
+
+  it('applicant ロールが未存在なら申込者Customerを legacy_applicant_danka_cd 付きで作成する', async () => {
+    const prisma = buildPrisma();
+    mockedLegacyQuery.mockResolvedValueOnce([differentPersonRow]);
+
+    const idMaps = createIdMaps();
+    await stepSaleContractRole.run({ prisma, logger: buildLogger(), idMaps, dryRun: false });
+
+    expect(prisma.customer.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: '佐藤 次郎',
+          legacy_applicant_danka_cd: 100,
+        }),
+      })
+    );
+    expect(prisma.saleContractRole.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('applicant ロールが既存なら申込者Customerを生成しない（再実行で重複しない）', async () => {
+    const prisma = buildPrisma({
+      saleContractRole: {
+        upsert: jest.fn().mockResolvedValue({}),
+        findFirst: jest.fn().mockResolvedValue({ id: 'role-existing', role: 'applicant' }),
+        create: jest.fn(),
+      },
+    });
+    mockedLegacyQuery.mockResolvedValueOnce([differentPersonRow]);
+
+    const idMaps = createIdMaps();
+    const result = await stepSaleContractRole.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: false,
+    });
+
+    expect(prisma.customer.create).not.toHaveBeenCalled();
+    expect(prisma.saleContractRole.create).not.toHaveBeenCalled();
+    // 件数整合のため applicant はカウントされる（再実行でも合計が一致する）
+    expect(result.inserted).toBeGreaterThan(0);
+  });
+});
+
+describe('dry-run resume の追加ケース (#224)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  it('stepContractPlot: dry-run で idMap が空でも physicalPlot を新DBから再構築し throw しない', async () => {
+    const physicalPlotFindMany = jest
+      .fn()
+      .mockResolvedValue([{ id: 'pp-1', plot_number: 'legacy-500' }]);
+    const prisma = {
+      physicalPlot: { findMany: physicalPlotFindMany },
+      contractPlot: { findMany: jest.fn().mockResolvedValue([]) },
+    } as unknown as PrismaClient;
+
+    // レガシー行なし（resume パスが throw しないことだけを検証）
+    mockedLegacyQuery.mockResolvedValue([]);
+
+    const idMaps = createIdMaps();
+    const { stepContractPlot } =
+      await import('../../../../scripts/legacy-migration/steps/05-contract-plot');
+
+    await expect(
+      stepContractPlot.run({ prisma, logger: buildLogger(), idMaps, dryRun: true })
+    ).resolves.toBeDefined();
+
+    // 旧挙動（if (!dryRun) ガード）ではここが呼ばれず assertIdMapsReady で throw していた
+    expect(physicalPlotFindMany).toHaveBeenCalled();
+    expect(idMaps.physicalPlot.size).toBe(1);
+  });
+
+  it('stepSaleContractRole: dry-run で idMap が空でも新DBから再構築し throw しない', async () => {
+    const customerFindMany = jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]);
+    const contractPlotFindMany = jest
+      .fn()
+      .mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]);
+    const prisma = {
+      customer: { findMany: customerFindMany, create: jest.fn() },
+      contractPlot: { findMany: contractPlotFindMany },
+      saleContractRole: { upsert: jest.fn(), findFirst: jest.fn(), create: jest.fn() },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([differentlessRow()]);
+
+    const idMaps = createIdMaps();
+    const result = await stepSaleContractRole.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: true,
+    });
+
+    expect(customerFindMany).toHaveBeenCalledTimes(1);
+    expect(contractPlotFindMany).toHaveBeenCalledTimes(1);
+    expect(idMaps.customer.size).toBe(1);
+    expect(idMaps.contractPlot.size).toBe(1);
+    expect(result.inserted).toBeGreaterThan(0);
+    // dry-run なので書き込みなし
+    expect(prisma.saleContractRole.upsert).not.toHaveBeenCalled();
+
+    function differentlessRow() {
+      return {
+        danka_cd: 100,
+        grave_cd: 500,
+        request_sei: null,
+        request_sei_kana: null,
+        request_mei: null,
+        request_mei_kana: null,
+        request_zip: null,
+        request_addr1: null,
+        request_addr2: null,
+        request_addr3: null,
+        request_tel1: null,
+        owner_sei: '山田',
+        owner_mei: '太郎',
+      };
+    }
+  });
+});

--- a/tests/scripts/verify-migration.test.ts
+++ b/tests/scripts/verify-migration.test.ts
@@ -1,0 +1,55 @@
+/**
+ * verify-migration の件数判定テスト（#223）
+ *
+ * judgeCount は従来「大幅不足」しか ❌ にせず、actual >= reference*0.9 を
+ * 無条件 ✅ としていたため、冪等性バグによる件数倍増（重複投入）を
+ * 検出できなかった。上振れ（> max(target, reference) * 1.05）を ❌ にする。
+ */
+import { judgeCount } from '../../scripts/verify-migration';
+
+describe('judgeCount (#223)', () => {
+  describe('正常ケース（従来動作の維持）', () => {
+    it('参照値なしは ⚠️', () => {
+      expect(judgeCount(100, null, null)).toBe('⚠️');
+    });
+
+    it('完全未投入は ❌', () => {
+      expect(judgeCount(0, 1000, null)).toBe('❌');
+    });
+
+    it('大幅不足（50%未満）は ❌', () => {
+      expect(judgeCount(400, 1000, null)).toBe('❌');
+    });
+
+    it('ベースライン ±2% 以内は ✅', () => {
+      expect(judgeCount(2641, 2744, 2641)).toBe('✅');
+      expect(judgeCount(2650, 2744, 2641)).toBe('✅');
+    });
+
+    it('レガシー比 90% 以上（ベースラインなし）は ✅', () => {
+      expect(judgeCount(950, 1000, null)).toBe('✅');
+    });
+
+    it('skip が少なく target を超えても legacy 件数以内なら ✅/⚠️（❌ にしない）', () => {
+      // FamilyContact: target=2641 < legacy=2744。actual=2744（skip 0）は正常上限
+      expect(judgeCount(2744, 2744, 2641)).not.toBe('❌');
+    });
+  });
+
+  describe('上振れ検出（#223 新規）', () => {
+    it('件数が約2倍（重複投入）なら ❌', () => {
+      // FamilyContact 2重投入: 2641*2 = 5282 > max(2641,2744)*1.05
+      expect(judgeCount(5282, 2744, 2641)).toBe('❌');
+      // BuriedPerson 2重投入
+      expect(judgeCount(12724, 6484, 6362)).toBe('❌');
+    });
+
+    it('レガシー件数の 105% を僅かに超えると ❌', () => {
+      expect(judgeCount(1051, 1000, null)).toBe('❌');
+    });
+
+    it('105% 以内の上振れは ❌ にしない', () => {
+      expect(judgeCount(1049, 1000, null)).not.toBe('❌');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
バグ監査起票のレガシー移行スクリプト5件（同根グループ）をまとめて修正。**スキーマ変更（migration 同梱）を含む。**

### #220: step07/08/09 が非冪等（再実行で全件重複INSERT）
billing/payment は `legacy_*_cd` の findUnique ガードを持つのに、この3ステップだけ無条件 create だった（t_maisou 6,484件・t_family 2,744件が倍増しうる）。

**修正**（issue推奨の @unique 方式）:
- schema にレガシー自然キーを追加: `FamilyContact.legacy_family_cd` / `BuriedPerson.legacy_maisou_cd` / `ConstructionInfo.legacy_construction_id`（`Int? @unique`）
- 各ステップで create 前に findUnique → 既存スキップ（`skip_existing` を notes に出力）
- migration: `20260605120000_add_legacy_idempotency_keys`

### #221: --truncate が申込者Customer（legacy_danka_cd=NULL）を残す
- `Customer.legacy_applicant_danka_cd Int?` を追加し、step06 の申込者作成時に danka_cd を付与
- `truncateNewDb` / `cleanup-legacy-data.ts` の削除条件を `OR [legacy_danka_cd, legacy_applicant_danka_cd]` に拡張（両所同一定義）

### #222: step06 別人申込者パスが非冪等
- applicant ロールの存在チェック（findFirst）を一次ガードに追加（issue推奨のロール側冪等判定）。「1契約に applicant 1名」の業務前提と整合し、truncate なしの単純再実行でも重複しない

### #223: judgeCount が件数倍増を見逃す（actual >= reference*0.9 で無条件✅）
- 上振れ検出: `actual > Math.max(target, reference) * 1.05 → ❌`（issue指示どおり、skip により target<legacy のステップで正常上限を誤検知しない max 基準）
- レポート凡例に「105%超（重複投入の疑い）」を追記
- `judgeCount` を export 化し `require.main === module` ガードで直接実行時のみ main 起動（テスト可能化、CLI 挙動は不変）

### #224: dry-run resume で step05/06 だけ InvariantViolationError
- `if (!dryRun)` ガードを除去し rebuildIdMap を無条件呼び出し（step07/10/11 と同形）。rebuildIdMap は size>0 で早期 return するため full dry-run では no-op

## テスト
- 冪等スキップ: step07/08/09 ＋ step06 applicant ガード ＋ legacy_applicant_danka_cd 付与
- dry-run resume: stepContractPlot / stepSaleContractRole（既存 stepFamilyContact と同型）
- judgeCount: 従来動作6ケース ＋ 上振れ4ケース（2倍化❌ / 105%境界）
- 全903テストpass、tsc clean、lint clean

## 運用メモ（マージ後）
- 本番DBへ `npx prisma migrate deploy` で新カラム適用が必要（#163 の本投入前に適用すること）
- 既投入データに重複がある場合は別途データクレンジングが必要（冪等キーは新規投入分から有効）

Closes #220
Closes #221
Closes #222
Closes #223
Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)