### PR TITLE
fix(collective-burials): 合祀の再作成時に残存埋葬者から count・上限到達日・請求予定日を再同期

### DIFF
--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -350,19 +350,26 @@ export const createCollectiveBurial = async (
           },
         });
 
+    // 実埋葬者から件数・上限到達日・請求予定日を再同期する（#281）。
+    // BuriedPerson は ContractPlot 紐付けのため合祀のソフトデリートでは消えない。
+    // 復活時に 0 固定のままだと「count=0 なのに埋葬者一覧に実データが並ぶ」矛盾や、
+    // 上限到達済みでも billing_scheduled_date が null でゆうちょ請求対象から漏れる。
+    const synced = await updateCollectiveBurialCount(prisma, contractPlotId);
+    const result = synced ?? collectiveBurial;
+
     res.status(201).json({
       success: true,
       data: {
-        id: collectiveBurial.id,
-        contractPlotId: collectiveBurial.contract_plot_id,
-        burialCapacity: collectiveBurial.burial_capacity,
-        currentBurialCount: collectiveBurial.current_burial_count,
-        validityPeriodYears: collectiveBurial.validity_period_years,
-        billingStatus: collectiveBurial.billing_status,
-        billingAmount: collectiveBurial.billing_amount,
-        notes: collectiveBurial.notes,
-        createdAt: collectiveBurial.created_at.toISOString(),
-        updatedAt: collectiveBurial.updated_at.toISOString(),
+        id: result.id,
+        contractPlotId: result.contract_plot_id,
+        burialCapacity: result.burial_capacity,
+        currentBurialCount: result.current_burial_count,
+        validityPeriodYears: result.validity_period_years,
+        billingStatus: result.billing_status,
+        billingAmount: result.billing_amount,
+        notes: result.notes,
+        createdAt: result.created_at.toISOString(),
+        updatedAt: result.updated_at.toISOString(),
       },
     });
   } catch (error) {

--- a/tests/collective-burials/collectiveBurialFixes.test.ts
+++ b/tests/collective-burials/collectiveBurialFixes.test.ts
@@ -158,6 +158,43 @@ describe('collectiveBurialController — バグ修正回帰', () => {
       });
       expect(responseStatus).toHaveBeenCalledWith(201);
     });
+
+    it('復活時に残存する埋葬者から count・上限到達日・請求予定日を再同期する (#281)', async () => {
+      // シナリオ: 合祀のみ削除（BuriedPerson 7名は ContractPlot 紐付けで残存）→ 同区画で再作成
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: 'cp1' });
+      // 1回目: 既存チェック（ソフトデリート済み行）/ 2回目: 再同期内の取得（復活済み行）
+      mockPrisma.collectiveBurial.findUnique
+        .mockResolvedValueOnce({ ...CB_ROW, deleted_at: new Date('2026-05-01') })
+        .mockResolvedValueOnce({ ...CB_ROW, burial_capacity: 5, deleted_at: null });
+      // 1回目: 復活 update / 2回目: 再同期 update
+      const restoredRow = { ...CB_ROW, burial_capacity: 5, current_burial_count: 0 };
+      const syncedRow = {
+        ...CB_ROW,
+        burial_capacity: 5,
+        current_burial_count: 7,
+        capacity_reached_date: new Date('2026-06-06'),
+        billing_scheduled_date: new Date('2059-06-06'),
+      };
+      mockPrisma.collectiveBurial.update
+        .mockResolvedValueOnce(restoredRow)
+        .mockResolvedValueOnce(syncedRow);
+      mockPrisma.buriedPerson.count.mockResolvedValue(7);
+
+      mockRequest.body = { ...validBody, burialCapacity: 5 };
+      await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // 再同期 update（2回目）が実埋葬者数で行われ、上限到達日・請求予定日もセットされること
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledTimes(2);
+      const syncCall = mockPrisma.collectiveBurial.update.mock.calls[1][0];
+      expect(syncCall.data).toMatchObject({ current_burial_count: 7 });
+      expect(syncCall.data.capacity_reached_date).toBeInstanceOf(Date);
+      expect(syncCall.data.billing_scheduled_date).toBeInstanceOf(Date);
+
+      // レスポンスは再同期後の値（count=0 固定でない）こと
+      expect(responseStatus).toHaveBeenCalledWith(201);
+      const payload = responseJson.mock.calls[0][0];
+      expect(payload.data.currentBurialCount).toBe(7);
+    });
   });
 
   describe('syncBurialCount (#203)', () => {


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #281 (low) の修正。

#202 の復活パス（ソフトデリート行の再利用）は `current_burial_count` を無条件 0、上限到達日・請求予定日を null にリセットするが、**BuriedPerson は ContractPlot 紐付けのため合祀のソフトデリートでは消えない**。

再現手順: ①合祀登録→埋葬者登録（上限到達）→②合祀のみ削除（埋葬者残存）→③同区画で再作成
→ count=0 なのに埋葬者一覧に実データが並ぶ矛盾 + `billing_scheduled_date` null で**ゆうちょ請求対象から漏れる**（POST は sync を呼ばず、手動 sync-count か区画編集まで自己修復しない）。

## 修正
作成・復活の直後に `updateCollectiveBurialCount` で実埋葬者数から count / 上限到達日 / 請求予定日を再同期し、**同期後の値をレスポンスで返す**。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/collective-burials/` **16/16 pass**（回帰テスト追加: 埋葬者7名残存+capacity5で再作成→count=7・上限到達日・請求予定日がセットされレスポンスにも反映）

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)