### PR TITLE
fix(plots,middleware): 家族連絡先の文字数上限をDB長に整合し P2000→400 マッピングを追加

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -315,6 +315,31 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
       });
     }
 
+    case 'P2000': {
+      // 値がカラムの最大長を超過（Zod 上限と DB VarChar 長の不整合等）。
+      // default に落とすと詳細なしの 500 になりトランザクション全体が原因不明で
+      // 失敗するため、400 VALIDATION_ERROR として返す（#276）。
+      // meta.column_name は v7 + driver adapter では取れない場合があるため任意。
+      const meta = error.meta as Record<string, unknown> | undefined;
+      const column =
+        typeof meta?.['column_name'] === 'string' ? (meta['column_name'] as string) : undefined;
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力値が長すぎます',
+          details: [
+            {
+              field: column,
+              message: column
+                ? `${toFieldLabel(column)} が保存可能な最大文字数を超えています`
+                : '入力値が保存可能な最大文字数を超えています',
+            },
+          ],
+        },
+      });
+    }
+
     case 'P2025':
       // Record not found
       return res.status(404).json({

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -107,7 +107,29 @@ export const familyContactSchema = sharedFamilyContactSchema.extend({
   name: z.string().max(100).optional().or(z.literal('')),
   relationship: z.string().max(50).optional().or(z.literal('')),
   address: z.string().max(200).optional().or(z.literal('')),
-  phoneNumber: z.string().max(20).optional().or(z.literal('')),
+  // 各上限は DB の VarChar 長に整合させる（#276）。共有スキーマの max(20)/max(10) の
+  // ままだと Zod 通過後に Prisma P2000 → 500 となりトランザクション全体が失敗する。
+  // phone_number/fax_number=VarChar(11), phone_number_2/work_phone_number=VarChar(15),
+  // postal_code=VarChar(7)
+  phoneNumber: z
+    .string()
+    .max(11, '電話番号は11文字以内（ハイフンなし）で入力してください')
+    .optional()
+    .or(z.literal('')),
+  phoneNumber2: z.string().max(15).optional().nullable().or(z.literal('')),
+  faxNumber: z
+    .string()
+    .max(11, 'FAX番号は11文字以内（ハイフンなし）で入力してください')
+    .optional()
+    .nullable()
+    .or(z.literal('')),
+  postalCode: z
+    .string()
+    .max(7, '郵便番号は7文字以内（ハイフンなし）で入力してください')
+    .optional()
+    .nullable()
+    .or(z.literal('')),
+  workPhoneNumber: z.string().max(15).optional().nullable().or(z.literal('')),
 });
 
 /**

--- a/tests/middleware/errorHandler.test.ts
+++ b/tests/middleware/errorHandler.test.ts
@@ -96,6 +96,41 @@ describe('Error Handler Middleware', () => {
         });
       });
 
+      it('P2000（カラム長超過）は 500 でなく 400 VALIDATION_ERROR を返すこと (#276)', () => {
+        const error = new Prisma.PrismaClientKnownRequestError(
+          'The provided value for the column is too long',
+          {
+            code: 'P2000',
+            clientVersion: '7.0.0',
+            meta: { column_name: 'phone_number' },
+          }
+        );
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        const payload = (mockResponse.json as jest.Mock).mock.calls[0][0];
+        expect(payload.error.code).toBe('VALIDATION_ERROR');
+        expect(payload.error.message).toBe('入力値が長すぎます');
+        expect(payload.error.details[0].field).toBe('phone_number');
+        // DB内部情報（テーブル名等）をそのまま返さないこと（#217 と同方針）
+        expect(JSON.stringify(payload)).not.toContain('column is too long');
+      });
+
+      it('P2000（meta.column_name 不在）でも 400 で汎用メッセージを返すこと (#276)', () => {
+        const error = new Prisma.PrismaClientKnownRequestError('Value too long', {
+          code: 'P2000',
+          clientVersion: '7.0.0',
+        });
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        const payload = (mockResponse.json as jest.Mock).mock.calls[0][0];
+        expect(payload.error.code).toBe('VALIDATION_ERROR');
+        expect(payload.error.details[0].message).toContain('最大文字数');
+      });
+
       it('P2002（v6 meta.target=string カンマ区切り）を正しく処理すること', () => {
         const error = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
           code: 'P2002',

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -4,6 +4,7 @@ import {
   createPlotSchema,
   updatePlotSchema,
   createPlotContractSchema,
+  familyContactSchema,
 } from '../../src/validations/plotValidation';
 
 describe('Plot Validation (ContractPlot Model)', () => {
@@ -684,6 +685,49 @@ describe('Plot Validation (ContractPlot Model)', () => {
       };
 
       expect(() => createPlotContractSchema.parse(dataWithOptionalFields)).not.toThrow();
+    });
+  });
+
+  describe('familyContactSchema の DB カラム長整合 (#276)', () => {
+    const base = { name: '山田太郎', relationship: '長男' };
+
+    it('DB VarChar 長以内の値は通過する', () => {
+      expect(() =>
+        familyContactSchema.parse({
+          ...base,
+          phoneNumber: '09012345678', // 11文字 = VarChar(11)
+          faxNumber: '0951234567', // 10文字
+          postalCode: '8500000', // 7文字 = VarChar(7)
+          phoneNumber2: '095-123-4567', // 12文字 <= VarChar(15)
+          workPhoneNumber: '095-123-4567',
+        })
+      ).not.toThrow();
+    });
+
+    it('電話番号が VarChar(11) を超えると Zod で弾く（P2000 の 500 を防ぐ）', () => {
+      // 修正前: max(20) で '090-1234-5678'(13文字) が Zod を通過し Prisma P2000 → 500
+      expect(() => familyContactSchema.parse({ ...base, phoneNumber: '090-1234-5678' })).toThrow(
+        /11文字以内/
+      );
+    });
+
+    it('郵便番号が VarChar(7) を超えると Zod で弾く', () => {
+      expect(() => familyContactSchema.parse({ ...base, postalCode: '850-0000' })).toThrow(
+        /7文字以内/
+      );
+    });
+
+    it('FAX番号が VarChar(11) を超えると Zod で弾く', () => {
+      expect(() => familyContactSchema.parse({ ...base, faxNumber: '095-123-45678' })).toThrow(
+        /11文字以内/
+      );
+    });
+
+    it('空文字・未指定は従来どおり許容する（バルク登録のスキップ判定と整合）', () => {
+      expect(() =>
+        familyContactSchema.parse({ ...base, phoneNumber: '', postalCode: '', faxNumber: '' })
+      ).not.toThrow();
+      expect(() => familyContactSchema.parse(base)).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #276 (medium) の修正。

#219/#242 で familyContacts の実DB書込経路が新設されたが、`familyContactSchema` の上限が DB VarChar 長を超えており、Zod 通過 → Prisma P2000 → **errorHandler default の 500（フィールド詳細なし）** でトランザクション全体が原因不明で失敗していた。

トリガー例: 家族連絡先の電話に `090-1234-5678`（13文字 > VarChar(11)）を入力して PUT/POST /plots。

## 修正（二段構え）
1. **familyContactSchema の上限を DB VarChar 長に整合**: phoneNumber/faxNumber→max(11)、phoneNumber2/workPhoneNumber→max(15)、postalCode→max(7)（「ハイフンなし」を促すメッセージ付き、空文字・未指定の許容は従来どおり）
2. **errorHandler に P2000→400 VALIDATION_ERROR を追加**: customer/applicant 等の同種の列長超過も横断的に 500→400 へ救済。`meta.column_name` があれば日本語ラベルでフィールド明示、DB内部情報は #217 の方針どおり非公開

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/validations/plotValidation.test.ts tests/middleware/errorHandler.test.ts` **103/103 pass**（回帰テスト7本追加）
- `npm test -- tests/plots/` **215/215 pass**（familyContacts 経路の既存テストに影響なし）

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)