### PR TITLE
feat(plots): 契約解約API POST /plots/:id/terminate を新設 (#236)

### DIFF
--- a/src/plots/controllers/deletePlot.ts
+++ b/src/plots/controllers/deletePlot.ts
@@ -3,7 +3,9 @@
  * DELETE /api/v1/plots/:id
  *
  * ContractPlot と関連データを論理削除します。
- * 契約キャンセル時に使用します。
+ * 誤登録レコードの整理用です。契約の解約には POST /:id/terminate を
+ * 使用してください（#236）。論理削除すると履歴・詳細・一覧から参照
+ * 不能になり、restoreContract でも復活できません。
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -14,7 +16,7 @@ import { recordEntityDeleted } from '../services/historyService';
 
 /**
  * ContractPlot削除（論理削除）
- * 契約をキャンセルし、関連データも論理削除します。
+ * 誤登録レコードの整理用。解約は terminateContract を使用すること。
  */
 export const deletePlot = async (
   req: Request,

--- a/src/plots/controllers/index.ts
+++ b/src/plots/controllers/index.ts
@@ -10,6 +10,7 @@ export { createPlot } from './createPlot';
 export { updatePlot } from './updatePlot';
 export { deletePlot } from './deletePlot';
 export { restoreContract } from './restoreContract';
+export { terminateContract } from './terminateContract';
 export { getPlotContracts } from './getPlotContracts';
 export { createPlotContract } from './createPlotContract';
 export { getPlotInventory } from './getPlotInventory';

--- a/src/plots/controllers/terminateContract.ts
+++ b/src/plots/controllers/terminateContract.ts
@@ -1,0 +1,81 @@
+/**
+ * 契約解約エンドポイント
+ * POST /api/v1/plots/:id/terminate
+ *
+ * active 状態の ContractPlot を terminated（解約）に遷移させる（#236）。
+ * deletePlot（論理削除）と異なり deleted_at は触らないため、解約後も
+ * 履歴・詳細・一覧から参照でき、誤操作時は restoreContract で復活できる。
+ * reason は履歴に記録するため必須。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { ContractStatus } from '@prisma/client';
+import prisma from '../../db/prisma';
+import { NotFoundError, ConflictError } from '../../middleware/errorHandler';
+import { recordEntityUpdated } from '../services/historyService';
+import { contractStatusService } from '../services/contractStatusService';
+import { updatePhysicalPlotStatus } from '../utils';
+import type { TerminateContractRequest } from '../../validations/plotValidation';
+
+export const terminateContract = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id = (req.params as Record<string, string>)['id'] as string;
+    const { reason } = req.body as TerminateContractRequest;
+
+    const contractPlot = await prisma.contractPlot.findUnique({
+      where: { id, deleted_at: null },
+    });
+
+    if (!contractPlot) {
+      throw new NotFoundError('指定された契約区画が見つかりません');
+    }
+
+    const beforeStatus = contractPlot.contract_status;
+
+    // 解約エンドポイントは active 状態のみ受け付ける
+    if (beforeStatus !== ContractStatus.active) {
+      throw new ConflictError(
+        `現在のステータス '${beforeStatus}' から解約はできません（active のみ解約可能）`
+      );
+    }
+
+    // サービス層の遷移定義（active → terminated）と整合させる
+    contractStatusService.validateTransition(beforeStatus, ContractStatus.terminated);
+
+    await prisma.$transaction(async (tx) => {
+      await tx.contractPlot.update({
+        where: { id },
+        data: { contract_status: ContractStatus.terminated },
+      });
+
+      // active 契約が外れるため物理区画ステータスを再計算する（restore #210 と対称）
+      await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id);
+
+      await recordEntityUpdated(tx, {
+        entityType: 'ContractPlot',
+        entityId: id,
+        physicalPlotId: contractPlot.physical_plot_id,
+        contractPlotId: id,
+        beforeRecord: { contract_status: beforeStatus },
+        afterRecord: { contract_status: ContractStatus.terminated },
+        changeReason: reason,
+        req,
+      });
+    });
+
+    res.status(200).json({
+      success: true,
+      data: {
+        message: '契約区画を解約しました',
+        id,
+        contractStatus: ContractStatus.terminated,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/plots/plotRoutes.ts
+++ b/src/plots/plotRoutes.ts
@@ -7,6 +7,7 @@ import {
   updatePlot,
   deletePlot,
   restoreContract,
+  terminateContract,
   getPlotContracts,
   createPlotContract,
   getPlotInventory,
@@ -27,6 +28,7 @@ import {
   updatePlotSchema,
   createPlotContractSchema,
   restoreContractSchema,
+  terminateContractSchema,
 } from '../validations/plotValidation';
 import {
   inventorySummaryQuerySchema,
@@ -132,6 +134,15 @@ router.delete(
   requirePermission(['manager', 'admin']),
   validate({ params: plotIdParamsSchema }),
   withLogging('Plots', 'deletePlot', deletePlot)
+);
+
+// 契約解約（active → terminated #236。論理削除と異なり解約後も参照・復活可能）
+router.post(
+  '/:id/terminate',
+  authenticate,
+  requirePermission(['operator', 'manager', 'admin']),
+  validate({ params: plotIdParamsSchema, body: terminateContractSchema }),
+  withLogging('Plots', 'terminateContract', terminateContract)
 );
 
 // 契約復活（terminated → active、誤操作リカバリ用）

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -303,6 +303,18 @@ export const restoreContractSchema = z.object({
 });
 
 /**
+ * 契約解約リクエストのバリデーションスキーマ（#236）
+ * 解約理由は履歴に記録するため必須（restore と対称）
+ */
+export const terminateContractSchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .min(1, '解約理由は必須です')
+    .max(200, '解約理由は200文字以内で入力してください'),
+});
+
+/**
  * 型エクスポート
  */
 export type PlotSearchQuery = z.infer<typeof plotSearchQuerySchema>;
@@ -311,6 +323,7 @@ export type CreatePlotRequest = z.infer<typeof createPlotSchema>;
 export type UpdatePlotRequest = z.infer<typeof updatePlotSchema>;
 export type CreatePlotContractRequest = z.infer<typeof createPlotContractSchema>;
 export type RestoreContractRequest = z.infer<typeof restoreContractSchema>;
+export type TerminateContractRequest = z.infer<typeof terminateContractSchema>;
 
 // dateSchema も従来通り再エクスポート（他モジュールからの参照互換性維持）
 export { dateSchema };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -371,6 +371,82 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/plots/{id}/terminate:
+    post:
+      tags:
+        - Plots
+      summary: 契約区画の解約（active → terminated）
+      description: |
+        active 状態の契約区画を terminated（解約）に遷移させる。
+        論理削除（DELETE /plots/{id}）と異なり deleted_at は変更しないため、
+        解約後も履歴・詳細・一覧から参照でき、誤操作時は /restore で復活できる。
+        reason は履歴に記録するため必須（1〜200文字、空白のみは不可）。
+        現在のステータスが active でない場合は 409 を返す。
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: 契約区画ID（UUID）
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 200
+                  description: 解約理由（履歴に記録される）
+                  example: 利用者からの解約申請のため
+      responses:
+        "200":
+          description: 解約成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        example: 契約区画を解約しました
+                      id:
+                        type: string
+                        format: uuid
+                      contractStatus:
+                        type: string
+                        enum: [vacant, active, terminated]
+                        example: terminated
+        "400":
+          description: バリデーションエラー（reason 欠落 / 長すぎ等）
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: active 以外のステータスからの解約
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/v1/plots/{id}/restore:
     post:
       tags:

--- a/tests/middleware/validation.test.ts
+++ b/tests/middleware/validation.test.ts
@@ -427,9 +427,14 @@ describe('Validation Middleware', () => {
         expect(() => yearMonthSchema.parse('')).not.toThrow();
       });
 
-      it('無効な形式でエラーが発生すること', () => {
-        expect(() => yearMonthSchema.parse('2024-01')).toThrow();
-        expect(() => yearMonthSchema.parse('2024/01')).toThrow();
+      it('表記揺れ（2024-01 / 2024/01）はYYYY年M月形式へ正規化されること（types#35）', () => {
+        expect(yearMonthSchema.parse('2024-01')).toBe('2024年1月');
+        expect(yearMonthSchema.parse('2024/01')).toBe('2024年1月');
+      });
+
+      it('正規化できない形式でエラーが発生すること', () => {
+        expect(() => yearMonthSchema.parse('invalid')).toThrow();
+        expect(() => yearMonthSchema.parse('2024年')).toThrow();
       });
 
       it('未定義でも許可されること', () => {

--- a/tests/plots/controllers/terminateContract.test.ts
+++ b/tests/plots/controllers/terminateContract.test.ts
@@ -1,0 +1,219 @@
+/**
+ * terminateContract コントローラのテスト（#236）
+ * POST /api/v1/plots/:id/terminate
+ *
+ * 解約は論理削除と異なり deleted_at を変更せず、解約後も参照・復活可能。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma: any = {
+  contractPlot: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  $transaction: jest.fn((callback: any) => Promise.resolve(callback(mockPrisma))),
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  ContractStatus: {
+    vacant: 'vacant',
+    active: 'active',
+    terminated: 'terminated',
+  },
+  PaymentStatus: {
+    unpaid: 'unpaid',
+    partial_paid: 'partial_paid',
+    paid: 'paid',
+    overdue: 'overdue',
+    refunded: 'refunded',
+    cancelled: 'cancelled',
+  },
+}));
+
+const mockRecordEntityUpdated = jest.fn();
+jest.mock('../../../src/plots/services/historyService', () => ({
+  recordEntityUpdated: (...args: unknown[]) => mockRecordEntityUpdated(...args),
+}));
+
+const mockUpdatePhysicalPlotStatus = jest.fn();
+jest.mock('../../../src/plots/utils', () => ({
+  updatePhysicalPlotStatus: (...args: unknown[]) => mockUpdatePhysicalPlotStatus(...args),
+}));
+
+import { terminateContract } from '../../../src/plots/controllers/terminateContract';
+import { NotFoundError, ConflictError } from '../../../src/middleware/errorHandler';
+
+const buildRes = (): Response => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  return res;
+};
+
+const buildReq = (overrides: Partial<Request> = {}): Request => {
+  const req = {
+    params: { id: 'cp-1' },
+    body: { reason: '利用者からの解約申請のため' },
+    user: {
+      id: 1,
+      email: 'staff@example.com',
+      name: 'Test Staff',
+      role: 'operator',
+      is_active: true,
+      supabase_uid: 'sup-1',
+    },
+    ip: '127.0.0.1',
+    get: jest.fn().mockReturnValue(undefined),
+    ...overrides,
+  } as unknown as Request;
+  return req;
+};
+
+describe('terminateContract (#236)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('成功ケース', () => {
+    it('active → terminated への解約が成功し、履歴と物理区画再計算が行われる', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'active',
+        deleted_at: null,
+      });
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        id: 'cp-1',
+        contract_status: 'terminated',
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await terminateContract(req, res, next);
+
+      expect(mockPrisma.contractPlot.update).toHaveBeenCalledWith({
+        where: { id: 'cp-1' },
+        data: { contract_status: 'terminated' },
+      });
+      // deleted_at は変更しない（解約後も参照・復活可能）
+      const updateData = mockPrisma.contractPlot.update.mock.calls[0][0].data;
+      expect(updateData).not.toHaveProperty('deleted_at');
+
+      // 物理区画ステータスの再計算（restore #210 と対称）
+      expect(mockUpdatePhysicalPlotStatus).toHaveBeenCalledWith(mockPrisma, 'pp-1');
+
+      // 履歴記録
+      expect(mockRecordEntityUpdated).toHaveBeenCalledTimes(1);
+      const historyCall = mockRecordEntityUpdated.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(historyCall).toMatchObject({
+        entityType: 'ContractPlot',
+        entityId: 'cp-1',
+        physicalPlotId: 'pp-1',
+        contractPlotId: 'cp-1',
+        beforeRecord: { contract_status: 'active' },
+        afterRecord: { contract_status: 'terminated' },
+        changeReason: '利用者からの解約申請のため',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          message: '契約区画を解約しました',
+          id: 'cp-1',
+          contractStatus: 'terminated',
+        },
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('失敗ケース', () => {
+    it('存在しない（または論理削除済み）ContractPlot は NotFoundError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(null);
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await terminateContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect((next as jest.Mock).mock.calls[0]?.[0]).toBeInstanceOf(NotFoundError);
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+    });
+
+    it('terminated 状態からの解約は ConflictError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'terminated',
+        deleted_at: null,
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await terminateContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = (next as jest.Mock).mock.calls[0]?.[0] as Error;
+      expect(err).toBeInstanceOf(ConflictError);
+      expect(err.message).toContain('active のみ解約可能');
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+    });
+
+    it('vacant 状態からの解約も ConflictError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'vacant',
+        deleted_at: null,
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await terminateContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect((next as jest.Mock).mock.calls[0]?.[0]).toBeInstanceOf(ConflictError);
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+    });
+
+    it('DB エラーは next に伝播される', async () => {
+      mockPrisma.contractPlot.findUnique.mockRejectedValue(new Error('connection lost'));
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await terminateContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(((next as jest.Mock).mock.calls[0]?.[0] as Error).message).toBe('connection lost');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
契約を `active → terminated`（解約）に遷移させるAPIが存在せず、deletePlot（論理削除）が解約を兼ねていた問題（#236）への対応。論理削除で「解約したつもり」になると契約が履歴含め全APIから参照不能になり、restoreContract でも復活できなかった（terminated は誰も書かない死にステートだった）。

## 変更内容（issue修正方針1+2）
### 1. `POST /plots/:id/terminate` 新設（restore と対称）
- `contractStatusService.validateTransition(active, terminated)` を通し `contract_status` のみ更新（**deleted_at は触らない** → 解約後も履歴・詳細・一覧から参照可能、誤操作時は `/restore` で復活可能）
- 解約理由（reason）必須（restore と対称、1〜200文字）。`recordEntityUpdated` で履歴記録
- active 契約が外れるため `updatePhysicalPlotStatus` で物理区画を再計算（restore側の #210 修正と対称）
- active 以外（vacant/terminated）からは 409 ConflictError
- permission: `['operator','manager','admin']`（restore と同等）
- swagger 追加・検証済み

### 2. deletePlot の誤用防止
- ヘッダコメントを「誤登録レコードの整理用（解約は terminate を使用）」へ修正

## テスト
- 成功（status更新・deleted_at不変・履歴・物理区画再計算・レスポンス）/ 404 / terminated・vacant からの409 / DBエラー伝播の5ケース
- tsc clean、lint clean、swagger valid
- フルテストの失敗1件は既知の `yearMonthSchema` 追従漏れ（types#35 起因、**PR #260 で修正済み**）でこのPRとは無関係

## 残課題（スコープ外）
- issue方針3（deletePlot への `validateOperation(status,'delete')` による active 契約削除ブロック）は**業務確認推奨**とされているため未実装。解約フロー確定（業務確認シートの区画再利用フロー #110 関連）後に判断
- frontend の解約ボタン/UI 配線は frontend 側課題

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)