### PR TITLE
fix(staff): 最後の有効admin保護のTOCTOUレースをSerializable tx内再検証で解消

### DIFF
--- a/src/staff/staffController.ts
+++ b/src/staff/staffController.ts
@@ -4,7 +4,7 @@
  */
 import { Request, Response, NextFunction } from 'express';
 import { getRequestLogger } from '../utils/logger';
-import { StaffRole } from '@prisma/client';
+import { Prisma, StaffRole } from '@prisma/client';
 import { NotFoundError, ConflictError, ValidationError } from '../middleware/errorHandler';
 import prisma from '../db/prisma';
 import {
@@ -53,6 +53,36 @@ const assertNotLastActiveAdmin = async (staffId: number, operationLabel: string)
     );
   }
 };
+
+/**
+ * 最後の有効 admin を失いうる更新を「更新＋再検証」の Serializable トランザクションで
+ * 原子的に実行する（#269）。
+ * 事前チェック（assertNotLastActiveAdmin）だけでは count→update の間に並行する
+ * 降格・無効化・削除が挟まる TOCTOU レースで admin が 0 人になりうる
+ * （例: admin が2人のとき互いを同時降格すると両方の事前チェックが通過する）。
+ * 更新後に同一トランザクション内で有効 admin を再カウントし、0 人ならロールバックする。
+ * Serializable 分離レベルにより競合するトランザクションは直列化される。
+ */
+const updateStaffGuardingLastAdmin = async (
+  staffId: number,
+  data: Prisma.StaffUncheckedUpdateInput,
+  operationLabel: string
+) =>
+  prisma.$transaction(
+    async (tx) => {
+      const updated = await tx.staff.update({ where: { id: staffId }, data });
+      const remainingAdmins = await tx.staff.count({
+        where: { role: 'admin', is_active: true, deleted_at: null },
+      });
+      if (remainingAdmins === 0) {
+        throw new ValidationError(
+          `最後の有効な管理者のため${operationLabel}できません。先に別のスタッフへ管理者権限を付与してください`
+        );
+      }
+      return updated;
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+  );
 
 /**
  * スタッフ一覧取得
@@ -413,8 +443,11 @@ export const updateStaff = async (
     // 最後の有効な admin の降格・無効化を防ぐ（#208）
     const demoting = role !== undefined && ['viewer', 'operator', 'manager'].includes(role);
     const deactivating = isActive === false;
-    if (existingStaff.role === 'admin' && existingStaff.is_active && (demoting || deactivating)) {
-      await assertNotLastActiveAdmin(staffId, demoting ? '権限を変更' : '無効化');
+    const needsLastAdminGuard =
+      existingStaff.role === 'admin' && existingStaff.is_active && (demoting || deactivating);
+    const guardLabel = demoting ? '権限を変更' : '無効化';
+    if (needsLastAdminGuard) {
+      await assertNotLastActiveAdmin(staffId, guardLabel);
     }
 
     // Supabase 側メールを更新したかどうか（DB更新失敗時の補償戻し判定用 #233）
@@ -479,10 +512,13 @@ export const updateStaff = async (
     // createStaff の補償削除と同様に、失敗時は Supabase 側を旧メールへ戻す（#233）。
     let updatedStaff;
     try {
-      updatedStaff = await prisma.staff.update({
-        where: { id: staffId },
-        data: updateData,
-      });
+      // admin を失いうる更新は tx 内再検証つきで原子的に行う（#269）
+      updatedStaff = needsLastAdminGuard
+        ? await updateStaffGuardingLastAdmin(staffId, updateData, guardLabel)
+        : await prisma.staff.update({
+            where: { id: staffId },
+            data: updateData,
+          });
     } catch (dbError) {
       if (supabaseEmailUpdated && existingStaff.supabase_uid) {
         try {
@@ -567,7 +603,8 @@ export const deleteStaff = async (
 
     // 最後の有効な admin の削除を防ぐ（#208）
     // Supabase アカウント削除より前に判定する（認証アカウントだけ消える事故を防ぐ）
-    if (existingStaff.role === 'admin' && existingStaff.is_active) {
+    const needsLastAdminGuard = existingStaff.role === 'admin' && existingStaff.is_active;
+    if (needsLastAdminGuard) {
       await assertNotLastActiveAdmin(staffId, '削除');
     }
 
@@ -588,14 +625,13 @@ export const deleteStaff = async (
       }
     }
 
-    // 論理削除実行
-    await prisma.staff.update({
-      where: { id: staffId },
-      data: {
-        deleted_at: new Date(),
-        is_active: false,
-      },
-    });
+    // 論理削除実行（admin を失いうる削除は tx 内再検証つきで原子的に行う #269）
+    const deleteData = { deleted_at: new Date(), is_active: false };
+    if (needsLastAdminGuard) {
+      await updateStaffGuardingLastAdmin(staffId, deleteData, '削除');
+    } else {
+      await prisma.staff.update({ where: { id: staffId }, data: deleteData });
+    }
 
     res.json({
       success: true,
@@ -644,17 +680,20 @@ export const toggleStaffActive = async (
     }
 
     // 最後の有効な admin の無効化を防ぐ（#208）
-    if (existingStaff.role === 'admin' && existingStaff.is_active) {
+    const needsLastAdminGuard = existingStaff.role === 'admin' && existingStaff.is_active;
+    if (needsLastAdminGuard) {
       await assertNotLastActiveAdmin(staffId, '無効化');
     }
 
-    // 有効/無効を切り替え
-    const updatedStaff = await prisma.staff.update({
-      where: { id: staffId },
-      data: {
-        is_active: !existingStaff.is_active,
-      },
-    });
+    // 有効/無効を切り替え（admin を失いうる無効化は tx 内再検証つきで原子的に行う #269）
+    const updatedStaff = needsLastAdminGuard
+      ? await updateStaffGuardingLastAdmin(staffId, { is_active: false }, '無効化')
+      : await prisma.staff.update({
+          where: { id: staffId },
+          data: {
+            is_active: !existingStaff.is_active,
+          },
+        });
 
     res.json({
       success: true,

--- a/tests/staff/staffController.test.ts
+++ b/tests/staff/staffController.test.ts
@@ -49,10 +49,15 @@ const mockPrisma = {
     update: jest.fn(),
     count: jest.fn(),
   },
+  // #269: 最後のadmin保護の tx 内再検証用。コールバックに mockPrisma 自身を渡す
+  $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(mockPrisma)),
 };
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: {
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
+  },
 }));
 
 // 環境変数をモック化
@@ -636,7 +641,45 @@ describe('Staff Controller', () => {
             data: expect.objectContaining({ role: 'viewer' }),
           })
         );
+        // admin を失いうる降格は Serializable tx で原子的に実行される（#269）
+        expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+          isolationLevel: 'Serializable',
+        });
         expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+      });
+
+      it('並行操作で事前チェック通過後に admin が0人になる場合、tx内再検証で拒否される (#269)', async () => {
+        // TOCTOU シナリオ: 事前チェック時は「他に有効adminが1人」だが、
+        // update 後の tx 内再カウント時には並行降格で 0 人になっている
+        mockRequest.params = { id: '1' };
+        mockRequest.body = { role: 'viewer' };
+
+        const mockExistingStaff = {
+          id: 1,
+          name: 'Admin',
+          email: 'admin@example.com',
+          role: 'admin',
+          is_active: true,
+          supabase_uid: 'admin-uid',
+          last_login_at: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        };
+        mockPrisma.staff.findFirst.mockResolvedValue(mockExistingStaff);
+        mockPrisma.staff.count
+          .mockResolvedValueOnce(1) // 事前チェック: 他に有効adminあり（通過）
+          .mockResolvedValueOnce(0); // tx内再検証: 並行降格で有効admin 0人
+        mockPrisma.staff.update.mockResolvedValue({ ...mockExistingStaff, role: 'viewer' });
+
+        await updateStaff(mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockNext).toHaveBeenCalled();
+        const error = (mockNext as jest.Mock).mock.calls[0][0];
+        expect(error.message).toContain('最後の有効な管理者');
+        // 再検証は更新と同一トランザクション内（Serializable）で行われること
+        expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+          isolationLevel: 'Serializable',
+        });
       });
     });
 


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #269 (medium) の修正。

`assertNotLastActiveAdmin`（#208）は count→update が**別トランザクション・行ロック無し**のため:

> admin が2人 (A, B) のとき「Aを降格」と「Bを降格」が同時実行されると、両方の事前チェックが「他に1人いる」と判定して通過 → 両 update 成功 → **有効admin 0人**

#208 が防ごうとした本番ロックアウト（admin専用操作全断、復旧に bootstrap script 必要）が同時実行で再現する。降格（updateStaff）・削除（deleteStaff）・無効化（toggleStaffActive）の3経路すべてに同じレース窓。

## 修正
- `updateStaffGuardingLastAdmin`: admin を失いうる更新を「update → 同一tx内で有効admin再カウント → 0人ならロールバック」の **Serializable トランザクション**で原子化（競合する並行txは直列化され片方が失敗）
- 3経路すべてに適用。admin に影響しない通常更新は従来どおり単発 update（性能影響なし）
- 事前チェック（#208）は高速失敗のため維持
- updateStaff では既存の Supabase メール補償戻し（#233）の try/catch 内で実行されるため、ロールバック時はメールも旧値へ戻る

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/staff/` **33/33 pass**（回帰テスト追加: 事前チェック通過後にtx内再カウントが0人→ValidationError / 降格がSerializable txで実行されることを検証）

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)