### PR TITLE
fix(auth): forgotPassword の招待未完了検知をメール正規化して偽陰性を解消

### DIFF
--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -699,7 +699,11 @@ export const forgotPassword = async (req: Request, res: Response) => {
       });
     }
 
-    const { email } = req.body as { email: string };
+    const { email: rawEmail } = req.body as { email: string };
+    // Staff.email は createStaff/updateStaff で trim().toLowerCase() 保存される。
+    // 入力をそのまま使うと大文字混じり・前後空白でルックアップがヒットせず、
+    // 招待未完了検知（#234）が偽陰性になるため同じ正規化を通す（#280）。
+    const email = rawEmail.trim().toLowerCase();
 
     log.info({ email }, 'Auth: password reset request');
 

--- a/tests/auth/authController.test.ts
+++ b/tests/auth/authController.test.ts
@@ -891,6 +891,31 @@ describe('Auth Controller', () => {
         expect(mockResponse.status).toHaveBeenCalledWith(200);
         expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
       });
+
+      it('大文字・前後空白入りメールでも正規化してルックアップ・リセット送信すること (#280)', async () => {
+        // Staff.email は trim().toLowerCase() で保存されるため、生入力のままでは
+        // ルックアップがヒットせず招待未完了検知（#234）が偽陰性になっていた
+        mockRequest.body = { email: '  Pending@Example.COM ' };
+        mockPrisma.staff.findFirst.mockResolvedValue({
+          id: 5,
+          supabase_uid: 'pending_1748000000000',
+        });
+
+        await forgotPassword(mockRequest as Request, mockResponse as Response);
+
+        // 診断ルックアップは正規化済みメールで行われること
+        expect(mockPrisma.staff.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { email: 'pending@example.com', deleted_at: null },
+          })
+        );
+        // リセット送信も正規化済みメールで行われること
+        expect(mockSupabaseAuth.resetPasswordForEmail).toHaveBeenCalledWith(
+          'pending@example.com',
+          expect.any(Object)
+        );
+        expect(mockResponse.status).toHaveBeenCalledWith(200);
+      });
     });
   }); // Supabase環境変数が設定されている場合の終了
 


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #280 (low) の修正。

#234 の招待未完了検知（supabase_uid が `pending_` のスタッフへのリセット要求を warn）は**生入力メール**で `staff.findFirst` していたが、Staff.email は createStaff/updateStaff で必ず `trim().toLowerCase()` 保存される。大文字混じり・前後空白付き入力ではヒットせず、**検知が必要なケースほど warn が出ない偽陰性**になっていた。

## 修正
ルックアップ前に `email.trim().toLowerCase()` で正規化し、`resetPasswordForEmail` にも同じ正規化済みメールを渡す（列挙対策の一律成功応答・タイミング均一化は従来どおり維持）。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/auth/authController.test.ts` **32/32 pass**（回帰テスト追加: `'  Pending@Example.COM '` 入力で正規化済みメールによるルックアップ＆リセット送信を検証）

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)