### PR TITLE
fix(documents): UPLOAD_DIR の末尾スラッシュ/相対パスでファイル機能が全停止する問題を修正

### DIFF
--- a/src/documents/fileStorage.ts
+++ b/src/documents/fileStorage.ts
@@ -14,7 +14,11 @@ import path from 'path';
 
 /** アップロードファイルの保存先ルートディレクトリ */
 export function getUploadDir(): string {
-  return process.env['UPLOAD_DIR'] || path.resolve(process.cwd(), 'uploads');
+  // env 生値をそのまま使うと、末尾スラッシュ付き（.../uploads/）や相対パスの設定で
+  // resolveDocumentFilePath の startsWith ガードが常に偽になり、全アップロード・
+  // ダウンロードが「ファイルが見つかりません」で無言全停止する（#274）。
+  // path.resolve で常に正規化済み絶対パスに揃える（末尾スラッシュ除去・相対→絶対）。
+  return path.resolve(process.env['UPLOAD_DIR'] || path.join(process.cwd(), 'uploads'));
 }
 
 /**

--- a/tests/documents/fileStorage.test.ts
+++ b/tests/documents/fileStorage.test.ts
@@ -39,6 +39,16 @@ describe('fileStorage', () => {
       delete process.env.UPLOAD_DIR;
       expect(getUploadDir()).toBe(path.resolve(process.cwd(), 'uploads'));
     });
+
+    it('末尾スラッシュ付きの UPLOAD_DIR を正規化する (#274)', () => {
+      process.env.UPLOAD_DIR = `${tmpDir}${path.sep}`;
+      expect(getUploadDir()).toBe(tmpDir);
+    });
+
+    it('相対パスの UPLOAD_DIR を絶対パスへ解決する (#274)', () => {
+      process.env.UPLOAD_DIR = 'relative-uploads';
+      expect(getUploadDir()).toBe(path.resolve(process.cwd(), 'relative-uploads'));
+    });
   });
 
   describe('buildDocumentFileKey', () => {
@@ -69,6 +79,21 @@ describe('fileStorage', () => {
       expect(() => resolveDocumentFilePath('documents/../../etc/passwd')).toThrow(
         'Invalid file key'
       );
+    });
+
+    it('末尾スラッシュ付き UPLOAD_DIR でも正規キーが解決できる（無言全停止の回帰防止 #274）', () => {
+      process.env.UPLOAD_DIR = `${tmpDir}${path.sep}`;
+      const resolved = resolveDocumentFilePath('documents/abc/file.pdf');
+      expect(resolved).toBe(path.join(tmpDir, 'documents', 'abc', 'file.pdf'));
+    });
+
+    it('相対パス UPLOAD_DIR でも正規キーが解決でき、トラバーサルは拒否される (#274)', () => {
+      process.env.UPLOAD_DIR = 'relative-uploads';
+      const resolved = resolveDocumentFilePath('documents/abc/file.pdf');
+      expect(resolved).toBe(
+        path.resolve(process.cwd(), 'relative-uploads', 'documents', 'abc', 'file.pdf')
+      );
+      expect(() => resolveDocumentFilePath('../outside.txt')).toThrow('Invalid file key');
     });
   });
 


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #274 (medium) の修正。

`getUploadDir()` が env 生値をそのまま返すため:

| 設定ミス | 何が起きるか |
|---|---|
| 末尾スラッシュ（`/srv/uploads/`） | パストラバーサルガードが `/srv/uploads//` を要求 → **全正規キーが拒否** |
| 相対パス（`uploads`） | uploadDir 相対のまま resolved だけ絶対化 → **同様に全拒否** |

いずれも #198 のアップロード・ダウンロードが「ファイルが見つかりません」しか出さず**無言で全停止**。komine-local 本番運用で管理者が設定しやすいミス。

## 修正
`getUploadDir()` を `path.resolve(...)` で常に正規化済み絶対パスに揃える（末尾スラッシュ除去・相対→絶対）。トラバーサルガードは従来どおり機能。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/documents/fileStorage.test.ts` **13/13 pass**（回帰テスト4本追加: 末尾スラッシュ正規化 / 相対→絶対 / 両ケースで正規キー解決可 / トラバーサル拒否維持）

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)