### PR TITLE
fix(billings): 請求ステータスの手動変更を written_off/overdue（と解除）に限定し無言破棄を解消

### DIFF
--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -314,6 +314,23 @@ export const updateBilling = async (
     const existing = await prisma.billing.findFirst({ where: { id, deleted_at: null } });
     if (!existing) throw new NotFoundError('請求が見つかりません');
 
+    // status の手動変更は written_off / overdue（とその解除）に限定する（#271）。
+    // それ以外の値は更新直後に入金実績からの自動算出（computeBillingStatus）で
+    // 上書きされ「UIで選べるのに保存されない」無言破棄になっていたため、
+    // 受理できない変更は明示的に 400 で返す。
+    // ※同値送信（フォーム全体送信で現在値をそのまま送るケース）は変更なしとして許容。
+    const MANUAL_STATUSES: string[] = ['written_off', 'overdue'];
+    if (input.status !== undefined && input.status !== existing.status) {
+      const manualTarget = MANUAL_STATUSES.includes(input.status);
+      const manualRelease = MANUAL_STATUSES.includes(existing.status);
+      if (!manualTarget && !manualRelease) {
+        throw new ValidationError(
+          'ステータスは入金実績から自動算出されるため手動変更できません。' +
+            '手動で設定できるのは「貸倒（written_off）」「延滞（overdue）」とその解除のみです'
+        );
+      }
+    }
+
     const data: Prisma.BillingUpdateInput = {};
     if (input.category !== undefined) data.category = input.category;
     if (input.amount !== undefined) data.amount = input.amount;

--- a/tests/billings/billingController.test.ts
+++ b/tests/billings/billingController.test.ts
@@ -423,6 +423,103 @@ describe('billingController', () => {
 
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'NotFoundError' }));
     });
+
+    it('自動算出対象ステータスへの手動変更は 400 で明示的に拒否される (#271)', async () => {
+      // 修正前: status: 'paid' を受理して update 直後に computeBillingStatus が
+      // 'billed' へ静かに戻す無言破棄だった
+      mockPrisma.billing.findFirst.mockResolvedValueOnce({
+        id: VALID_UUID,
+        contract_plot_id: PLOT_UUID,
+        amount: 15000,
+        terminated: false,
+        status: 'billed',
+        billing_date: new Date('2026-03-01'),
+      });
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { status: 'paid' },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'ValidationError' }));
+      const err = (next as jest.Mock).mock.calls[0][0];
+      expect(err.message).toContain('自動算出');
+      expect(mockPrisma.billing.update).not.toHaveBeenCalled();
+    });
+
+    it('written_off への手動変更は受理され再集計も呼ばれる (#271)', async () => {
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({
+          id: VALID_UUID,
+          contract_plot_id: PLOT_UUID,
+          amount: 15000,
+          terminated: false,
+          status: 'billed',
+          billing_date: new Date('2026-03-01'),
+        })
+        .mockResolvedValueOnce(buildBillingRow({ status: 'written_off' }));
+      mockPrisma.billing.update.mockResolvedValue(buildBillingRow({ status: 'written_off' }));
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { status: 'written_off' },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const updateCall = mockPrisma.billing.update.mock.calls[0][0];
+      expect(updateCall.data).toEqual({ status: 'written_off' });
+      expect(recalculateBillingPaymentsMock).toHaveBeenCalled();
+    });
+
+    it('written_off の解除（任意ステータスへの変更）は受理され自動算出に戻る (#271)', async () => {
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({
+          id: VALID_UUID,
+          contract_plot_id: PLOT_UUID,
+          amount: 15000,
+          terminated: false,
+          status: 'written_off',
+          billing_date: new Date('2026-03-01'),
+        })
+        .mockResolvedValueOnce(buildBillingRow({ status: 'billed' }));
+      mockPrisma.billing.update.mockResolvedValue(buildBillingRow({ status: 'pending' }));
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { status: 'pending' },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      // 解除後は再集計（computeBillingStatus）が実態のステータスを導出する
+      expect(recalculateBillingPaymentsMock).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('status の同値送信（フォーム全体送信）は変更なしとして許容される (#271)', async () => {
+      mockPrisma.billing.findFirst
+        .mockResolvedValueOnce({
+          id: VALID_UUID,
+          contract_plot_id: PLOT_UUID,
+          amount: 15000,
+          terminated: false,
+          status: 'billed',
+          billing_date: new Date('2026-03-01'),
+        })
+        .mockResolvedValueOnce(buildBillingRow({ status: 'billed' }));
+      mockPrisma.billing.update.mockResolvedValue(buildBillingRow({ status: 'billed' }));
+
+      const req = buildRequest({
+        params: { id: VALID_UUID },
+        body: { status: 'billed', notes: '備考も更新' },
+      });
+      await updateBilling(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(next).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteBilling', () => {


### PR DESCRIPTION
## 概要
2026-06-06 バグ監査の指摘 #271 (medium) の修正。

UI は全ステータスを選べるドロップダウンを出し backend も受理するが、更新直後の再集計（`computeBillingStatus` #211）が自動算出値で上書きするため、**手動選択が静かに破棄**されていた（例: 運用者が「paid」を選んでも入金0なら billed に戻る）。

## 修正（自動算出を正とし、受理範囲を明示）
status の**変更**リクエストは以下のみ受理、それ以外は **400** で理由を明示:

| ケース | 挙動 |
|---|---|
| → written_off / overdue | 受理（自動算出ソースが無い業務判断ステータス） |
| written_off / overdue → 任意 | 受理＝**解除**（解除後は再集計が実態を導出） |
| 同値送信（フォーム全体送信） | 変更なしとして許容 → **現行フロントは無変更で動作** |
| その他（pending/billed/partial_paid/paid 等への変更） | 400「ステータスは入金実績から自動算出されるため手動変更できません…」 |

フロント側のドロップダウン選択肢を手動可能値に絞る改善は frontend 側で別途対応可能（任意）。

## 検証
- `npx tsc --noEmit` clean
- `npm test -- tests/billings/` **34/34 pass**（回帰テスト4本追加: paid変更400 / written_off受理 / 解除受理 / 同値許容）

備考: PR #284（#264 移行paid_amount保全）と同関数を変更するが挿入位置が異なるため通常マージで両立する想定。

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)