### PR TITLE
chore: @komine/types bump（封筒PDF修正・年月正規化の反映）+ 回帰テスト

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=67e6fe7ebf4a18591aca8091678c5f9b28835283
+ARG TYPES_REF=d4055528467e8f154204acc1be4d2d9a2e8913f4
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/tests/documents/documentValidation.test.ts
+++ b/tests/documents/documentValidation.test.ts
@@ -3,8 +3,16 @@
  *
  * regeneratePdf で DB から復元した template_data を、テンプレ種別ごとの
  * Zod スキーマでパースする。正常系と不正系（ZodError スロー）を検証する。
+ *
+ * generatePdfRequestSchema（POST /documents/generate-pdf の入口検証）も
+ * ここで検証する。discriminated union から envelope-letter/envelope-base が
+ * 欠落していた回帰を防ぐ（types#32）。
  */
-import { parseTemplateData } from '../../src/validations/documentValidation';
+import {
+  parseTemplateData,
+  generatePdfRequestSchema,
+} from '../../src/validations/documentValidation';
+import { DOCUMENT_TEMPLATE_TYPES } from '@komine/types';
 
 const validPostcard = {
   recipientName: '受取 太郎',
@@ -77,5 +85,47 @@ describe('parseTemplateData', () => {
       const r = parseTemplateData('payment-guide', { orgName: '小嶺霊園' });
       expect(r).toMatchObject({ orgName: '小嶺霊園' });
     });
+  });
+});
+
+describe('generatePdfRequestSchema（generate-pdf 入口検証）', () => {
+  // テンプレートタイプごとの最小有効 templateData
+  const MINIMAL_TEMPLATE_DATA: Record<string, unknown> = {
+    invoice: { customerName: '山田太郎' },
+    postcard: {
+      recipientName: '受取 太郎',
+      recipientAddress: '福岡県北九州市1-2-3',
+      recipientPostalCode: '8000000',
+      senderName: '小嶺霊園',
+      senderAddress: '福岡県北九州市4-5-6',
+      senderPostalCode: '8001111',
+      message: 'お知らせ',
+      date: '2026-06-05',
+    },
+    permit: {},
+    'envelope-letter': { recipientName: '受取 太郎' },
+    'envelope-base': { recipientName: '受取 太郎' },
+    'payment-guide': {},
+  };
+
+  // envelope-letter/envelope-base が union から欠落していると
+  // 'No matching discriminator' で封筒PDFが常時400になる（types#32 の回帰防止）
+  it.each(DOCUMENT_TEMPLATE_TYPES.map((t) => [t]))(
+    '全テンプレートタイプを受理する: %s',
+    (templateType) => {
+      const result = generatePdfRequestSchema.safeParse({
+        templateType,
+        templateData: MINIMAL_TEMPLATE_DATA[templateType],
+      });
+      expect(result.success).toBe(true);
+    }
+  );
+
+  it('未知の templateType は拒否する', () => {
+    const result = generatePdfRequestSchema.safeParse({
+      templateType: 'unknown',
+      templateData: {},
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/tests/middleware/validation.test.ts
+++ b/tests/middleware/validation.test.ts
@@ -427,9 +427,17 @@ describe('Validation Middleware', () => {
         expect(() => yearMonthSchema.parse('')).not.toThrow();
       });
 
+      it('表記揺れは正規化して受理されること（types#31）', () => {
+        // レガシー移行データ・UI入力の 'YYYY-MM'/'YYYY/MM'/'YYYYMM' は
+        // @komine/types の yearMonthSchema が preprocess で正規化する
+        expect(yearMonthSchema.parse('2024-01')).toBe('2024年1月');
+        expect(yearMonthSchema.parse('2024/01')).toBe('2024年1月');
+        expect(yearMonthSchema.parse('202404')).toBe('2024年4月');
+      });
+
       it('無効な形式でエラーが発生すること', () => {
-        expect(() => yearMonthSchema.parse('2024-01')).toThrow();
-        expect(() => yearMonthSchema.parse('2024/01')).toThrow();
+        expect(() => yearMonthSchema.parse('2024-13')).toThrow();
+        expect(() => yearMonthSchema.parse('abc')).toThrow();
       });
 
       it('未定義でも許可されること', () => {


### PR DESCRIPTION
## 概要
types 側の root fix 2件（zaitsu82/komine-types#34 / #35）の backend 反映。

- **封筒書・封筒台の generate-pdf 常時400**（types#32）→ `TYPES_REF` bump で本番ビルドに反映。backend コードの変更は不要（`generatePdfFromTemplate` 側は元々 envelope を処理可能、入口の union 欠落だけが原因）
- **終納請求年月のレガシー値で保存不能**（types#31）→ `yearMonthSchema` の正規化が backend の validate ミドルウェア経由でも効く

## 変更内容
- `Dockerfile`: `TYPES_REF` → `d405552`
- `tests/documents/documentValidation.test.ts`: `generatePdfRequestSchema` の入口検証を追加（issue#32 記載の回帰防止。`DOCUMENT_TEMPLATE_TYPES` 全網羅で union 欠落を検知）
- `tests/middleware/validation.test.ts`: `yearMonthSchema` のテストを新挙動（表記揺れは正規化して受理 / 範囲外月は拒否）に更新

## テスト
- `npx tsc --noEmit` clean / `npm run lint` clean / `npm test` 912 passed

Refs zaitsu82/komine-types#31 / zaitsu82/komine-types#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)