### PR TITLE
fix(dates): 日付UTC正規化の横展開漏れ2件を修正（nextBillingDate月境界ずれ + 元号判定のローカルTZ依存）

### DIFF
--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -357,8 +357,10 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
         if (match && match[1] && match[2]) {
           const year = parseInt(match[1]);
           const month = parseInt(match[2]);
-          const nextDate = new Date(year, month, 1); // 次の月の1日
-          nextBillingDate = nextDate;
+          // 次の月の1日。ローカルTZ の new Date(year, month, 1) だと toISOString で
+          // 前月末日の UTC datetime に化け、非JST環境やソート集計で月境界がずれる
+          // ため UTC で構築する（#277、#214 の UTC 正規化と同方針）
+          nextBillingDate = new Date(Date.UTC(year, month, 1));
         }
       }
 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -50,31 +50,38 @@ export function addYearsUtc(date: Date, years: number): Date {
   return new Date(Date.UTC(date.getUTCFullYear() + years, date.getUTCMonth(), date.getUTCDate()));
 }
 
-// 元号の開始日（ローカル暦日比較用）
-const REIWA_START = new Date(2019, 4, 1); // 2019-05-01
-const HEISEI_START = new Date(1989, 0, 8); // 1989-01-08
-const SHOWA_START = new Date(1926, 11, 25); // 1926-12-25
+// 元号の開始日（UTC 暦日比較用 #277）。
+// @db.Date 列は UTC 00:00 の Date として読まれるため、ローカルTZ 構築の境界定数
+// （new Date(2019, 4, 1)）＋ローカル getter だと非JST環境で境界日に前日扱いとなり
+// 令和/平成を誤判定する。境界・年月日の取得を UTC に統一する。
+const REIWA_START_UTC = Date.UTC(2019, 4, 1); // 2019-05-01
+const HEISEI_START_UTC = Date.UTC(1989, 0, 8); // 1989-01-08
+const SHOWA_START_UTC = Date.UTC(1926, 11, 25); // 1926-12-25
 
 /**
- * 日付から元号と元号年を判定する（#215）。
- * 年単位でなく境界日で判定する（frontend formatDateWithEra と同一基準）。
+ * 日付から元号と元号年を判定する（#215/#277）。
+ * 年単位でなく境界日（UTC 暦日）で判定する。
+ * ※frontend formatDateWithEra は令和/平成のみで昭和分岐を持たないため、
+ *   backend で和暦を画面/書類へ出す際は表記の統一に注意（#277 で確認済み）。
  * 元号適用外（昭和より前）は null を返す。
  */
 function resolveJapaneseEra(date: Date): { era: string; eraYear: number } | null {
-  if (date >= REIWA_START) return { era: '令和', eraYear: date.getFullYear() - 2018 };
-  if (date >= HEISEI_START) return { era: '平成', eraYear: date.getFullYear() - 1988 };
-  if (date >= SHOWA_START) return { era: '昭和', eraYear: date.getFullYear() - 1925 };
+  const t = date.getTime();
+  if (t >= REIWA_START_UTC) return { era: '令和', eraYear: date.getUTCFullYear() - 2018 };
+  if (t >= HEISEI_START_UTC) return { era: '平成', eraYear: date.getUTCFullYear() - 1988 };
+  if (t >= SHOWA_START_UTC) return { era: '昭和', eraYear: date.getUTCFullYear() - 1925 };
   return null;
 }
 
 /**
  * 和暦変換（境界日判定: 令和=2019-05-01〜 / 平成=1989-01-08〜 / 昭和=1926-12-25〜）
+ * 入力は @db.Date 由来の UTC 00:00 Date を想定し、UTC 暦日で整形する（#277）。
  */
 export function toJapaneseDate(date: Date | null | undefined): string | null {
   if (!date) return null;
 
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  const month = date.getUTCMonth() + 1;
+  const day = date.getUTCDate();
   const era = resolveJapaneseEra(date);
 
   if (era) {
@@ -83,23 +90,24 @@ export function toJapaneseDate(date: Date | null | undefined): string | null {
   }
 
   // 元号適用外は西暦で返す
-  return `${date.getFullYear()}年${month}月${day}日`;
+  return `${date.getUTCFullYear()}年${month}月${day}日`;
 }
 
 /**
  * 和暦（年月のみ）
+ * 入力は @db.Date 由来の UTC 00:00 Date を想定し、UTC 暦日で整形する（#277）。
  */
 export function toJapaneseYearMonth(date: Date | null | undefined): string | null {
   if (!date) return null;
 
-  const month = date.getMonth() + 1;
+  const month = date.getUTCMonth() + 1;
   const era = resolveJapaneseEra(date);
 
   if (era) {
     return `${era.era}${era.eraYear}年${month}月`;
   }
 
-  return `${date.getFullYear()}年${month}月`;
+  return `${date.getUTCFullYear()}年${month}月`;
 }
 
 /**

--- a/tests/utils/dateUtils.test.ts
+++ b/tests/utils/dateUtils.test.ts
@@ -45,47 +45,58 @@ describe('dateUtils', () => {
     });
   });
 
-  describe('toJapaneseDate (#215 元号境界)', () => {
+  // #277: 入力は @db.Date 由来の UTC 00:00 Date を想定するため、テストも UTC で構築する
+  const utcDate = (y: number, m: number, d: number): Date => new Date(Date.UTC(y, m, d));
+
+  describe('toJapaneseDate (#215 元号境界 / #277 UTC基準)', () => {
     it('2019年1〜4月は平成31年（令和ではない）', () => {
-      expect(toJapaneseDate(new Date(2019, 2, 1))).toBe('平成31年3月1日');
-      expect(toJapaneseDate(new Date(2019, 3, 30))).toBe('平成31年4月30日');
+      expect(toJapaneseDate(utcDate(2019, 2, 1))).toBe('平成31年3月1日');
+      expect(toJapaneseDate(utcDate(2019, 3, 30))).toBe('平成31年4月30日');
     });
 
     it('令和は2019年5月1日から', () => {
-      expect(toJapaneseDate(new Date(2019, 4, 1))).toBe('令和元年5月1日');
-      expect(toJapaneseDate(new Date(2026, 5, 5))).toBe('令和8年6月5日');
+      expect(toJapaneseDate(utcDate(2019, 4, 1))).toBe('令和元年5月1日');
+      expect(toJapaneseDate(utcDate(2026, 5, 5))).toBe('令和8年6月5日');
     });
 
     it('1989年1月初週は昭和64年（平成ではない）', () => {
-      expect(toJapaneseDate(new Date(1989, 0, 7))).toBe('昭和64年1月7日');
+      expect(toJapaneseDate(utcDate(1989, 0, 7))).toBe('昭和64年1月7日');
     });
 
     it('平成は1989年1月8日から', () => {
-      expect(toJapaneseDate(new Date(1989, 0, 8))).toBe('平成元年1月8日');
+      expect(toJapaneseDate(utcDate(1989, 0, 8))).toBe('平成元年1月8日');
     });
 
     it('昭和は1926年12月25日から', () => {
-      expect(toJapaneseDate(new Date(1926, 11, 25))).toBe('昭和元年12月25日');
-      expect(toJapaneseDate(new Date(1926, 11, 24))).toBe('1926年12月24日'); // 大正は西暦表記
+      expect(toJapaneseDate(utcDate(1926, 11, 25))).toBe('昭和元年12月25日');
+      expect(toJapaneseDate(utcDate(1926, 11, 24))).toBe('1926年12月24日'); // 大正は西暦表記
     });
 
     it('null/undefined は null を返す', () => {
       expect(toJapaneseDate(null)).toBeNull();
       expect(toJapaneseDate(undefined)).toBeNull();
     });
+
+    it('@db.Date 由来の UTC 00:00 datetime でも元号境界日が前日にずれない (#277)', () => {
+      // 修正前: ローカルTZ境界 + getFullYear のため、非JST環境（負オフセットTZ）で
+      // 2019-05-01T00:00:00Z が 2019-04-30 ローカル扱いになり平成と誤判定していた
+      expect(toJapaneseDate(new Date('2019-05-01T00:00:00.000Z'))).toBe('令和元年5月1日');
+      expect(toJapaneseDate(new Date('1989-01-08T00:00:00.000Z'))).toBe('平成元年1月8日');
+      expect(toJapaneseDate(new Date('1926-12-25T00:00:00.000Z'))).toBe('昭和元年12月25日');
+    });
   });
 
-  describe('toJapaneseYearMonth (#215 元号境界)', () => {
+  describe('toJapaneseYearMonth (#215 元号境界 / #277 UTC基準)', () => {
     it('2019年4月は平成31年4月', () => {
-      expect(toJapaneseYearMonth(new Date(2019, 3, 15))).toBe('平成31年4月');
+      expect(toJapaneseYearMonth(utcDate(2019, 3, 15))).toBe('平成31年4月');
     });
 
     it('2019年5月は令和元年5月', () => {
-      expect(toJapaneseYearMonth(new Date(2019, 4, 15))).toBe('令和1年5月');
+      expect(toJapaneseYearMonth(utcDate(2019, 4, 15))).toBe('令和1年5月');
     });
 
     it('昭和の年月も変換できる（従来は分岐が欠落していた）', () => {
-      expect(toJapaneseYearMonth(new Date(1980, 5, 15))).toBe('昭和55年6月');
+      expect(toJapaneseYearMonth(utcDate(1980, 5, 15))).toBe('昭和55年6月');
     });
   });
 


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #277 (low×2束ね) の修正。横断パターン「#214 UTC正規化の横展開漏れ」の backend 側残件。

| 箇所 | 問題 | 修正 |
|---|---|---|
| `getPlots` nextBillingDate | ローカルTZ の `new Date(year, month, 1)` → toISOString で**前月末日の UTC datetime** に化ける（JST本番では潜伏、非JST環境・ソート集計で月ずれ） | `Date.UTC` で構築 |
| `toJapaneseDate` 等の元号判定 | 境界定数がローカルTZ 構築＋ローカル getter のため、@db.Date（UTC 00:00）入力で非JST環境の**元号境界日に令和/平成を誤判定** | 境界を `Date.UTC` 定数、取得を `getUTC*` に統一 |

元号判定は現状 src から未呼び出し（テスト専用）の潜伏バグだが、利用開始前に基準を正し、「frontend formatDateWithEra と同一基準」コメントも実態（frontendは昭和分岐なし）に合わせて修正。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/utils/dateUtils.test.ts tests/plots/plotController.test.ts` **65/65 pass**（テストを @db.Date 実形状（UTC 00:00）構築に更新 + UTC datetime 入力で境界日がずれない回帰テスト追加）

関連: frontend #250（同パターンの frontend 側 = formatDate の date-only 判定が実APIの datetime 形状で発火しない問題）は別PRで対応予定。

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)