### PR TITLE
fix: check-then-act の非トランザクション境界を Serializable tx で原子化

### DIFF
--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from 'express';
+import { Prisma } from '@prisma/client';
 import prisma from '../db/prisma';
+import { ConflictError, NotFoundError } from '../middleware/errorHandler';
 import { getRequestLogger } from '../utils/logger';
 import {
   createMasterSchema,
@@ -509,22 +511,27 @@ export const getPositionMaster = async (req: Request, res: Response) => {
 };
 
 /**
+ * マスタ CRUD で使う DB クライアント。トランザクション内では tx を渡す（#278）。
+ */
+type MasterDbClient = typeof prisma | Prisma.TransactionClient;
+
+/**
  * マスタタイプからPrismaモデルデリゲートを取得
  */
-const getMasterDelegate = (masterType: MasterType): MasterDelegate => {
+const getMasterDelegate = (masterType: MasterType, db: MasterDbClient = prisma): MasterDelegate => {
   const delegateMap: Record<MasterType, unknown> = {
-    'cemetery-type': prisma.cemeteryTypeMaster,
-    'payment-method': prisma.paymentMethodMaster,
-    'tax-type': prisma.taxTypeMaster,
-    'calc-type': prisma.calcTypeMaster,
-    'billing-type': prisma.billingTypeMaster,
-    'recipient-type': prisma.recipientTypeMaster,
-    'construction-type': prisma.constructionTypeMaster,
-    'section-name': prisma.sectionNameMaster,
-    relationship: prisma.relationshipMaster,
-    contractor: prisma.contractorMaster,
-    direction: prisma.directionMaster,
-    position: prisma.positionMaster,
+    'cemetery-type': db.cemeteryTypeMaster,
+    'payment-method': db.paymentMethodMaster,
+    'tax-type': db.taxTypeMaster,
+    'calc-type': db.calcTypeMaster,
+    'billing-type': db.billingTypeMaster,
+    'recipient-type': db.recipientTypeMaster,
+    'construction-type': db.constructionTypeMaster,
+    'section-name': db.sectionNameMaster,
+    relationship: db.relationshipMaster,
+    contractor: db.contractorMaster,
+    direction: db.directionMaster,
+    position: db.positionMaster,
   };
   return delegateMap[masterType] as MasterDelegate;
 };
@@ -569,42 +576,46 @@ const MASTER_CODE_MAX_LENGTH: Record<MasterType, number> = {
  * 参照側が孤児コード化して「旧コード: X」表示に化けるのを事前に防ぐ。
  * 参照箇所が特定できないマスタタイプは 0 を返す（従来動作を維持）。
  */
-const countMasterCodeUsage = async (masterType: MasterType, code: string): Promise<number> => {
+const countMasterCodeUsage = async (
+  masterType: MasterType,
+  code: string,
+  db: MasterDbClient = prisma
+): Promise<number> => {
   switch (masterType) {
     case 'tax-type': {
       const [usage, management] = await Promise.all([
-        prisma.usageFee.count({ where: { tax_type: code, deleted_at: null } }),
-        prisma.managementFee.count({ where: { tax_type: code, deleted_at: null } }),
+        db.usageFee.count({ where: { tax_type: code, deleted_at: null } }),
+        db.managementFee.count({ where: { tax_type: code, deleted_at: null } }),
       ]);
       return usage + management;
     }
     case 'calc-type': {
       const [usage, management] = await Promise.all([
-        prisma.usageFee.count({ where: { calculation_type: code, deleted_at: null } }),
-        prisma.managementFee.count({ where: { calculation_type: code, deleted_at: null } }),
+        db.usageFee.count({ where: { calculation_type: code, deleted_at: null } }),
+        db.managementFee.count({ where: { calculation_type: code, deleted_at: null } }),
       ]);
       return usage + management;
     }
     case 'billing-type': {
       const [usage, management] = await Promise.all([
-        prisma.usageFee.count({ where: { billing_type: code, deleted_at: null } }),
-        prisma.managementFee.count({ where: { billing_type: code, deleted_at: null } }),
+        db.usageFee.count({ where: { billing_type: code, deleted_at: null } }),
+        db.managementFee.count({ where: { billing_type: code, deleted_at: null } }),
       ]);
       return usage + management;
     }
     case 'payment-method': {
       const [usage, management] = await Promise.all([
-        prisma.usageFee.count({ where: { payment_method: code, deleted_at: null } }),
-        prisma.managementFee.count({ where: { payment_method: code, deleted_at: null } }),
+        db.usageFee.count({ where: { payment_method: code, deleted_at: null } }),
+        db.managementFee.count({ where: { payment_method: code, deleted_at: null } }),
       ]);
       return usage + management;
     }
     case 'construction-type':
-      return prisma.constructionInfo.count({
+      return db.constructionInfo.count({
         where: { construction_type: code, deleted_at: null },
       });
     case 'contractor':
-      return prisma.constructionInfo.count({ where: { contractor: code, deleted_at: null } });
+      return db.constructionInfo.count({ where: { contractor: code, deleted_at: null } });
     // direction/position は GravestoneInfo が int を保持し、名称解決は Number(code) と
     // 突合する（seed / フロント resolveMasterName と整合）。PK id は API 追加・再seed・
     // 移行 backfill で code とドリフトしうるため、id でなく code 基準で数える（#268）。
@@ -612,12 +623,12 @@ const countMasterCodeUsage = async (masterType: MasterType, code: string): Promi
     case 'direction': {
       const codeNum = Number(code);
       if (!Number.isInteger(codeNum)) return 0;
-      return prisma.gravestoneInfo.count({ where: { direction_id: codeNum, deleted_at: null } });
+      return db.gravestoneInfo.count({ where: { direction_id: codeNum, deleted_at: null } });
     }
     case 'position': {
       const codeNum = Number(code);
       if (!Number.isInteger(codeNum)) return 0;
-      return prisma.gravestoneInfo.count({ where: { position_id: codeNum, deleted_at: null } });
+      return db.gravestoneInfo.count({ where: { position_id: codeNum, deleted_at: null } });
     }
     default:
       return 0;
@@ -798,28 +809,7 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
   }
 
   try {
-    const delegate = getMasterDelegate(masterType);
     const { taxRate, sortOrder, isActive, period, ...rest } = parsed.data;
-
-    // 使用中マスタの code 改名は既存参照（String カラム）を孤児化するため拒否する（#231）
-    if (rest.code !== undefined) {
-      const existing = await delegate.findUnique({ where: { id: masterId } });
-      if (existing && existing.code !== rest.code) {
-        const usageCount = await countMasterCodeUsage(masterType, existing.code);
-        if (usageCount > 0) {
-          const label = masterTypeLabels[masterType];
-          res.status(409).json({
-            success: false,
-            error: {
-              code: 'CONFLICT',
-              message: `${label}マスタのコード「${existing.code}」は${usageCount}件のデータで使用中のため変更できません`,
-              details: [],
-            },
-          });
-          return;
-        }
-      }
-    }
 
     const updateData: Record<string, unknown> = { ...rest };
     if (sortOrder !== undefined) updateData['sort_order'] = sortOrder;
@@ -831,10 +821,34 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
       updateData['period'] = period;
     }
 
-    const updated = await delegate.update({
-      where: { id: masterId },
-      data: updateData,
-    });
+    // 使用中チェックと更新を単一 Serializable tx で原子化する（#278）。
+    // check と act が別 tx だと、count=0 確認〜update の間に同 code を参照する
+    // 契約が並行コミットされて孤児コード化する（#231 事象の同時実行版）。
+    const updated = await prisma.$transaction(
+      async (tx) => {
+        const delegate = getMasterDelegate(masterType, tx);
+
+        // 使用中マスタの code 改名は既存参照（String カラム）を孤児化するため拒否する（#231）
+        if (rest.code !== undefined) {
+          const existing = await delegate.findUnique({ where: { id: masterId } });
+          if (existing && existing.code !== rest.code) {
+            const usageCount = await countMasterCodeUsage(masterType, existing.code, tx);
+            if (usageCount > 0) {
+              const label = masterTypeLabels[masterType];
+              throw new ConflictError(
+                `${label}マスタのコード「${existing.code}」は${usageCount}件のデータで使用中のため変更できません`
+              );
+            }
+          }
+        }
+
+        return delegate.update({
+          where: { id: masterId },
+          data: updateData,
+        });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     const label = masterTypeLabels[masterType];
     const formatted: Record<string, unknown> = {
@@ -859,6 +873,32 @@ export const updateMaster = async (req: Request, res: Response): Promise<void> =
     });
   } catch (error: unknown) {
     const label = masterTypeLabels[masterType];
+
+    // tx 内の使用中チェックで拒否されたケース（#231 / #278）
+    if (error instanceof ConflictError) {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'CONFLICT',
+          message: error.message,
+          details: [],
+        },
+      });
+      return;
+    }
+
+    // Serializable トランザクションの直列化競合。リトライで成功するため 409（#278）
+    if (getErrorCode(error) === 'P2034') {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'CONFLICT',
+          message: '同時更新が競合しました。もう一度お試しください',
+          details: [],
+        },
+      });
+      return;
+    }
 
     if (getErrorCode(error) === 'P2025') {
       res.status(404).json({
@@ -942,39 +982,34 @@ export const deleteMaster = async (req: Request, res: Response): Promise<void> =
   }
 
   try {
-    const delegate = getMasterDelegate(masterType);
     const label = masterTypeLabels[masterType];
 
     // 使用中チェック（#231）: マスタ参照は FK でなく String カラムのため、
     // 物理削除すると参照側が孤児コード化し「旧コード: X」表示に化ける。
     // 使用中の場合は削除を拒否し、論理無効化（isActive=false）を案内する。
-    const existing = await delegate.findUnique({ where: { id: masterId } });
-    if (!existing) {
-      res.status(404).json({
-        success: false,
-        error: {
-          code: 'NOT_FOUND',
-          message: `${label}マスタが見つかりません (ID: ${id})`,
-          details: [],
-        },
-      });
-      return;
-    }
+    // チェックと削除は単一 Serializable tx で原子化する（#278）: 別 tx だと
+    // count=0 確認〜delete の間に同 code を参照する契約が並行コミットされて
+    // 孤児コード化する。
+    await prisma.$transaction(
+      async (tx) => {
+        const delegate = getMasterDelegate(masterType, tx);
 
-    const usageCount = await countMasterCodeUsage(masterType, existing.code);
-    if (usageCount > 0) {
-      res.status(409).json({
-        success: false,
-        error: {
-          code: 'CONFLICT',
-          message: `${label}マスタ「${existing.name}」は${usageCount}件のデータで使用中のため削除できません。先に無効化してください`,
-          details: [],
-        },
-      });
-      return;
-    }
+        const existing = await delegate.findUnique({ where: { id: masterId } });
+        if (!existing) {
+          throw new NotFoundError(`${label}マスタが見つかりません (ID: ${id})`);
+        }
 
-    await delegate.delete({ where: { id: masterId } });
+        const usageCount = await countMasterCodeUsage(masterType, existing.code, tx);
+        if (usageCount > 0) {
+          throw new ConflictError(
+            `${label}マスタ「${existing.name}」は${usageCount}件のデータで使用中のため削除できません。先に無効化してください`
+          );
+        }
+
+        await delegate.delete({ where: { id: masterId } });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     res.status(200).json({
       success: true,
@@ -982,6 +1017,45 @@ export const deleteMaster = async (req: Request, res: Response): Promise<void> =
     });
   } catch (error: unknown) {
     const label = masterTypeLabels[masterType];
+
+    // tx 内の存在チェックで弾かれたケース（#278）
+    if (error instanceof NotFoundError) {
+      res.status(404).json({
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: error.message,
+          details: [],
+        },
+      });
+      return;
+    }
+
+    // tx 内の使用中チェックで拒否されたケース（#231 / #278）
+    if (error instanceof ConflictError) {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'CONFLICT',
+          message: error.message,
+          details: [],
+        },
+      });
+      return;
+    }
+
+    // Serializable トランザクションの直列化競合。リトライで成功するため 409（#278）
+    if (getErrorCode(error) === 'P2034') {
+      res.status(409).json({
+        success: false,
+        error: {
+          code: 'CONFLICT',
+          message: '同時更新が競合しました。もう一度お試しください',
+          details: [],
+        },
+      });
+      return;
+    }
 
     if (getErrorCode(error) === 'P2025') {
       res.status(404).json({

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -375,6 +375,20 @@ const handlePrismaError = (error: Prisma.PrismaClientKnownRequestError, res: Res
         },
       });
 
+    case 'P2034':
+      // Serializable トランザクションの直列化競合（write conflict / deadlock）。
+      // check-then-act を原子化した在庫検証・契約解約復活等（#278）で並行更新が
+      // 衝突した場合に発生する。データは壊れておらずリトライで成功するため、
+      // 500 でなく 409 として再試行を案内する。
+      return res.status(409).json({
+        success: false,
+        error: {
+          code: 'CONFLICT',
+          message: '同時更新が競合しました。もう一度お試しください',
+          details: [],
+        },
+      });
+
     default:
       return res.status(500).json({
         success: false,

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -476,9 +476,13 @@ export const createPlot = async (
   try {
     const input = req.body as CreatePlotRequest;
 
-    const result = await prisma.$transaction(async (tx) => {
-      return createPlotCore(tx, input, req);
-    });
+    const result = await prisma.$transaction(
+      async (tx) => {
+        return createPlotCore(tx, input, req);
+      },
+      // 在庫面積の検証・作成・status再計算を並行更新と直列化する（#278）
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     // 作成完了後、詳細情報を取得して返却
     const createdContractPlot = await prisma.contractPlot.findUnique({

--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -10,6 +10,7 @@ import { Prisma, PaymentStatus, ContractRole, ContractStatus } from '@prisma/cli
 import { CreatePlotRequest } from '@komine/types';
 import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
 import prisma from '../../db/prisma';
+import { ValidationError } from '../../middleware/errorHandler';
 import { getRequestLogger } from '../../utils/logger';
 
 /**
@@ -36,179 +37,181 @@ export const createPlotContract = async (req: Request, res: Response): Promise<R
       });
     }
 
-    // 契約面積の検証
-    const validationResult = await validateContractArea(
-      prisma,
-      physicalPlotId,
-      input.contractPlot.contractAreaSqm
-    );
-
-    if (!validationResult.isValid) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          code: 'VALIDATION_ERROR',
-          message: validationResult.message || '契約面積の検証に失敗しました',
-        },
-      });
-    }
-
     // トランザクション内で契約作成
-    const result = await prisma.$transaction(async (tx) => {
-      // Customer作成
-      const customer = await tx.customer.create({
-        data: {
-          name: input.customer.name,
-          name_kana: input.customer.nameKana,
-          birth_date: input.customer.birthDate ? new Date(input.customer.birthDate) : null,
-          gender: input.customer.gender || null,
-          postal_code: input.customer.postalCode,
-          address: input.customer.address,
-          registered_address: input.customer.registeredAddress || null,
-          phone_number: input.customer.phoneNumber,
-          fax_number: input.customer.faxNumber || null,
-          email: input.customer.email || null,
-          notes: input.customer.notes || null,
-        },
-      });
+    const result = await prisma.$transaction(
+      async (tx) => {
+        // 契約面積の検証（#278）: tx 外で検証すると検証〜作成の間に並行リクエストが
+        // 同じ空き面積を見て両方通過し過剰割当が成立するため、tx 内で検証する。
+        // Serializable 分離レベルにより同一物理区画への並行契約追加は直列化される。
+        const validationResult = await validateContractArea(
+          tx,
+          physicalPlotId,
+          input.contractPlot.contractAreaSqm
+        );
 
-      // WorkInfo作成（オプション）
-      if (input.workInfo) {
-        await tx.workInfo.create({
+        if (!validationResult.isValid) {
+          throw new ValidationError(validationResult.message || '契約面積の検証に失敗しました');
+        }
+
+        // Customer作成
+        const customer = await tx.customer.create({
           data: {
-            customer_id: customer.id,
-            company_name: input.workInfo.companyName || '',
-            company_name_kana: input.workInfo.companyNameKana || '',
-            work_postal_code: input.workInfo.workPostalCode || '',
-            work_address: input.workInfo.workAddress || '',
-            work_phone_number: input.workInfo.workPhoneNumber || '',
-            dm_setting: input.workInfo.dmSetting || 'allow',
-            address_type: input.workInfo.addressType || 'work',
-            notes: input.workInfo.notes || null,
+            name: input.customer.name,
+            name_kana: input.customer.nameKana,
+            birth_date: input.customer.birthDate ? new Date(input.customer.birthDate) : null,
+            gender: input.customer.gender || null,
+            postal_code: input.customer.postalCode,
+            address: input.customer.address,
+            registered_address: input.customer.registeredAddress || null,
+            phone_number: input.customer.phoneNumber,
+            fax_number: input.customer.faxNumber || null,
+            email: input.customer.email || null,
+            notes: input.customer.notes || null,
           },
         });
-      }
 
-      // ContractPlot作成（販売契約情報を統合）
-      const contractPlot = await tx.contractPlot.create({
-        data: {
-          physical_plot_id: physicalPlotId,
-          // 分割販売の新規契約も実契約のため active（schema default の vacant ではない）。#165 / #167 参照。
-          contract_status: ContractStatus.active,
-          contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
-          location_description: input.contractPlot.locationDescription || null,
-          // 販売契約情報（ContractPlotに統合済み）
-          contract_date: input.saleContract.contractDate
-            ? new Date(input.saleContract.contractDate)
-            : null,
-          price: input.saleContract.price ?? null,
-          payment_status: input.saleContract.paymentStatus || PaymentStatus.unpaid,
-          reservation_date: input.saleContract.reservationDate
-            ? new Date(input.saleContract.reservationDate)
-            : null,
-          request_date: input.saleContract.requestDate
-            ? new Date(input.saleContract.requestDate)
-            : null,
-          acceptance_number: input.saleContract.acceptanceNumber || null,
-          permit_number: input.saleContract.permitNumber || null,
-          permit_date: input.saleContract.permitDate
-            ? new Date(input.saleContract.permitDate)
-            : null,
-          start_date: input.saleContract.startDate ? new Date(input.saleContract.startDate) : null,
-          // 未収金額は請求実績から導出する派生値（#170）。新規区画は請求未生成のため 0。手入力は無視。
-          uncollected_amount: 0,
-          notes: input.saleContract.notes || null,
-          grave_kind: input.saleContract.graveKind ?? null,
-          grave_kubun: input.saleContract.graveKubun ?? null,
-          grave_type: input.saleContract.graveType ?? null,
-          legacy_grave_cd: input.saleContract.legacyGraveCd ?? null,
-        },
-      });
+        // WorkInfo作成（オプション）
+        if (input.workInfo) {
+          await tx.workInfo.create({
+            data: {
+              customer_id: customer.id,
+              company_name: input.workInfo.companyName || '',
+              company_name_kana: input.workInfo.companyNameKana || '',
+              work_postal_code: input.workInfo.workPostalCode || '',
+              work_address: input.workInfo.workAddress || '',
+              work_phone_number: input.workInfo.workPhoneNumber || '',
+              dm_setting: input.workInfo.dmSetting || 'allow',
+              address_type: input.workInfo.addressType || 'work',
+              notes: input.workInfo.notes || null,
+            },
+          });
+        }
 
-      // 契約における顧客役割の作成
-      // 新方式: roles配列が指定されている場合
-      if (input.saleContract.roles && input.saleContract.roles.length > 0) {
-        for (const roleData of input.saleContract.roles) {
+        // ContractPlot作成（販売契約情報を統合）
+        const contractPlot = await tx.contractPlot.create({
+          data: {
+            physical_plot_id: physicalPlotId,
+            // 分割販売の新規契約も実契約のため active（schema default の vacant ではない）。#165 / #167 参照。
+            contract_status: ContractStatus.active,
+            contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
+            location_description: input.contractPlot.locationDescription || null,
+            // 販売契約情報（ContractPlotに統合済み）
+            contract_date: input.saleContract.contractDate
+              ? new Date(input.saleContract.contractDate)
+              : null,
+            price: input.saleContract.price ?? null,
+            payment_status: input.saleContract.paymentStatus || PaymentStatus.unpaid,
+            reservation_date: input.saleContract.reservationDate
+              ? new Date(input.saleContract.reservationDate)
+              : null,
+            request_date: input.saleContract.requestDate
+              ? new Date(input.saleContract.requestDate)
+              : null,
+            acceptance_number: input.saleContract.acceptanceNumber || null,
+            permit_number: input.saleContract.permitNumber || null,
+            permit_date: input.saleContract.permitDate
+              ? new Date(input.saleContract.permitDate)
+              : null,
+            start_date: input.saleContract.startDate
+              ? new Date(input.saleContract.startDate)
+              : null,
+            // 未収金額は請求実績から導出する派生値（#170）。新規区画は請求未生成のため 0。手入力は無視。
+            uncollected_amount: 0,
+            notes: input.saleContract.notes || null,
+            grave_kind: input.saleContract.graveKind ?? null,
+            grave_kubun: input.saleContract.graveKubun ?? null,
+            grave_type: input.saleContract.graveType ?? null,
+            legacy_grave_cd: input.saleContract.legacyGraveCd ?? null,
+          },
+        });
+
+        // 契約における顧客役割の作成
+        // 新方式: roles配列が指定されている場合
+        if (input.saleContract.roles && input.saleContract.roles.length > 0) {
+          for (const roleData of input.saleContract.roles) {
+            await tx.saleContractRole.create({
+              data: {
+                contract_plot_id: contractPlot.id, // sale_contract_id → contract_plot_idに変更
+                customer_id: roleData.customerId || customer.id, // 指定がなければ作成した顧客を使用
+                role: roleData.role,
+                role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
+                role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
+                notes: roleData.notes || null,
+              },
+            });
+          }
+        } else {
+          // 旧方式（後方互換性）: customerとcustomerRoleから1つの役割を作成
           await tx.saleContractRole.create({
             data: {
               contract_plot_id: contractPlot.id, // sale_contract_id → contract_plot_idに変更
-              customer_id: roleData.customerId || customer.id, // 指定がなければ作成した顧客を使用
-              role: roleData.role,
-              role_start_date: roleData.roleStartDate ? new Date(roleData.roleStartDate) : null,
-              role_end_date: roleData.roleEndDate ? new Date(roleData.roleEndDate) : null,
-              notes: roleData.notes || null,
+              customer_id: customer.id,
+              role: (input.saleContract.customerRole as ContractRole) || ContractRole.contractor,
             },
           });
         }
-      } else {
-        // 旧方式（後方互換性）: customerとcustomerRoleから1つの役割を作成
-        await tx.saleContractRole.create({
-          data: {
-            contract_plot_id: contractPlot.id, // sale_contract_id → contract_plot_idに変更
-            customer_id: customer.id,
-            role: (input.saleContract.customerRole as ContractRole) || ContractRole.contractor,
-          },
-        });
-      }
 
-      // 墓石情報作成（オプション・issue #154）
-      if (input.gravestoneInfo) {
-        const gravestoneData = buildGravestoneInfoData(input.gravestoneInfo);
-        if (Object.keys(gravestoneData).length > 0) {
-          await tx.gravestoneInfo.create({
+        // 墓石情報作成（オプション・issue #154）
+        if (input.gravestoneInfo) {
+          const gravestoneData = buildGravestoneInfoData(input.gravestoneInfo);
+          if (Object.keys(gravestoneData).length > 0) {
+            await tx.gravestoneInfo.create({
+              data: {
+                contract_plot_id: contractPlot.id,
+                ...gravestoneData,
+              },
+            });
+          }
+        }
+
+        // UsageFee作成（オプション）
+        if (input.usageFee) {
+          await tx.usageFee.create({
             data: {
               contract_plot_id: contractPlot.id,
-              ...gravestoneData,
+              calculation_type: input.usageFee.calculationType || null,
+              tax_type: input.usageFee.taxType || null,
+              billing_type: input.usageFee.billingType || '',
+              billing_years: input.usageFee.billingYears || '1',
+              area: input.usageFee.area ? input.usageFee.area.toString() : null,
+              unit_price: input.usageFee.unitPrice ? input.usageFee.unitPrice.toString() : null,
+              usage_fee: input.usageFee.usageFee ? input.usageFee.usageFee.toString() : null,
+              payment_method: input.usageFee.paymentMethod || null,
             },
           });
         }
-      }
 
-      // UsageFee作成（オプション）
-      if (input.usageFee) {
-        await tx.usageFee.create({
-          data: {
-            contract_plot_id: contractPlot.id,
-            calculation_type: input.usageFee.calculationType || null,
-            tax_type: input.usageFee.taxType || null,
-            billing_type: input.usageFee.billingType || '',
-            billing_years: input.usageFee.billingYears || '1',
-            area: input.usageFee.area ? input.usageFee.area.toString() : null,
-            unit_price: input.usageFee.unitPrice ? input.usageFee.unitPrice.toString() : null,
-            usage_fee: input.usageFee.usageFee ? input.usageFee.usageFee.toString() : null,
-            payment_method: input.usageFee.paymentMethod || null,
-          },
-        });
-      }
+        // ManagementFee作成（オプション）
+        if (input.managementFee) {
+          await tx.managementFee.create({
+            data: {
+              contract_plot_id: contractPlot.id,
+              calculation_type: input.managementFee.calculationType || null,
+              tax_type: input.managementFee.taxType || null,
+              billing_type: input.managementFee.billingType || 'yearly',
+              billing_years: input.managementFee.billingYears || '1',
+              area: input.managementFee.area ? input.managementFee.area.toString() : null,
+              billing_month: input.managementFee.billingMonth || null,
+              management_fee: input.managementFee.managementFee
+                ? input.managementFee.managementFee.toString()
+                : null,
+              unit_price: input.managementFee.unitPrice
+                ? input.managementFee.unitPrice.toString()
+                : null,
+              last_billing_month: input.managementFee.lastBillingMonth || null,
+              payment_method: input.managementFee.paymentMethod || null,
+            },
+          });
+        }
 
-      // ManagementFee作成（オプション）
-      if (input.managementFee) {
-        await tx.managementFee.create({
-          data: {
-            contract_plot_id: contractPlot.id,
-            calculation_type: input.managementFee.calculationType || null,
-            tax_type: input.managementFee.taxType || null,
-            billing_type: input.managementFee.billingType || 'yearly',
-            billing_years: input.managementFee.billingYears || '1',
-            area: input.managementFee.area ? input.managementFee.area.toString() : null,
-            billing_month: input.managementFee.billingMonth || null,
-            management_fee: input.managementFee.managementFee
-              ? input.managementFee.managementFee.toString()
-              : null,
-            unit_price: input.managementFee.unitPrice
-              ? input.managementFee.unitPrice.toString()
-              : null,
-            last_billing_month: input.managementFee.lastBillingMonth || null,
-            payment_method: input.managementFee.paymentMethod || null,
-          },
-        });
-      }
+        // PhysicalPlotのステータス更新
+        await updatePhysicalPlotStatus(tx, physicalPlotId);
 
-      // PhysicalPlotのステータス更新
-      await updatePhysicalPlotStatus(tx, physicalPlotId);
-
-      return { contractPlot, customer };
-    });
+        return { contractPlot, customer };
+      },
+      // 在庫の検証・作成・status再計算を並行更新と直列化する（#278）
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     // 作成完了後、詳細情報を取得して返却
     const createdContractPlot = await prisma.contractPlot.findUnique({
@@ -295,6 +298,18 @@ export const createPlotContract = async (req: Request, res: Response): Promise<R
     });
   } catch (error) {
     getRequestLogger().error({ err: error }, 'Error creating plot contract');
+
+    // Serializable トランザクションの直列化競合（#278）。リトライで成功するため
+    // 内部メッセージを晒す 400 でなく再試行を案内する 409 を返す。
+    if ((error as { code?: string } | null)?.code === 'P2034') {
+      return res.status(409).json({
+        success: false,
+        error: {
+          code: 'CONFLICT',
+          message: '同時更新が競合しました。もう一度お試しください',
+        },
+      });
+    }
 
     if (error instanceof Error && error.message) {
       return res.status(400).json({

--- a/src/plots/controllers/deletePlot.ts
+++ b/src/plots/controllers/deletePlot.ts
@@ -9,6 +9,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
 import { updatePhysicalPlotStatus } from '../utils';
 import prisma from '../../db/prisma';
 import { NotFoundError } from '../../middleware/errorHandler';
@@ -54,123 +55,127 @@ export const deletePlot = async (
     const physicalPlotId = contractPlot.physical_plot_id;
 
     // トランザクション内で論理削除
-    await prisma.$transaction(async (tx) => {
-      // 1. ContractPlotを論理削除
-      await tx.contractPlot.update({
-        where: { id },
-        data: { deleted_at: now },
-      });
-      await recordEntityDeleted(tx, {
-        entityType: 'ContractPlot',
-        entityId: id,
-        physicalPlotId,
-        contractPlotId: id,
-        beforeRecord: {
-          id: contractPlot.id,
-          contract_area_sqm: contractPlot.contract_area_sqm.toString(),
-          contract_date: contractPlot.contract_date?.toISOString(),
-          price: contractPlot.price,
-          payment_status: contractPlot.payment_status,
-        },
-        req,
-      });
-
-      // 2. UsageFeeを論理削除
-      if (contractPlot.usageFee) {
-        await tx.usageFee.update({
-          where: { id: contractPlot.usageFee.id },
+    await prisma.$transaction(
+      async (tx) => {
+        // 1. ContractPlotを論理削除
+        await tx.contractPlot.update({
+          where: { id },
           data: { deleted_at: now },
         });
         await recordEntityDeleted(tx, {
-          entityType: 'UsageFee',
-          entityId: contractPlot.usageFee.id,
+          entityType: 'ContractPlot',
+          entityId: id,
           physicalPlotId,
           contractPlotId: id,
           beforeRecord: {
-            id: contractPlot.usageFee.id,
-            usage_fee: contractPlot.usageFee.usage_fee,
+            id: contractPlot.id,
+            contract_area_sqm: contractPlot.contract_area_sqm.toString(),
+            contract_date: contractPlot.contract_date?.toISOString(),
+            price: contractPlot.price,
+            payment_status: contractPlot.payment_status,
           },
           req,
         });
-      }
 
-      // 3. ManagementFeeを論理削除
-      if (contractPlot.managementFee) {
-        await tx.managementFee.update({
-          where: { id: contractPlot.managementFee.id },
-          data: { deleted_at: now },
-        });
-        await recordEntityDeleted(tx, {
-          entityType: 'ManagementFee',
-          entityId: contractPlot.managementFee.id,
-          physicalPlotId,
-          contractPlotId: id,
-          beforeRecord: {
-            id: contractPlot.managementFee.id,
-            management_fee: contractPlot.managementFee.management_fee,
-          },
-          req,
-        });
-      }
-
-      // 4-6. 各顧客のWorkInfo、Customerを論理削除
-      // 注: saleContractRolesを通じて顧客にアクセス
-      if (contractPlot.saleContractRoles) {
-        for (const role of contractPlot.saleContractRoles) {
-          const customer = role.customer;
-
-          // WorkInfoを論理削除（存在する場合）
-          if (customer.workInfo) {
-            await tx.workInfo.update({
-              where: { id: customer.workInfo.id },
-              data: { deleted_at: now },
-            });
-            await recordEntityDeleted(tx, {
-              entityType: 'WorkInfo',
-              entityId: customer.workInfo.id,
-              physicalPlotId,
-              contractPlotId: id,
-              beforeRecord: {
-                id: customer.workInfo.id,
-                company_name: customer.workInfo.company_name,
-              },
-              req,
-            });
-          }
-
-          // この顧客を参照している他の契約を検索
-          const otherRoles = await tx.saleContractRole.findMany({
-            where: {
-              customer_id: customer.id,
-              contract_plot_id: { not: id },
-              deleted_at: null,
-            },
+        // 2. UsageFeeを論理削除
+        if (contractPlot.usageFee) {
+          await tx.usageFee.update({
+            where: { id: contractPlot.usageFee.id },
+            data: { deleted_at: now },
           });
+          await recordEntityDeleted(tx, {
+            entityType: 'UsageFee',
+            entityId: contractPlot.usageFee.id,
+            physicalPlotId,
+            contractPlotId: id,
+            beforeRecord: {
+              id: contractPlot.usageFee.id,
+              usage_fee: contractPlot.usageFee.usage_fee,
+            },
+            req,
+          });
+        }
 
-          // 他の契約がない場合のみCustomerを論理削除
-          if (otherRoles.length === 0) {
-            await tx.customer.update({
-              where: { id: customer.id },
-              data: { deleted_at: now },
-            });
-            await recordEntityDeleted(tx, {
-              entityType: 'Customer',
-              entityId: customer.id,
-              physicalPlotId,
-              contractPlotId: id,
-              beforeRecord: {
-                id: customer.id,
-                name: customer.name,
+        // 3. ManagementFeeを論理削除
+        if (contractPlot.managementFee) {
+          await tx.managementFee.update({
+            where: { id: contractPlot.managementFee.id },
+            data: { deleted_at: now },
+          });
+          await recordEntityDeleted(tx, {
+            entityType: 'ManagementFee',
+            entityId: contractPlot.managementFee.id,
+            physicalPlotId,
+            contractPlotId: id,
+            beforeRecord: {
+              id: contractPlot.managementFee.id,
+              management_fee: contractPlot.managementFee.management_fee,
+            },
+            req,
+          });
+        }
+
+        // 4-6. 各顧客のWorkInfo、Customerを論理削除
+        // 注: saleContractRolesを通じて顧客にアクセス
+        if (contractPlot.saleContractRoles) {
+          for (const role of contractPlot.saleContractRoles) {
+            const customer = role.customer;
+
+            // WorkInfoを論理削除（存在する場合）
+            if (customer.workInfo) {
+              await tx.workInfo.update({
+                where: { id: customer.workInfo.id },
+                data: { deleted_at: now },
+              });
+              await recordEntityDeleted(tx, {
+                entityType: 'WorkInfo',
+                entityId: customer.workInfo.id,
+                physicalPlotId,
+                contractPlotId: id,
+                beforeRecord: {
+                  id: customer.workInfo.id,
+                  company_name: customer.workInfo.company_name,
+                },
+                req,
+              });
+            }
+
+            // この顧客を参照している他の契約を検索
+            const otherRoles = await tx.saleContractRole.findMany({
+              where: {
+                customer_id: customer.id,
+                contract_plot_id: { not: id },
+                deleted_at: null,
               },
-              req,
             });
+
+            // 他の契約がない場合のみCustomerを論理削除
+            if (otherRoles.length === 0) {
+              await tx.customer.update({
+                where: { id: customer.id },
+                data: { deleted_at: now },
+              });
+              await recordEntityDeleted(tx, {
+                entityType: 'Customer',
+                entityId: customer.id,
+                physicalPlotId,
+                contractPlotId: id,
+                beforeRecord: {
+                  id: customer.id,
+                  name: customer.name,
+                },
+                req,
+              });
+            }
           }
         }
-      }
 
-      // 7. PhysicalPlotのステータスを更新
-      await updatePhysicalPlotStatus(tx, physicalPlotId);
-    });
+        // 7. PhysicalPlotのステータスを更新
+        await updatePhysicalPlotStatus(tx, physicalPlotId);
+      },
+      // 在庫面積・status再計算を含むため並行更新と直列化する（#278）
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     res.status(200).json({
       success: true,

--- a/src/plots/controllers/restoreContract.ts
+++ b/src/plots/controllers/restoreContract.ts
@@ -7,7 +7,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { ContractStatus } from '@prisma/client';
+import { ContractStatus, Prisma } from '@prisma/client';
 import prisma from '../../db/prisma';
 import { NotFoundError, ConflictError } from '../../middleware/errorHandler';
 import { recordEntityUpdated } from '../services/historyService';
@@ -24,66 +24,75 @@ export const restoreContract = async (
     const id = (req.params as Record<string, string>)['id'] as string;
     const { reason } = req.body as RestoreContractRequest;
 
-    const contractPlot = await prisma.contractPlot.findUnique({
-      where: { id, deleted_at: null },
-    });
+    // 現在ステータスの読取り・検証・更新を単一の Serializable トランザクションで
+    // 原子化する（#278）。tx 外で読んだ状態を前提に更新すると、復活の2連打や
+    // 並行する解約・契約追加と交錯して二重遷移・過剰割当が成立しうる。
+    await prisma.$transaction(
+      async (tx) => {
+        const contractPlot = await tx.contractPlot.findUnique({
+          where: { id, deleted_at: null },
+        });
 
-    if (!contractPlot) {
-      throw new NotFoundError('指定された契約区画が見つかりません');
-    }
+        if (!contractPlot) {
+          throw new NotFoundError('指定された契約区画が見つかりません');
+        }
 
-    const beforeStatus = contractPlot.contract_status;
+        const beforeStatus = contractPlot.contract_status;
 
-    // 復活エンドポイントは terminated 状態のみ受け付ける（vacant→active 等は通常 PUT を使う）
-    if (beforeStatus !== ContractStatus.terminated) {
-      throw new ConflictError(
-        `現在のステータス '${beforeStatus}' から復活はできません（terminated のみ復活可能）`
-      );
-    }
+        // 復活エンドポイントは terminated 状態のみ受け付ける（vacant→active 等は通常 PUT を使う）
+        if (beforeStatus !== ContractStatus.terminated) {
+          throw new ConflictError(
+            `現在のステータス '${beforeStatus}' から復活はできません（terminated のみ復活可能）`
+          );
+        }
 
-    // 復活遷移＋reason 必須の整合性を保証
-    contractStatusService.validateTransitionWithReason(beforeStatus, ContractStatus.active, reason);
-
-    await prisma.$transaction(async (tx) => {
-      // 復活面積が物理区画の空きに収まるか検証する（#270）。
-      // 解約で空いた面積に別契約が販売されている場合（A解約→B販売→A復活）、
-      // 無検証で active に戻すと物理面積を超える過剰割当が成立してしまう。
-      // 自分自身は terminated のため集計外だが、明示的に除外して将来の状態変更に備える。
-      const areaValidation = await validateContractArea(
-        tx,
-        contractPlot.physical_plot_id,
-        Number(contractPlot.contract_area_sqm),
-        id
-      );
-      if (!areaValidation.isValid) {
-        throw new ConflictError(
-          `契約面積が物理区画の空き面積を超えるため復活できません: ${areaValidation.message ?? ''}` +
-            `（復活には他契約の解約または面積の調整が必要です）`
+        // 復活遷移＋reason 必須の整合性を保証
+        contractStatusService.validateTransitionWithReason(
+          beforeStatus,
+          ContractStatus.active,
+          reason
         );
-      }
+        // 復活面積が物理区画の空きに収まるか検証する（#270）。
+        // 解約で空いた面積に別契約が販売されている場合（A解約→B販売→A復活）、
+        // 無検証で active に戻すと物理面積を超える過剰割当が成立してしまう。
+        // 自分自身は terminated のため集計外だが、明示的に除外して将来の状態変更に備える。
+        const areaValidation = await validateContractArea(
+          tx,
+          contractPlot.physical_plot_id,
+          Number(contractPlot.contract_area_sqm),
+          id
+        );
+        if (!areaValidation.isValid) {
+          throw new ConflictError(
+            `契約面積が物理区画の空き面積を超えるため復活できません: ${areaValidation.message ?? ''}` +
+              `（復活には他契約の解約または面積の調整が必要です）`
+          );
+        }
 
-      await tx.contractPlot.update({
-        where: { id },
-        data: { contract_status: ContractStatus.active },
-      });
+        await tx.contractPlot.update({
+          where: { id },
+          data: { contract_status: ContractStatus.active },
+        });
 
-      // 物理区画ステータスを再計算する（#210）。
-      // 解約時に available 等へ戻った PhysicalPlot.status を据え置くと、
-      // 在庫サマリー（plot.status 基準で集計）に復活分が反映されず過大表示になる。
-      // create/update/delete 系コントローラと同様に復活でも再計算する。
-      await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id);
+        // 物理区画ステータスを再計算する（#210）。
+        // 解約時に available 等へ戻った PhysicalPlot.status を据え置くと、
+        // 在庫サマリー（plot.status 基準で集計）に復活分が反映されず過大表示になる。
+        // create/update/delete 系コントローラと同様に復活でも再計算する。
+        await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id);
 
-      await recordEntityUpdated(tx, {
-        entityType: 'ContractPlot',
-        entityId: id,
-        physicalPlotId: contractPlot.physical_plot_id,
-        contractPlotId: id,
-        beforeRecord: { contract_status: beforeStatus },
-        afterRecord: { contract_status: ContractStatus.active },
-        changeReason: reason,
-        req,
-      });
-    });
+        await recordEntityUpdated(tx, {
+          entityType: 'ContractPlot',
+          entityId: id,
+          physicalPlotId: contractPlot.physical_plot_id,
+          contractPlotId: id,
+          beforeRecord: { contract_status: beforeStatus },
+          afterRecord: { contract_status: ContractStatus.active },
+          changeReason: reason,
+          req,
+        });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     res.status(200).json({
       success: true,

--- a/src/plots/controllers/terminateContract.ts
+++ b/src/plots/controllers/terminateContract.ts
@@ -9,7 +9,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { ContractStatus } from '@prisma/client';
+import { ContractStatus, Prisma } from '@prisma/client';
 import prisma from '../../db/prisma';
 import { NotFoundError, ConflictError } from '../../middleware/errorHandler';
 import { recordEntityUpdated } from '../services/historyService';
@@ -26,46 +26,52 @@ export const terminateContract = async (
     const id = (req.params as Record<string, string>)['id'] as string;
     const { reason } = req.body as TerminateContractRequest;
 
-    const contractPlot = await prisma.contractPlot.findUnique({
-      where: { id, deleted_at: null },
-    });
+    // 現在ステータスの読取り・検証・更新を単一の Serializable トランザクションで
+    // 原子化する（#278）。tx 外で読んだ状態を前提に更新すると、解約の2連打や
+    // 並行する復活・契約追加と交錯して二重遷移・status 不整合が成立しうる。
+    await prisma.$transaction(
+      async (tx) => {
+        const contractPlot = await tx.contractPlot.findUnique({
+          where: { id, deleted_at: null },
+        });
 
-    if (!contractPlot) {
-      throw new NotFoundError('指定された契約区画が見つかりません');
-    }
+        if (!contractPlot) {
+          throw new NotFoundError('指定された契約区画が見つかりません');
+        }
 
-    const beforeStatus = contractPlot.contract_status;
+        const beforeStatus = contractPlot.contract_status;
 
-    // 解約エンドポイントは active 状態のみ受け付ける
-    if (beforeStatus !== ContractStatus.active) {
-      throw new ConflictError(
-        `現在のステータス '${beforeStatus}' から解約はできません（active のみ解約可能）`
-      );
-    }
+        // 解約エンドポイントは active 状態のみ受け付ける
+        if (beforeStatus !== ContractStatus.active) {
+          throw new ConflictError(
+            `現在のステータス '${beforeStatus}' から解約はできません（active のみ解約可能）`
+          );
+        }
 
-    // サービス層の遷移定義（active → terminated）と整合させる
-    contractStatusService.validateTransition(beforeStatus, ContractStatus.terminated);
+        // サービス層の遷移定義（active → terminated）と整合させる
+        contractStatusService.validateTransition(beforeStatus, ContractStatus.terminated);
 
-    await prisma.$transaction(async (tx) => {
-      await tx.contractPlot.update({
-        where: { id },
-        data: { contract_status: ContractStatus.terminated },
-      });
+        await tx.contractPlot.update({
+          where: { id },
+          data: { contract_status: ContractStatus.terminated },
+        });
 
-      // active 契約が外れるため物理区画ステータスを再計算する（restore #210 と対称）
-      await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id);
+        // active 契約が外れるため物理区画ステータスを再計算する（restore #210 と対称）
+        await updatePhysicalPlotStatus(tx, contractPlot.physical_plot_id);
 
-      await recordEntityUpdated(tx, {
-        entityType: 'ContractPlot',
-        entityId: id,
-        physicalPlotId: contractPlot.physical_plot_id,
-        contractPlotId: id,
-        beforeRecord: { contract_status: beforeStatus },
-        afterRecord: { contract_status: ContractStatus.terminated },
-        changeReason: reason,
-        req,
-      });
-    });
+        await recordEntityUpdated(tx, {
+          entityType: 'ContractPlot',
+          entityId: id,
+          physicalPlotId: contractPlot.physical_plot_id,
+          contractPlotId: id,
+          beforeRecord: { contract_status: beforeStatus },
+          afterRecord: { contract_status: ContractStatus.terminated },
+          changeReason: reason,
+          req,
+        });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     res.status(200).json({
       success: true,

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -1507,6 +1507,8 @@ export const updatePlot = async (
       },
       {
         timeout: 10000,
+        // 在庫面積・status再計算を含むため並行更新と直列化する（#278）
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
       }
     );
 

--- a/tests/masters/masterCrud.test.ts
+++ b/tests/masters/masterCrud.test.ts
@@ -16,6 +16,8 @@ declare global {
 }
 
 const mockPrisma: any = {
+  // 使用中チェック＋更新/削除の Serializable tx 化（#278）: tx クライアントとして自身を渡す
+  $transaction: jest.fn((callback: any) => Promise.resolve(callback(mockPrisma))),
   // 使用中チェック（#231）が参照する集計用デリゲート
   usageFee: { count: jest.fn().mockResolvedValue(0) },
   managementFee: { count: jest.fn().mockResolvedValue(0) },
@@ -102,6 +104,10 @@ const mockPrisma: any = {
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
+  // Serializable tx 化（#278）で参照される分離レベル定数
+  Prisma: {
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
+  },
 }));
 
 import { createMaster, updateMaster, deleteMaster } from '../../src/masters/masterController';
@@ -433,7 +439,31 @@ describe('Master CRUD Controller', () => {
         where: { id: 1 },
         data: { name: '公営（更新）' },
       });
+      // 使用中チェックと更新は単一 Serializable tx で原子化される（#278）
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'Serializable',
+      });
       expect(mockResponse.status).toHaveBeenCalledWith(200);
+    });
+
+    it('直列化競合（P2034）は 409 CONFLICT を返すこと (#278)', async () => {
+      mockRequest.params = { masterType: 'cemetery-type', id: '1' };
+      mockRequest.body = { name: '公営（更新）' };
+
+      mockPrisma.$transaction.mockRejectedValueOnce({ code: 'P2034' });
+
+      await updateMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(409);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({
+            code: 'CONFLICT',
+            message: expect.stringContaining('同時更新が競合しました'),
+          }),
+        })
+      );
     });
 
     it('使用中マスタの code 変更は 409 で拒否されること (#231)', async () => {
@@ -588,6 +618,11 @@ describe('Master CRUD Controller', () => {
         })
       );
       expect(mockPrisma.taxTypeMaster.delete).not.toHaveBeenCalled();
+
+      // 使用中チェックと削除は単一 Serializable tx で原子化される（#278）
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'Serializable',
+      });
 
       // 後続テストのためにリセット
       mockPrisma.usageFee.count.mockResolvedValue(0);

--- a/tests/middleware/errorHandler.test.ts
+++ b/tests/middleware/errorHandler.test.ts
@@ -333,6 +333,28 @@ describe('Error Handler Middleware', () => {
         });
       });
 
+      it('P2034（直列化競合）を 409 CONFLICT として処理すること（#278）', () => {
+        const error = new Prisma.PrismaClientKnownRequestError(
+          'Transaction failed due to a write conflict or a deadlock',
+          {
+            code: 'P2034',
+            clientVersion: '5.0.0',
+          }
+        );
+
+        errorHandler(error, mockRequest as Request, mockResponse as Response, mockNext);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(409);
+        expect(mockResponse.json).toHaveBeenCalledWith({
+          success: false,
+          error: {
+            code: 'CONFLICT',
+            message: '同時更新が競合しました。もう一度お試しください',
+            details: [],
+          },
+        });
+      });
+
       it('その他のPrismaエラーを正しく処理すること', () => {
         const error = new Prisma.PrismaClientKnownRequestError('Unknown error', {
           code: 'P9999',

--- a/tests/plots/controllers/restoreContract.test.ts
+++ b/tests/plots/controllers/restoreContract.test.ts
@@ -33,6 +33,10 @@ const mockPrisma: any = {
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
+  // Serializable tx 化（#278）で参照される分離レベル定数
+  Prisma: {
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
+  },
   ContractStatus: {
     vacant: 'vacant',
     active: 'active',
@@ -133,6 +137,11 @@ describe('restoreContract', () => {
         afterRecord: { contract_status: 'active' },
         changeReason: '誤って解約したため復活',
       });
+      // 読取り・検証・更新は単一 Serializable tx で原子化される（#278）
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'Serializable',
+      });
+
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
         success: true,

--- a/tests/plots/controllers/terminateContract.test.ts
+++ b/tests/plots/controllers/terminateContract.test.ts
@@ -33,6 +33,10 @@ const mockPrisma: any = {
 
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
+  // Serializable tx 化（#278）で参照される分離レベル定数
+  Prisma: {
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
+  },
   ContractStatus: {
     vacant: 'vacant',
     active: 'active',
@@ -121,6 +125,11 @@ describe('terminateContract (#236)', () => {
 
       // 物理区画ステータスの再計算（restore #210 と対称）
       expect(mockUpdatePhysicalPlotStatus).toHaveBeenCalledWith(mockPrisma, 'pp-1');
+
+      // 読取り・検証・更新は単一 Serializable tx で原子化される（#278）
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'Serializable',
+      });
 
       // 履歴記録
       expect(mockRecordEntityUpdated).toHaveBeenCalledTimes(1);

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -90,6 +90,8 @@ const mockPrisma: any = {
 jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
   Prisma: {
+    // Serializable tx 化（#278）で参照される分離レベル定数
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
     Decimal: class MockDecimal {
       constructor(private value: number) {}
       toNumber() {
@@ -2042,6 +2044,51 @@ describe('Plot Controller (ContractPlot Model)', () => {
       await createPlotContract(mockRequest as Request, mockResponse as Response);
 
       expect(responseStatus).toHaveBeenCalledWith(400);
+    });
+
+    it('面積検証は Serializable トランザクション内で行われること（#278）', async () => {
+      (validateContractArea as jest.Mock).mockResolvedValue({
+        isValid: false,
+        message: '契約面積が利用可能面積を超えています',
+      });
+
+      mockPrisma.physicalPlot.findUnique.mockResolvedValue({ id: 'pp1' });
+      mockRequest.params = { id: 'pp1' };
+      mockRequest.body = {
+        contractPlot: { contractAreaSqm: 10.0 },
+        saleContract: {},
+        customer: {},
+      };
+
+      await createPlotContract(mockRequest as Request, mockResponse as Response);
+
+      // 検証〜作成の check-then-act を tx 内へ移したことを固定する
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'Serializable',
+      });
+      // tx クライアント（モックでは mockPrisma 自身）で検証している
+      expect(validateContractArea).toHaveBeenCalledWith(mockPrisma, 'pp1', 10.0);
+    });
+
+    it('直列化競合（P2034）は 409 CONFLICT を返すこと（#278）', async () => {
+      mockPrisma.physicalPlot.findUnique.mockResolvedValue({ id: 'pp1' });
+      mockPrisma.$transaction.mockRejectedValueOnce({ code: 'P2034' });
+      mockRequest.params = { id: 'pp1' };
+      mockRequest.body = {
+        contractPlot: { contractAreaSqm: 3.6 },
+        saleContract: {},
+        customer: {},
+      };
+
+      await createPlotContract(mockRequest as Request, mockResponse as Response);
+
+      expect(responseStatus).toHaveBeenCalledWith(409);
+      expect(responseJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ code: 'CONFLICT' }),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## 概要

バグ監査（2026-06-06）で指摘された **check-then-act の非トランザクション境界の系統的欠落** を修正する。count/findUnique による検証と後続 update が別トランザクション・行ロック無しのため、2人のオペレーターが同時操作すると過剰割当・status 不整合・孤児コード化が成立しうる問題。

Closes #278

## 修正内容

| 箇所 | 問題 | 修正 |
|------|------|------|
| `createPlotContract` | 面積検証が tx 外 → 並行リクエストが同じ空きを見て両方通過し過剰割当 | 検証を tx 内へ移動 + Serializable |
| `terminateContract` / `restoreContract` | status を tx 外 read → TOCTOU 二重遷移・status 不整合 | 読取り・検証・更新を単一 Serializable tx に原子化 |
| `masterController` update/delete | 使用中チェック(#231)と act が別 tx → 同時契約登録で孤児コード化 | check+act を単一 Serializable tx 化（delegate/count を tx クライアント対応に） |
| `createPlot` / `updatePlot` / `deletePlot` | 在庫検証・status 再計算 tx が Read Committed | Serializable 付与 |
| `errorHandler` | P2034（直列化競合）が 500 DATABASE_ERROR | 409 CONFLICT「同時更新が競合しました。もう一度お試しください」 |

## 設計メモ

- **SELECT FOR UPDATE でなく Serializable を採用**: staffController の最後の admin 保護（#269）で確立済みのパターンに統一。raw SQL 不要で Prisma モック CI とも整合。
- **plots 系 tx に一括で Serializable を付与した理由**: PostgreSQL の SSI は **Serializable tx 同士でのみ**直列化を保証する。マスタ使用中チェックが usageFee/managementFee 等の並行 INSERT を検知するには、それらを書く全経路（createPlot/updatePlot/deletePlot/createPlotContract）も Serializable である必要がある。
- 競合時は P2034 → 409 でクライアントに再試行を案内（自動リトライは導入せず、低頻度の事務所内同時操作を想定）。
- staffController は #269 で対応済みのため変更なし。

## テスト

- `npm test`: **1112 pass**（新規4件: P2034→409 / Serializable 付与の固定化 / tx 内検証）
- `npm run lint`: clean
- `npm run swagger:validate`: valid
- 既存テストのモックに `Prisma.TransactionIsolationLevel` を追加（terminate/restore/plotController/masterCrud）

🤖 Generated with [Claude Code](https://claude.com/claude-code)