### PR TITLE
fix(plots): 契約復活時に物理区画の空き面積を検証し過剰割当を防止

### DIFF
--- a/src/plots/controllers/restoreContract.ts
+++ b/src/plots/controllers/restoreContract.ts
@@ -12,7 +12,7 @@ import prisma from '../../db/prisma';
 import { NotFoundError, ConflictError } from '../../middleware/errorHandler';
 import { recordEntityUpdated } from '../services/historyService';
 import { contractStatusService } from '../services/contractStatusService';
-import { updatePhysicalPlotStatus } from '../utils';
+import { updatePhysicalPlotStatus, validateContractArea } from '../utils';
 import type { RestoreContractRequest } from '../../validations/plotValidation';
 
 export const restoreContract = async (
@@ -45,6 +45,23 @@ export const restoreContract = async (
     contractStatusService.validateTransitionWithReason(beforeStatus, ContractStatus.active, reason);
 
     await prisma.$transaction(async (tx) => {
+      // 復活面積が物理区画の空きに収まるか検証する（#270）。
+      // 解約で空いた面積に別契約が販売されている場合（A解約→B販売→A復活）、
+      // 無検証で active に戻すと物理面積を超える過剰割当が成立してしまう。
+      // 自分自身は terminated のため集計外だが、明示的に除外して将来の状態変更に備える。
+      const areaValidation = await validateContractArea(
+        tx,
+        contractPlot.physical_plot_id,
+        Number(contractPlot.contract_area_sqm),
+        id
+      );
+      if (!areaValidation.isValid) {
+        throw new ConflictError(
+          `契約面積が物理区画の空き面積を超えるため復活できません: ${areaValidation.message ?? ''}` +
+            `（復活には他契約の解約または面積の調整が必要です）`
+        );
+      }
+
       await tx.contractPlot.update({
         where: { id },
         data: { contract_status: ContractStatus.active },

--- a/tests/plots/controllers/restoreContract.test.ts
+++ b/tests/plots/controllers/restoreContract.test.ts
@@ -54,8 +54,10 @@ jest.mock('../../../src/plots/services/historyService', () => ({
 }));
 
 const mockUpdatePhysicalPlotStatus = jest.fn();
+const mockValidateContractArea = jest.fn();
 jest.mock('../../../src/plots/utils', () => ({
   updatePhysicalPlotStatus: (...args: unknown[]) => mockUpdatePhysicalPlotStatus(...args),
+  validateContractArea: (...args: unknown[]) => mockValidateContractArea(...args),
 }));
 
 import { restoreContract } from '../../../src/plots/controllers/restoreContract';
@@ -90,6 +92,8 @@ const buildReq = (overrides: Partial<Request> = {}): Request => {
 describe('restoreContract', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // 既定: 面積検証は通過（#270 の検証は個別テストで上書き）
+    mockValidateContractArea.mockResolvedValue({ isValid: true, availableArea: 3.6 });
   });
 
   describe('成功ケース', () => {
@@ -98,6 +102,7 @@ describe('restoreContract', () => {
         id: 'cp-1',
         physical_plot_id: 'pp-1',
         contract_status: 'terminated',
+        contract_area_sqm: 3.6,
         deleted_at: null,
       });
       mockPrisma.contractPlot.update.mockResolvedValue({
@@ -138,10 +143,43 @@ describe('restoreContract', () => {
         },
       });
       expect(next).not.toHaveBeenCalled();
+      // 面積検証がトランザクション内で正しい引数で呼ばれること（#270）
+      expect(mockValidateContractArea).toHaveBeenCalledWith(mockPrisma, 'pp-1', 3.6, 'cp-1');
     });
   });
 
   describe('失敗ケース', () => {
+    it('復活面積が物理区画の空きを超える場合は ConflictError で拒否される (#270)', async () => {
+      // シナリオ: P(3.6㎡) で A(3.6) 解約 → B(3.6) 新規販売 → A 復活を試行
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp-1',
+        physical_plot_id: 'pp-1',
+        contract_status: 'terminated',
+        contract_area_sqm: 3.6,
+        deleted_at: null,
+      });
+      mockValidateContractArea.mockResolvedValue({
+        isValid: false,
+        availableArea: 0,
+        message: '空き面積 0㎡ に対して 3.6㎡ は契約できません',
+      });
+
+      const req = buildReq();
+      const res = buildRes();
+      const next = jest.fn() as NextFunction;
+
+      await restoreContract(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const err = (next as jest.Mock).mock.calls[0]?.[0] as Error;
+      expect(err).toBeInstanceOf(ConflictError);
+      expect(err.message).toContain('復活できません');
+      // active への更新・物理区画再計算・履歴記録のいずれも実行されないこと
+      expect(mockPrisma.contractPlot.update).not.toHaveBeenCalled();
+      expect(mockUpdatePhysicalPlotStatus).not.toHaveBeenCalled();
+      expect(mockRecordEntityUpdated).not.toHaveBeenCalled();
+    });
+
     it('存在しない ContractPlot は NotFoundError', async () => {
       mockPrisma.contractPlot.findUnique.mockResolvedValue(null);
 


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #270 (medium) の修正。

restoreContract（terminated→active）に面積検証が無く、以下の手順で**物理区画の過剰割当**が成立していた:

1. P(3.6㎡) に契約 A(3.6㎡, active)
2. A を解約 → #209 により空き 3.6㎡ 扱い
3. B(3.6㎡) を新規販売（validateContractArea 通過）
4. **A を復活 → A+B = 7.2㎡ が 3.6㎡ に同居**（エラー無く成功）

`updatePhysicalPlotStatus` の `Math.max(0,…)` クランプで画面上は sold_out に丸まり、不整合が潜伏する。terminate(#236) 側は active が外れる方向で安全、restore 側だけガードが欠落していた非対称。

## 修正
tx 内・active 更新前に `validateContractArea`（自分自身を excludeContractPlotId で除外）で復活面積が空きに収まるか検証し、超過時は **409 ConflictError** で復活を拒否。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/plots/controllers/restoreContract.test.ts` **7/7 pass**（回帰テスト追加: 空き超過で409・update/再計算/履歴のいずれも実行されない / 成功時に正しい引数で面積検証が呼ばれる）

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)