### PR TITLE
fix(billings): 請求更新の入金再集計が移行済み paid_amount/status を破壊する問題を修正

### DIFF
--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -331,6 +331,19 @@ export const updateBilling = async (
       data.terminated_date = toDateOrNull(input.terminatedDate);
     if (input.notes !== undefined) data.notes = input.notes;
 
+    // 入金集計・status 算出に影響するフィールドが「実際に変化した」時だけ再集計する（#264）。
+    // レガシー移行の Billing は paid_amount を t_seikyu.nyukin_goukei から直接投入しており
+    // Payment 行と独立のため（del_flg=1 入金は未移行等）、notes 等の無関係な編集で
+    // 無条件に再集計すると移行済みの入金実績が Payment 合計で上書きされ消失する。
+    const dateEquals = (a: Date | null, b: Date | null): boolean =>
+      (a?.getTime() ?? null) === (b?.getTime() ?? null);
+    const paymentRelevantChanged =
+      (input.amount !== undefined && input.amount !== existing.amount) ||
+      (input.terminated !== undefined && input.terminated !== existing.terminated) ||
+      (input.status !== undefined && input.status !== existing.status) ||
+      (input.billingDate !== undefined &&
+        !dateEquals(toDateOrNull(input.billingDate), existing.billing_date));
+
     const updated = await prisma.$transaction(async (tx) => {
       await tx.billing.update({
         where: { id },
@@ -340,8 +353,10 @@ export const updateBilling = async (
       // 変わりうるため、入金合計から status・paid_amount・last_payment_date を
       // 再算出する（#211）。内部で ContractPlot の payment_status 再計算（#162）も行う。
       // written_off / overdue の手動ステータスは computeBillingStatus 側で尊重される。
-      await recalculateBillingPayments(tx, existing.id);
-      // status が再書き込みされるため、レスポンスは再計算後の値を取得し直す
+      if (paymentRelevantChanged) {
+        await recalculateBillingPayments(tx, existing.id);
+      }
+      // status が再書き込みされうるため、レスポンスは再計算後の値を取得し直す
       return tx.billing.findFirst({
         where: { id: existing.id },
         include: includeRelations,

--- a/src/billings/billingService.ts
+++ b/src/billings/billingService.ts
@@ -57,6 +57,22 @@ export const recalculateBillingPayments = async (
     select: { payment_amount: true, payment_date: true },
   });
 
+  // レガシー移行の入金実績の保全（#264）:
+  // 移行 Billing（legacy_seikyu_cd 有）の paid_amount は t_seikyu.nyukin_goukei から
+  // 直接投入され、対応する Payment 行が存在しないことがある（del_flg=1 入金は未移行、
+  // 孤児入金は billing 未紐付け）。Payment 行が 0 件のままなら移行値を上書きせず、
+  // status のみ既存 paid_amount から再算出する。
+  // ※非レガシー Billing は対象外（最後の入金を削除→0 円に戻す正常系を維持）
+  if (payments.length === 0 && billing.legacy_seikyu_cd !== null && billing.paid_amount > 0) {
+    const preservedStatus = computeBillingStatus(billing, billing.paid_amount);
+    await client.billing.update({
+      where: { id: billingId },
+      data: { status: preservedStatus },
+    });
+    await recalculateContractPlotPaymentStatus(client, billing.contract_plot_id);
+    return;
+  }
+
   const paidAmount = payments.reduce((sum, p) => sum + p.payment_amount, 0);
   const lastPaymentDate = payments.reduce<Date | null>((latest, p) => {
     if (!p.payment_date) return latest;

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -423,6 +423,75 @@ describe('billingController', () => {
 
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'NotFoundError' }));
     });
+
+    it('notes のみの編集では入金再集計を呼ばない（移行済み paid_amount の保全 #264）', async () => {
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({
+          id: VALID_UUID,
+          contract_plot_id: PLOT_UUID,
+          amount: 15000,
+          terminated: false,
+          status: 'paid',
+          billing_date: new Date('2020-03-01'),
+        })
+        .mockResolvedValueOnce(buildBillingRow({ amount: 15000, status: 'paid' }));
+      mockPrisma.billing.update.mockResolvedValue(buildBillingRow({ amount: 15000 }));
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { notes: '備考のみ更新' },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(recalculateBillingPaymentsMock).not.toHaveBeenCalled();
+    });
+
+    it('amount が既存と同値なら入金再集計を呼ばない (#264)', async () => {
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({
+          id: VALID_UUID,
+          contract_plot_id: PLOT_UUID,
+          amount: 15000,
+          terminated: false,
+          status: 'paid',
+          billing_date: null,
+        })
+        .mockResolvedValueOnce(buildBillingRow({ amount: 15000, status: 'paid' }));
+      mockPrisma.billing.update.mockResolvedValue(buildBillingRow({ amount: 15000 }));
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { amount: 15000, notes: 'フォーム全体送信を想定' },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(recalculateBillingPaymentsMock).not.toHaveBeenCalled();
+    });
+
+    it('terminated の変更では入金再集計を呼ぶ (#264)', async () => {
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({
+          id: VALID_UUID,
+          contract_plot_id: PLOT_UUID,
+          amount: 15000,
+          terminated: false,
+          status: 'billed',
+          billing_date: new Date('2026-03-01'),
+        })
+        .mockResolvedValueOnce(buildBillingRow({ amount: 15000, status: 'terminated' }));
+      mockPrisma.billing.update.mockResolvedValue(buildBillingRow({ amount: 15000 }));
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { terminated: true },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(recalculateBillingPaymentsMock).toHaveBeenCalledWith(mockPrisma, VALID_UUID);
+    });
   });
 
   describe('deleteBilling', () => {

--- a/tests/billings/billingService.test.ts
+++ b/tests/billings/billingService.test.ts
@@ -138,6 +138,83 @@ describe('recalculateBillingPayments', () => {
     });
   });
 
+  it('レガシー移行 Billing（legacy_seikyu_cd 有・Payment 0件）は移行済み paid_amount を保全し status のみ再算出する (#264)', async () => {
+    const client = buildClient();
+    billingFindFirst.mockResolvedValue({
+      id: 'b1',
+      amount: 10000,
+      billing_date: new Date('2020-03-01'),
+      terminated: false,
+      status: 'paid',
+      paid_amount: 10000, // t_seikyu.nyukin_goukei 由来（対応する Payment 行は未移行）
+      legacy_seikyu_cd: 12345,
+      contract_plot_id: 'cp1',
+    });
+    paymentFindMany.mockResolvedValue([]);
+
+    await recalculateBillingPayments(client, 'b1');
+
+    // paid_amount / last_payment_date は上書きせず、status のみ既存 paid_amount から再算出
+    expect(billingUpdate).toHaveBeenCalledWith({
+      where: { id: 'b1' },
+      data: { status: 'paid' },
+    });
+  });
+
+  it('レガシー移行 Billing でも Payment 行が存在すれば通常どおり再集計する (#264)', async () => {
+    const client = buildClient();
+    billingFindFirst.mockResolvedValue({
+      id: 'b1',
+      amount: 10000,
+      billing_date: new Date('2020-03-01'),
+      terminated: false,
+      status: 'paid',
+      paid_amount: 10000,
+      legacy_seikyu_cd: 12345,
+      contract_plot_id: 'cp1',
+    });
+    paymentFindMany.mockResolvedValue([
+      { payment_amount: 4000, payment_date: new Date('2020-04-01') },
+    ]);
+
+    await recalculateBillingPayments(client, 'b1');
+
+    expect(billingUpdate).toHaveBeenCalledWith({
+      where: { id: 'b1' },
+      data: {
+        paid_amount: 4000,
+        last_payment_date: new Date('2020-04-01'),
+        status: 'partial_paid',
+      },
+    });
+  });
+
+  it('非レガシー Billing は Payment 0件で paid_amount を 0 に戻す（最後の入金削除の正常系を維持） (#264)', async () => {
+    const client = buildClient();
+    billingFindFirst.mockResolvedValue({
+      id: 'b1',
+      amount: 10000,
+      billing_date: new Date('2026-03-01'),
+      terminated: false,
+      status: 'partial_paid',
+      paid_amount: 5000,
+      legacy_seikyu_cd: null,
+      contract_plot_id: 'cp1',
+    });
+    paymentFindMany.mockResolvedValue([]);
+
+    await recalculateBillingPayments(client, 'b1');
+
+    expect(billingUpdate).toHaveBeenCalledWith({
+      where: { id: 'b1' },
+      data: {
+        paid_amount: 0,
+        last_payment_date: null,
+        status: 'billed',
+      },
+    });
+  });
+
   it('skips update when billing not found', async () => {
     const client = buildClient();
     billingFindFirst.mockResolvedValue(null);


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #264 (high) の修正。

レガシー移行の Billing は `paid_amount` を `t_seikyu.nyukin_goukei` から直接投入しており Payment 行と独立（del_flg=1 入金は未移行、孤児入金は未紐付け）。#211 で updateBilling が**無条件に** `recalculateBillingPayments` を呼ぶようになったため、**notes 1つの編集でも**移行済み入金実績が Payment 合計で上書きされ消失し、status が paid→unpaid に転落、区画の payment_status / 未収金額まで連動破壊されていた。

## 修正（二段構え）
1. **updateBilling**: 入金集計・status 算出に影響するフィールド（amount / terminated / status / billingDate）が**既存値から実際に変化した時だけ**再集計
2. **recalculateBillingPayments**: `legacy_seikyu_cd` 有・Payment 0件・paid_amount>0 の Billing は移行値を保全し status のみ既存 paid_amount から再算出
   - 非レガシー Billing は従来どおり（最後の入金削除で 0 円に戻る正常系を維持）
   - レガシーでも Payment 行が存在すれば通常再集計（移行入金は大半 Payment 行として紐付き済み）

## 既知の限界
移行 Payment 行が部分的にしか紐付かない Billing（孤児入金16件等）は再集計時に差分が失われうる。根本対応は #163 の入金データ整備側で行う。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/billings/` 36/36 pass（#264 回帰テスト6本追加: notes のみ編集で再集計しない / 同値 amount で再集計しない / terminated 変更で再集計する / レガシー保全 / レガシー+Payment有は通常再集計 / 非レガシー0件は0円に戻す）

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)