### PR TITLE
fix(masters): 方角/位置マスタの使用中チェックを PK id でなく code 基準に修正

### DIFF
--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -569,11 +569,7 @@ const MASTER_CODE_MAX_LENGTH: Record<MasterType, number> = {
  * 参照側が孤児コード化して「旧コード: X」表示に化けるのを事前に防ぐ。
  * 参照箇所が特定できないマスタタイプは 0 を返す（従来動作を維持）。
  */
-const countMasterCodeUsage = async (
-  masterType: MasterType,
-  code: string,
-  masterId: number
-): Promise<number> => {
+const countMasterCodeUsage = async (masterType: MasterType, code: string): Promise<number> => {
   switch (masterType) {
     case 'tax-type': {
       const [usage, management] = await Promise.all([
@@ -609,11 +605,20 @@ const countMasterCodeUsage = async (
       });
     case 'contractor':
       return prisma.constructionInfo.count({ where: { contractor: code, deleted_at: null } });
-    // direction/position は GravestoneInfo が int の id を保持し code === String(id) で解決する
-    case 'direction':
-      return prisma.gravestoneInfo.count({ where: { direction_id: masterId, deleted_at: null } });
-    case 'position':
-      return prisma.gravestoneInfo.count({ where: { position_id: masterId, deleted_at: null } });
+    // direction/position は GravestoneInfo が int を保持し、名称解決は Number(code) と
+    // 突合する（seed / フロント resolveMasterName と整合）。PK id は API 追加・再seed・
+    // 移行 backfill で code とドリフトしうるため、id でなく code 基準で数える（#268）。
+    // ※フレッシュ seed 直後は偶然 id === Number(code) のため従来実装でも一致していた。
+    case 'direction': {
+      const codeNum = Number(code);
+      if (!Number.isInteger(codeNum)) return 0;
+      return prisma.gravestoneInfo.count({ where: { direction_id: codeNum, deleted_at: null } });
+    }
+    case 'position': {
+      const codeNum = Number(code);
+      if (!Number.isInteger(codeNum)) return 0;
+      return prisma.gravestoneInfo.count({ where: { position_id: codeNum, deleted_at: null } });
+    }
     default:
       return 0;
   }
@@ -800,7 +805,7 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
     if (rest.code !== undefined) {
       const existing = await delegate.findUnique({ where: { id: masterId } });
       if (existing && existing.code !== rest.code) {
-        const usageCount = await countMasterCodeUsage(masterType, existing.code, masterId);
+        const usageCount = await countMasterCodeUsage(masterType, existing.code);
         if (usageCount > 0) {
           const label = masterTypeLabels[masterType];
           res.status(409).json({
@@ -956,7 +961,7 @@ export const deleteMaster = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
-    const usageCount = await countMasterCodeUsage(masterType, existing.code, masterId);
+    const usageCount = await countMasterCodeUsage(masterType, existing.code);
     if (usageCount > 0) {
       res.status(409).json({
         success: false,

--- a/tests/masters/masterCrud.test.ts
+++ b/tests/masters/masterCrud.test.ts
@@ -91,6 +91,13 @@ const mockPrisma: any = {
     update: jest.fn(),
     delete: jest.fn(),
   },
+  directionMaster: {
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
 };
 
 jest.mock('@prisma/client', () => ({
@@ -585,6 +592,45 @@ describe('Master CRUD Controller', () => {
       // 後続テストのためにリセット
       mockPrisma.usageFee.count.mockResolvedValue(0);
       mockPrisma.managementFee.count.mockResolvedValue(0);
+    });
+
+    it('方角マスタの使用中チェックは PK id でなく code 基準で照合すること (#268)', async () => {
+      // PK id と code がドリフトした状態（再seed・API追加後）:
+      // id=12, code='3' のマスタに対し direction_id=3 の区画が存在 → 使用中
+      mockRequest.params = { masterType: 'direction', id: '12' };
+      mockPrisma.directionMaster.findUnique.mockResolvedValue({
+        id: 12,
+        code: '3',
+        name: '南東',
+      });
+      mockPrisma.gravestoneInfo.count.mockResolvedValue(4);
+
+      await deleteMaster(mockRequest as Request, mockResponse as Response);
+
+      // 旧実装は masterId=12 で照合して 0 件→削除を許可していた（孤児コード化）
+      expect(mockPrisma.gravestoneInfo.count).toHaveBeenCalledWith({
+        where: { direction_id: 3, deleted_at: null },
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(409);
+      expect(mockPrisma.directionMaster.delete).not.toHaveBeenCalled();
+
+      // 後続テストのためにリセット
+      mockPrisma.gravestoneInfo.count.mockResolvedValue(0);
+    });
+
+    it('数値でない code の方角マスタは使用中 0 扱いで削除できること（NaN 照合をしない）(#268)', async () => {
+      mockRequest.params = { masterType: 'direction', id: '13' };
+      mockPrisma.directionMaster.findUnique.mockResolvedValue({
+        id: 13,
+        code: 'NE',
+        name: '北東',
+      });
+      mockPrisma.directionMaster.delete.mockResolvedValue({ id: 13 });
+
+      await deleteMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.gravestoneInfo.count).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
     });
 
     it('存在しないIDの場合、404エラーを返すこと', async () => {


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #268 (medium) の修正。

#231 の使用中チェックが direction/position を **PK id** で照合（`gravestoneInfo.count({ direction_id: masterId })`）していたが、名称解決は `direction_id === Number(master.code)` で行う（seed / フロント resolveMasterName と整合）。id と code がドリフトすると（API追加・再seed・移行backfill）:

- 使用中マスタでも件数0で削除許可 → **孤児コード化**（#231 が防ごうとした事象の再発）
- 逆に無関係な行をカウントして安全な削除を 409 で誤ブロック

## 修正
- direction/position の照合を `Number(existing.code)` 基準へ変更（`Number.isInteger` ガード付き、数値でない code は使用中0扱い）
- 未使用になった `masterId` 引数を `countMasterCodeUsage` から除去

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/masters/` **87/87 pass**（回帰テスト2本追加: id=12/code='3' ドリフト状態で direction_id=3 を照合し409 / 非数値codeはNaN照合せず削除可）

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)