### PR TITLE
fix(yucho): 振替CSV生成の入力堅牢性4件を修正（口座欠損/引用符エスケープ/小数桁ずれ/全角数字）

### DIFF
--- a/src/yucho/yuchoCsv.ts
+++ b/src/yucho/yuchoCsv.ts
@@ -227,8 +227,11 @@ const extractBranchCode = (branchName: string): string => {
  */
 export const buildDataRow = (item: YuchoBillingItem): string => {
   const info = item.billingInfo;
+  // 口座名義は唯一の二重引用符囲みフィールド。toHalfWidthKana は ASCII を素通し
+  // するため、名義に半角 " が残ると囲みが途中で閉じて列ズレを起こす。
+  // RFC4180 に従い内部の " を "" に二重化してから囲む（#273）。
   const accountHolder = padRight(
-    toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? ''),
+    toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? '').replace(/"/g, '""'),
     ACCOUNT_HOLDER_WIDTH
   );
 
@@ -254,13 +257,25 @@ interface BuildCsvParams {
 }
 
 /**
+ * 口座番号として使える値か（数字を1桁以上含み、全0でないこと）。
+ * buildDataRow は口座番号空を `0000000`、店番空を `000` で埋めるため、
+ * ここで弾かないと「構造上正しいが口座が存在しない」不正振替行が出力される（#266）。
+ */
+const hasUsableAccountNumber = (item: YuchoBillingItem): boolean => {
+  const digits = (item.billingInfo?.accountNumber ?? '').replace(/[^\d]/g, '');
+  return digits.length > 0 && Number(digits) > 0;
+};
+
+/**
  * CSV（振替ファイル）のデータ行として出力可能な請求項目かどうか。
- * 口座情報（billingInfo）があり、かつ請求金額が正であること。
+ * 口座情報（billingInfo）があり、口座番号が実在しうる値で、かつ請求金額が正であること。
  * 件数表示の整合性のため、この判定を CSV 生成（buildYuchoCsv）と
  * 集計（yuchoService の summary）で共用する。これが実出力件数の唯一の基準となる。
+ * 口座番号欠損はここで弾くことで excludedNoAccountCount（請求漏れ検知 #172）に
+ * 自動計上される（#266）。
  */
 export const isExportableBillingItem = (item: YuchoBillingItem): boolean =>
-  Boolean(item.billingInfo) && item.billingAmount > 0;
+  Boolean(item.billingInfo) && hasUsableAccountNumber(item) && item.billingAmount > 0;
 
 /**
  * ゆうちょ自動払込みCSV (12列カンマ区切り) を生成する。

--- a/src/yucho/yuchoService.ts
+++ b/src/yucho/yuchoService.ts
@@ -32,21 +32,28 @@ const parseBillingMonth = (value: string | null | undefined): number | null => {
 /**
  * 文字列の管理料金額を整数(円)に変換。"10,000" や "10000円" などの表記を許容。
  *
- * 金額は円単位の正整数であるべきため、数字以外（小数点・ハイフン含む）は
- * すべて除去する（#212）。旧実装はハイフン・小数を温存していたため、
- * '-1000'→-1000（負額）、'3.6'→4（四捨五入誤額）がゆうちょ振替の
- * 引落金額に出力されうる問題があった。
+ * 金額は円単位の正整数であるべきため、数字以外（ハイフン等）は除去する（#212）。
+ * 旧実装はハイフン・小数を温存していたため、'-1000'→-1000（負額）が
+ * ゆうちょ振替の引落金額に出力されうる問題があった。
+ * - 全角数字は半角へ正規化して扱う（#279: 全角金額が 0 円扱いになり振替対象から
+ *   無言で除外されるのを防ぐ）
+ * - 小数表記は整数部のみ採用する（#275: 小数点だけを除去すると '3.6'→'36' に
+ *   桁結合して 10 倍の引落金額になるため）
  * 数字以外を含む値は異常データ検知のため warn ログを出す（黙って出力しない）。
  */
 const parseManagementFeeAmount = (value: string | null | undefined, sourceId?: string): number => {
   if (!value) return 0;
+  // 全角数字 → 半角（#279）
+  const halfWidth = value.replace(/[０-９]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0xfee0));
   // 桁区切りカンマと円表記のみ正常系として無警告で除去
-  const normalized = value.replace(/[,，円\s]/g, '');
-  const cleaned = normalized.replace(/[^\d]/g, '');
+  const normalized = halfWidth.replace(/[,，円\s]/g, '');
+  // 小数表記は整数部のみ（#275）
+  const integerPart = normalized.split('.')[0] ?? '';
+  const cleaned = integerPart.replace(/[^\d]/g, '');
   if (cleaned !== normalized) {
     getRequestLogger().warn(
       { managementFeeId: sourceId, rawValue: value },
-      '管理料金額に数字以外の文字が含まれています（数字のみ抽出して処理）'
+      '管理料金額に数字以外の文字が含まれています（整数部の数字のみ抽出して処理）'
     );
   }
   if (!cleaned) return 0;

--- a/tests/yucho/yuchoController.test.ts
+++ b/tests/yucho/yuchoController.test.ts
@@ -281,6 +281,46 @@ describe('yuchoController', () => {
       ).toBeUndefined();
     });
 
+    it('管理料の金額パースで小数の桁結合・全角数字の0円化を発生させない (#275/#279)', async () => {
+      mockPrisma.managementFee.findMany.mockResolvedValue([
+        {
+          id: 'f1',
+          contract_plot_id: 'cp-1',
+          billing_month: '4',
+          management_fee: '3.6', // 小数表記 → '36'(10倍) に桁結合せず整数部 3 を採用
+          contractPlot: buildContractPlot(),
+        },
+        {
+          id: 'f2',
+          contract_plot_id: 'cp-2',
+          billing_month: '4',
+          management_fee: '１２０００', // 全角数字 → 0円扱いで除外せず 12000 として処理
+          contractPlot: buildContractPlot({ id: 'cp-2' }),
+        },
+        {
+          id: 'f3',
+          contract_plot_id: 'cp-3',
+          billing_month: '4',
+          management_fee: '12,000.50円', // 複合: 全角混在なし・カンマ円・小数 → 12000
+          contractPlot: buildContractPlot({ id: 'cp-3' }),
+        },
+      ]);
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
+
+      const req = buildRequest({ year: '2026', month: '4', category: 'management' });
+      await getYuchoBilling(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      const byId = (id: string) =>
+        payload.data.items.find((i: { sourceId: string }) => i.sourceId === id);
+      // '3.6' は 36 にならず整数部 3（warn ログ対象）
+      expect(byId('f1').billingAmount).toBe(3);
+      // 全角 '１２０００' は除外されず 12000
+      expect(byId('f2').billingAmount).toBe(12000);
+      // '12,000.50円' は 12000
+      expect(byId('f3').billingAmount).toBe(12000);
+    });
+
     it('honours category=collective by skipping management fee query', async () => {
       mockPrisma.collectiveBurial.findMany.mockResolvedValue([]);
 

--- a/tests/yucho/yuchoCsv.test.ts
+++ b/tests/yucho/yuchoCsv.test.ts
@@ -255,4 +255,95 @@ describe('isExportableBillingItem', () => {
   it('is false when amount is 0', () => {
     expect(isExportableBillingItem(baseItem({ billingAmount: 0 }))).toBe(false);
   });
+
+  describe('口座番号欠損の除外（#266）', () => {
+    it('銀行名だけあり口座番号が null なら出力対象外（全0の不正振替行を防ぐ）', () => {
+      const item = baseItem({
+        billingInfo: { ...baseItem().billingInfo!, accountNumber: null, branchName: null },
+      });
+      expect(isExportableBillingItem(item)).toBe(false);
+    });
+
+    it('口座番号が空文字なら出力対象外', () => {
+      const item = baseItem({
+        billingInfo: { ...baseItem().billingInfo!, accountNumber: '' },
+      });
+      expect(isExportableBillingItem(item)).toBe(false);
+    });
+
+    it('口座番号が全0（実在しない値）なら出力対象外', () => {
+      const item = baseItem({
+        billingInfo: { ...baseItem().billingInfo!, accountNumber: '0000000' },
+      });
+      expect(isExportableBillingItem(item)).toBe(false);
+    });
+
+    it('口座番号が数字を含まない（記号のみ）なら出力対象外', () => {
+      const item = baseItem({
+        billingInfo: { ...baseItem().billingInfo!, accountNumber: '---' },
+      });
+      expect(isExportableBillingItem(item)).toBe(false);
+    });
+
+    it('ハイフン区切りの正常な口座番号は出力対象', () => {
+      const item = baseItem({
+        billingInfo: { ...baseItem().billingInfo!, accountNumber: '123-4567' },
+      });
+      expect(isExportableBillingItem(item)).toBe(true);
+    });
+  });
+});
+
+describe('口座名義の二重引用符エスケープ（#273）', () => {
+  /** RFC4180 準拠の最小 CSV 行パーサ（囲みフィールド内の "" と , を解釈） */
+  const splitRfc4180 = (line: string): string[] => {
+    const out: string[] = [];
+    let cur = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (inQuotes) {
+        if (ch === '"') {
+          if (line[i + 1] === '"') {
+            cur += '"';
+            i++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          cur += ch;
+        }
+      } else if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ',') {
+        out.push(cur);
+        cur = '';
+      } else {
+        cur += ch;
+      }
+    }
+    out.push(cur);
+    return out;
+  };
+
+  it('名義に半角 " が含まれても囲みフィールドが破損しない（RFC4180 "" 二重化）', () => {
+    const item = baseItem({
+      billingInfo: { ...baseItem().billingInfo!, accountHolder: 'ヤマ"ダ"タロウ' },
+    });
+    const row = buildDataRow(item);
+    // 列10 は "..." 囲みのまま、内部の " は "" に二重化される
+    expect(row).toContain('"ﾔﾏ""ﾀﾞ""ﾀﾛｳ');
+    // RFC4180 パーサで読んだとき列数が 12 のままで、名義が正しく復元されること
+    const fields = splitRfc4180(row);
+    expect(fields.length).toBe(12);
+    expect(fields[9]).toContain('ﾔﾏ"ﾀﾞ"ﾀﾛｳ');
+    // 後続フィールド（引落金額・フラグ）が列ズレしていないこと
+    expect(fields[10]).toBe('12000');
+  });
+
+  it('名義に " が無い場合は従来どおり', () => {
+    const cells = buildDataRow(baseItem()).split(',');
+    expect(cells[9]?.startsWith('"')).toBe(true);
+    expect(cells[9]?.includes('""')).toBe(false);
+  });
 });


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査のゆうちょCSV関連4件をまとめて修正。いずれも自動払込みCSVの**金額・口座・列構造**に直結する。

| issue | sev | 修正 |
|---|---|---|
| #266 | high | `isExportableBillingItem` に「口座番号が数字を含み全0でない」を必須化。bank_name だけ入って口座未登録の顧客が**店番000・口座0000000の不正振替行**として出力されるのを防止。欠損は `excludedNoAccountCount`（請求漏れ検知 #172）に自動計上されるようになる |
| #273 | medium | 口座名義の内部 `"` を RFC4180 準拠で `""` に二重化。囲みフィールドの途中閉じ→列ズレを防止 |
| #275 | medium | 金額パースで小数表記は**整数部のみ採用**（#212 の数字以外全除去だと '3.6'→'36' に桁結合し10倍の引落金額になっていた） |
| #279 | low | 金額パース前に**全角数字→半角**正規化（全角金額が0円扱い→振替対象から無言除外されていた） |

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/yucho/` **62/62 pass**（回帰テスト9本追加: 口座欠損5パターン / RFC4180パーサで列数12維持+名義復元 / 小数 '3.6'→3 / 全角 '１２０００'→12000 / 複合 '12,000.50円'→12000）

Closes #266
Closes #273
Closes #275
Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)