### PR TITLE
fix(billings): 請求サマリーの未入金額から解約済・貸倒請求を除外（#170 の未収規則と整合）

### DIFF
--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -159,9 +159,23 @@ export const getBillingsSummary = async (
       };
     }
 
-    const [sums, totalCount, overdueCount] = await Promise.all([
+    // 未入金は回収可能な債権のみで算出する（#272）。
+    // 解約済み（terminated）・貸倒（written_off）は債務/債権が消滅しており、
+    // 含めると回収不能金額が「未入金」に積み上がる。#170 の
+    // deriveContractPlotPayment（terminated 除外）と同一規則を適用し、
+    // 区画詳細の uncollected_amount とサマリー StatCard を整合させる。
+    // AND 合成でユーザー指定の status 等のフィルタは維持する。
+    const collectibleWhere: Prisma.BillingWhereInput = {
+      AND: [where, { terminated: false, status: { notIn: ['written_off', 'terminated'] } }],
+    };
+
+    const [sums, collectibleSums, totalCount, overdueCount] = await Promise.all([
       prisma.billing.aggregate({
         where,
+        _sum: { amount: true, paid_amount: true },
+      }),
+      prisma.billing.aggregate({
+        where: collectibleWhere,
         _sum: { amount: true, paid_amount: true },
       }),
       prisma.billing.count({ where }),
@@ -170,10 +184,13 @@ export const getBillingsSummary = async (
 
     const totalAmount = sums._sum.amount ?? 0;
     const paidAmount = sums._sum.paid_amount ?? 0;
+    const collectibleAmount = collectibleSums._sum.amount ?? 0;
+    const collectiblePaid = collectibleSums._sum.paid_amount ?? 0;
     const data: BillingSummaryResponse = {
       totalAmount,
       paidAmount,
-      unpaidAmount: totalAmount - paidAmount,
+      // 過入金で負にしない（uncollectedFromTotals と同じ規約）
+      unpaidAmount: Math.max(0, collectibleAmount - collectiblePaid),
       overdueCount,
       totalCount,
     };

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -225,6 +225,31 @@ describe('billingController', () => {
       });
     });
 
+    it('未入金額は解約済・貸倒請求を除いた回収可能債権のみで算出する (#272)', async () => {
+      mockPrisma.billing.aggregate
+        // 1回目: フィルタ一致の全件（解約済 200,000 円を含む）
+        .mockResolvedValueOnce({ _sum: { amount: 500000, paid_amount: 200000 } })
+        // 2回目: 回収可能（terminated/written_off 除外）のみ
+        .mockResolvedValueOnce({ _sum: { amount: 300000, paid_amount: 200000 } });
+      mockPrisma.billing.count.mockResolvedValueOnce(120).mockResolvedValueOnce(7);
+
+      const req = buildRequest({ query: {} });
+      await getBillingsSummary(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      // 全件差の 300,000 ではなく回収可能のみの 100,000（#170 の未収規則と整合）
+      expect(payload.data.unpaidAmount).toBe(100000);
+      expect(payload.data.totalAmount).toBe(500000);
+      expect(payload.data.paidAmount).toBe(200000);
+      // 2回目の aggregate に除外条件が AND 合成されること（ユーザーフィルタは維持）
+      const collectibleWhere = mockPrisma.billing.aggregate.mock.calls[1][0].where;
+      expect(collectibleWhere.AND[1]).toEqual({
+        terminated: false,
+        status: { notIn: ['written_off', 'terminated'] },
+      });
+      expect(collectibleWhere.AND[0]).toMatchObject({ deleted_at: null });
+    });
+
     it('applies filter conditions and adds overdue status for overdue count', async () => {
       mockPrisma.billing.aggregate.mockResolvedValue({
         _sum: { amount: null, paid_amount: null },


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #272 (medium) の修正。

GET /billings/summary の `unpaidAmount` がフィルタ一致**全件**の `totalAmount - paidAmount` で算出され、解約済（terminated）・貸倒（written_off）の**回収不能金額が「未入金」に積み上がっていた**。#170 の正準ロジック `deriveContractPlotPayment`（terminated 除外）と矛盾し、区画詳細の uncollected_amount とサマリー StatCard が乖離する。

## 修正
- 回収可能債権（`terminated: false` かつ `status notIn ['written_off','terminated']`）のみの aggregate を別途実行し `unpaidAmount` を算出（過入金は `Math.max(0, …)` で負にしない = uncollectedFromTotals と同規約）
- ユーザー指定フィルタ（status/category/期間等）は **AND 合成**で維持
- `totalAmount` / `paidAmount` / `totalCount` は従来どおり全件（一覧表示との整合）

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/billings/` **31/31 pass**（回帰テスト追加: 解約済20万円混入時に unpaid=10万円（全件差30万円でない）/ 除外条件のAND合成とユーザーフィルタ維持を検証）

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)