### PR TITLE
test(validation): yearMonthSchema の表記揺れ正規化（types#35）にテストを追従

### DIFF
--- a/tests/middleware/validation.test.ts
+++ b/tests/middleware/validation.test.ts
@@ -427,9 +427,14 @@ describe('Validation Middleware', () => {
         expect(() => yearMonthSchema.parse('')).not.toThrow();
       });
 
-      it('無効な形式でエラーが発生すること', () => {
-        expect(() => yearMonthSchema.parse('2024-01')).toThrow();
-        expect(() => yearMonthSchema.parse('2024/01')).toThrow();
+      it('表記揺れ（2024-01 / 2024/01）はYYYY年M月形式へ正規化されること（types#35）', () => {
+        expect(yearMonthSchema.parse('2024-01')).toBe('2024年1月');
+        expect(yearMonthSchema.parse('2024/01')).toBe('2024年1月');
+      });
+
+      it('正規化できない形式でエラーが発生すること', () => {
+        expect(() => yearMonthSchema.parse('invalid')).toThrow();
+        expect(() => yearMonthSchema.parse('2024年')).toThrow();
       });
 
       it('未定義でも許可されること', () => {


### PR DESCRIPTION
## 概要
types リポジトリの [#35](https://github.com/zaitsu82/komine-types/pull/35)（yearMonthSchema に表記揺れ正規化 preprocess を追加）により、backend の `tests/middleware/validation.test.ts` の「`2024-01` / `2024/01` は throw する」という期待が成立しなくなり、**CI（typesのmainをclone）で全PRのテストが落ちる状態**になっています。

## 修正
- 「無効な形式でエラー」→「表記揺れは `2024年1月` へ正規化される」+「正規化できない形式（`invalid` / `2024年`）はエラー」に更新

## 備考
このPRはCIブロッカー解消のため、他のopen PRより先のマージを推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)