### PR TITLE
fix(scripts): verify-migration の上振れ検出が正常移行を誤❌判定する偽陽性を修正

### DIFF
--- a/scripts/verify-migration.ts
+++ b/scripts/verify-migration.ts
@@ -123,7 +123,8 @@ type Judgment = '✅' | '⚠️' | '❌';
 export function judgeCount(
   actual: number,
   legacy: number | null,
-  expectedInserted: number | null
+  expectedInserted: number | null,
+  opts?: { allowGrowth?: boolean }
 ): Judgment {
   const reference = legacy ?? expectedInserted;
   if (reference == null) return '⚠️';
@@ -134,8 +135,13 @@ export function judgeCount(
   // 上振れ検出（#223）: 冪等性バグ等による重複投入（件数倍増）を見逃さない。
   // skip により target < legacy となるステップがあるため、上限基準は
   // target 単体でなく Math.max(target, reference) を取る（正常上限は通し、~2x は弾く）。
+  // allowGrowth（#265/#267）: アプリ運用で移行後に正当に増えるテーブル
+  // （マスタの手動追加等）は上振れを ❌ にせず下限チェックのみ行う。
   const upper = Math.max(target, reference);
-  if (reference > 0 && actual > upper * 1.05) return '❌';
+  if (reference > 0 && actual > upper * 1.05) {
+    if (!opts?.allowGrowth) return '❌';
+    return '✅'; // 下限チェックは通過済み。正当な増加とみなす
+  }
   const tolerance = Math.max(5, Math.round(target * 0.02));
   if (Math.abs(actual - target) <= tolerance) return '✅';
   if (actual >= reference * 0.9) return '✅';
@@ -184,6 +190,8 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
     staff,
     physicalPlots,
     customers,
+    applicantCustomers,
+    applicantRoles,
     contractPlots,
     saleContractRoles,
     familyContacts,
@@ -193,9 +201,20 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
     payments,
   ] = await Promise.all([
     prisma.relationshipMaster.count(),
-    prisma.staff.count({ where: { deleted_at: null } }),
+    // 移行由来のみ（#267）: bootstrap admin 等の手動追加スタッフを混ぜると
+    // ベースライン(11)超過で誤 ❌ になるため supabase_uid プレフィクスで絞る
+    prisma.staff.count({
+      where: { deleted_at: null, supabase_uid: { startsWith: 'legacy-tancd-' } },
+    }),
     prisma.physicalPlot.count({ where: { deleted_at: null } }),
-    prisma.customer.count({ where: { deleted_at: null } }),
+    // 契約者由来のみ（#265）: step06 の申込者展開 Customer（1:N）を混ぜると
+    // ベースライン(t_danka=契約者のみ)超過で誤 ❌ になるため legacy_danka_cd で絞る
+    prisma.customer.count({ where: { deleted_at: null, legacy_danka_cd: { not: null } } }),
+    // 申込者展開 Customer は別行で検証（applicant ロール数との整合）
+    prisma.customer.count({
+      where: { deleted_at: null, legacy_applicant_danka_cd: { not: null } },
+    }),
+    prisma.saleContractRole.count({ where: { role: 'applicant', deleted_at: null } }),
     prisma.contractPlot.count({ where: { deleted_at: null } }),
     prisma.saleContractRole.count(),
     prisma.familyContact.count({ where: { deleted_at: null } }),
@@ -240,10 +259,13 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
       actual: relationshipMaster,
       baselineLegacy: null,
       baselineInserted: b.insertedCounts.relationship_master,
-      judgment: judgeCount(relationshipMaster, null, b.insertedCounts.relationship_master),
+      // マスタは admin がアプリから追加しうるため上振れを許容（#265/#267 同根）
+      judgment: judgeCount(relationshipMaster, null, b.insertedCounts.relationship_master, {
+        allowGrowth: true,
+      }),
     },
     {
-      label: 'Staff (matant + 手動)',
+      label: 'Staff (matant 由来のみ)',
       legacyTable: 'matant',
       legacy: null,
       actual: staff,
@@ -261,13 +283,26 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
       judgment: judgeCount(physicalPlots, legPhysical, b.insertedCounts.physical_plots),
     },
     {
-      label: 'Customer',
+      label: 'Customer (契約者: legacy_danka_cd 有)',
       legacyTable: 't_danka',
       legacy: legCustomer,
       actual: customers,
       baselineLegacy: b.legacyCounts.customers,
       baselineInserted: b.insertedCounts.customers,
       judgment: judgeCount(customers, legCustomer, b.insertedCounts.customers),
+    },
+    {
+      // 申込者展開（step06: applicant != contractor の場合の別 Customer）。
+      // ベースライン件数を持たないため、applicant ロール数との整合で検証する:
+      // 申込者 Customer は必ず applicant ロールに紐づくので、ロール数を超えたら
+      // 重複生成（冪等性バグ）の疑い（#223 の検知目的を維持しつつ誤 ❌ を排除）。
+      label: 'Customer (申込者展開: applicant ロール数以下であること)',
+      legacyTable: 't_danka (request_*)',
+      legacy: null,
+      actual: applicantCustomers,
+      baselineLegacy: null,
+      baselineInserted: applicantRoles,
+      judgment: applicantCustomers <= applicantRoles ? '✅' : '❌',
     },
     {
       label: 'ContractPlot',

--- a/tests/scripts/verify-migration.test.ts
+++ b/tests/scripts/verify-migration.test.ts
@@ -52,4 +52,37 @@ describe('judgeCount (#223)', () => {
       expect(judgeCount(1049, 1000, null)).not.toBe('❌');
     });
   });
+
+  describe('正当な超過の許容（#265/#267）', () => {
+    it('allowGrowth ならベースライン超過でも ❌ にしない（マスタの手動追加等）', () => {
+      // RelationshipMaster: baseline=35 に admin がアプリから追加して 50 件
+      expect(judgeCount(50, null, 35, { allowGrowth: true })).toBe('✅');
+      // 2倍超でも growth テーブルは ❌ にしない
+      expect(judgeCount(80, null, 35, { allowGrowth: true })).toBe('✅');
+    });
+
+    it('allowGrowth でも下限チェック（未投入/大幅不足）は維持する', () => {
+      expect(judgeCount(0, null, 35, { allowGrowth: true })).toBe('❌');
+      expect(judgeCount(10, null, 35, { allowGrowth: true })).toBe('❌');
+    });
+
+    it('allowGrowth 未指定の従来呼び出しは上振れ ❌ のまま（#223 の回帰防止）', () => {
+      expect(judgeCount(80, null, 35)).toBe('❌');
+    });
+
+    it('Customer: 契約者のみに絞った actual が legacy=baseline と一致すれば ✅（#265 の回帰防止）', () => {
+      // 修正前: actual=4587(申込者展開込) > 3487*1.05 で必発 ❌ だった。
+      // 修正後は legacy_danka_cd 有のみを数えるため 3487 で比較される。
+      expect(judgeCount(3487, 3487, 3487)).toBe('✅');
+    });
+
+    it('Customer: 契約者のみ集計でも重複投入（約2倍）は ❌ を維持', () => {
+      expect(judgeCount(6974, 3487, 3487)).toBe('❌');
+    });
+
+    it('Staff: 移行由来のみに絞った actual=11 はベースライン一致で ✅（#267 の回帰防止）', () => {
+      // 修正前: bootstrap admin を含む actual>=12 > 11*1.05 で必発 ❌ だった
+      expect(judgeCount(11, null, 11)).toBe('✅');
+    });
+  });
 });


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #265 (high) / #267 (medium) の修正。#163 本番投入の go/no-go ゲートが**正しい移行で必ず止まる**問題。

#223 で導入した上振れ検出（`actual > max(target, reference) * 1.05 → ❌`）が、移行ベースライン外の**正当な追加行**を許容しない:

| 行 | 誤❌の理由 |
|---|---|
| Customer | actual は step06 の申込者展開 Customer（契約者と別人の申込者ごとに作成）を含むが、ベースラインは契約者のみ 3,487 → 必発❌ |
| Staff | `npm run bootstrap:admin` で手動 admin が必ず1名以上追加され actual≥12 > 11×1.05 → 必発❌ |

## 修正
- **Customer 行**: `legacy_danka_cd` 有（契約者由来）のみを集計しベースラインと厳密比較
- **申込者展開 Customer の検証行を新設**: applicant ロール数との整合で検証（ロール数超過＝重複生成の疑い→❌。#223 の重複検知目的は維持）
- **Staff 行**: `supabase_uid` が `legacy-tancd-` prefix（移行由来）のみを集計（ラベルも「matant 由来のみ」に変更）
- **RelationshipMaster 行**: アプリからの手動追加で正当に増えるため `judgeCount` に `allowGrowth` オプションを追加し上振れ❌を免除（完全未投入・大幅不足の下限チェックは維持）

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/scripts/verify-migration.test.ts` 15/15 pass（#265/#267 の回帰テスト7本を追加。allowGrowth 未指定の従来呼び出しが上振れ❌のままであること=#223 の回帰防止も固定）

Closes #265
Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)