### PR TITLE
fix: 契約者名ソートをスナップショット列による DB 側ページングに置換

### DIFF
--- a/prisma/migrations/20260606120000_add_primary_contractor_name_kana/migration.sql
+++ b/prisma/migrations/20260606120000_add_primary_contractor_name_kana/migration.sql
@@ -1,0 +1,25 @@
+-- 主契約者カナのスナップショット列を追加（#282）
+-- 契約者名ソート（sortBy=customerName）が全件ロード＋アプリ側ソートだったのを
+-- DB 側 orderBy + take のページングに置き換えるための非正規化列。
+-- 値は「最初の有効な contractor ロールの customer.name_kana || name」。
+
+-- AlterTable
+ALTER TABLE "contract_plots" ADD COLUMN     "primary_contractor_name_kana" VARCHAR(100);
+
+-- CreateIndex
+CREATE INDEX "contract_plots_primary_contractor_name_kana_idx" ON "contract_plots"("primary_contractor_name_kana");
+
+-- Backfill: 既存契約の主契約者カナを同期
+UPDATE "contract_plots" cp
+SET "primary_contractor_name_kana" = sub.kana
+FROM (
+  SELECT DISTINCT ON (scr."contract_plot_id")
+         scr."contract_plot_id" AS contract_plot_id,
+         COALESCE(NULLIF(c."name_kana", ''), c."name") AS kana
+  FROM "sale_contract_roles" scr
+  JOIN "customers" c ON c."customer_id" = scr."customer_id"
+  WHERE scr."role" = 'contractor'
+    AND scr."deleted_at" IS NULL
+  ORDER BY scr."contract_plot_id", scr."created_at" ASC, scr."sale_contract_role_id" ASC
+) sub
+WHERE cp."contract_plot_id" = sub.contract_plot_id;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,6 +188,12 @@ model ContractPlot {
   // 移行用（後で削除可能）
   legacy_grave_cd Int? // レガシー m_bochi.grave_cd 保持
 
+  // 主契約者カナのスナップショット（#282）: 契約者名ソートを DB 側 orderBy + take で
+  // ページングするための非正規化列。値は「最初の有効な contractor ロールの
+  // customer.name_kana || name」。ロール・顧客を書き換える各経路の tx 末尾で
+  // syncPrimaryContractorNameKana により同期する。
+  primary_contractor_name_kana String? @db.VarChar(100)
+
   created_at DateTime  @default(now())
   updated_at DateTime  @updatedAt
   deleted_at DateTime?
@@ -213,6 +219,7 @@ model ContractPlot {
   @@index([payment_status])
   @@index([deleted_at])
   @@index([legacy_grave_cd])
+  @@index([primary_contractor_name_kana])
   @@map("contract_plots")
 }
 

--- a/scripts/legacy-migration/steps/06-sale-contract-role.ts
+++ b/scripts/legacy-migration/steps/06-sale-contract-role.ts
@@ -200,6 +200,28 @@ export const stepSaleContractRole: MigrationStep = {
       applicantInserted++;
     }
 
+    // 主契約者カナのスナップショット一括同期（#282）。
+    // contractor ロール作成後に primary_contractor_name_kana を backfill する。
+    // 個別 create では同期されないため、ステップ末尾に SQL 一括更新で冪等に反映する
+    // （migration 20260606120000 の backfill と同一クエリ）。
+    if (!dryRun) {
+      const synced = await prisma.$executeRaw`
+        UPDATE "contract_plots" cp
+        SET "primary_contractor_name_kana" = sub.kana
+        FROM (
+          SELECT DISTINCT ON (scr."contract_plot_id")
+                 scr."contract_plot_id" AS contract_plot_id,
+                 COALESCE(NULLIF(c."name_kana", ''), c."name") AS kana
+          FROM "sale_contract_roles" scr
+          JOIN "customers" c ON c."customer_id" = scr."customer_id"
+          WHERE scr."role" = 'contractor'
+            AND scr."deleted_at" IS NULL
+          ORDER BY scr."contract_plot_id", scr."created_at" ASC, scr."sale_contract_role_id" ASC
+        ) sub
+        WHERE cp."contract_plot_id" = sub.contract_plot_id`;
+      logger.info({ synced }, 'primary_contractor_name_kana backfilled (#282)');
+    }
+
     return {
       inserted: contractorInserted + applicantInserted,
       skipped,

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -16,7 +16,12 @@ import {
   AddressType,
 } from '@prisma/client';
 import { CreatePlotRequest } from '@komine/types';
-import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
+import {
+  validateContractArea,
+  updatePhysicalPlotStatus,
+  buildGravestoneInfoData,
+  syncPrimaryContractorNameKana,
+} from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
 import {
@@ -356,6 +361,9 @@ export async function createPlotCore(
 
   // 10. 物理区画のステータス更新
   await updatePhysicalPlotStatus(tx, physicalPlot.id);
+
+  // 10.5. 主契約者カナのスナップショット同期（#282、契約者名ソートの DB 側ページング用）
+  await syncPrimaryContractorNameKana(tx, contractPlot.id);
 
   // 11. 履歴の自動記録
   if (!input.physicalPlot.id) {

--- a/src/plots/controllers/createPlotContract.ts
+++ b/src/plots/controllers/createPlotContract.ts
@@ -8,7 +8,12 @@
 import { Request, Response } from 'express';
 import { Prisma, PaymentStatus, ContractRole, ContractStatus } from '@prisma/client';
 import { CreatePlotRequest } from '@komine/types';
-import { validateContractArea, updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
+import {
+  validateContractArea,
+  updatePhysicalPlotStatus,
+  buildGravestoneInfoData,
+  syncPrimaryContractorNameKana,
+} from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError } from '../../middleware/errorHandler';
 import { getRequestLogger } from '../../utils/logger';
@@ -206,6 +211,9 @@ export const createPlotContract = async (req: Request, res: Response): Promise<R
 
         // PhysicalPlotのステータス更新
         await updatePhysicalPlotStatus(tx, physicalPlotId);
+
+        // 主契約者カナのスナップショット同期（#282、契約者名ソートの DB 側ページング用）
+        await syncPrimaryContractorNameKana(tx, contractPlot.id);
 
         return { contractPlot, customer };
       },

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -290,51 +290,32 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
     let contractPlots: Prisma.ContractPlotGetPayload<{ include: typeof listInclude }>[];
 
     if (sortBy === 'customerName') {
-      // 契約者名ソート（#216）
-      // 主契約者(role=contractor)は to-many リレーションのため Prisma の orderBy では
-      // 直接ソートできない。該当全件の id + 契約者カナのみ取得してアプリ側で
-      // 五十音ソート → ページ分の id だけ詳細取得する2段階方式で、
-      // ページ跨ぎでも正しい氏名順を実現する。
-      const sortRows = await prisma.contractPlot.findMany({
-        where: whereCondition,
-        select: {
-          id: true,
-          saleContractRoles: {
-            where: { deleted_at: null, role: 'contractor' },
-            select: {
-              customer: { select: { name_kana: true, name: true } },
+      // 契約者名ソート（#216 → #282）
+      // 旧実装は whereCondition 一致の全件 id + 契約者カナをロードしアプリ側で
+      // 五十音ソートしており、数千区画ではページ送りの度にデータセット全体を
+      // メモリ展開していた。ロール・顧客の書込み経路で同期するスナップショット列
+      // primary_contractor_name_kana への orderBy + skip/take で DB 側ページングに置換。
+      // 契約者なし（null）は昇順・降順問わず末尾固定（旧実装と同挙動）。
+      // ※並び順は Intl.Collator('ja') から DB 照合順（カナはコードポイント順 ≒ 五十音順）に変わる。
+      [total, contractPlots] = await Promise.all([
+        prisma.contractPlot.count({ where: whereCondition }),
+        prisma.contractPlot.findMany({
+          where: whereCondition,
+          skip,
+          take,
+          orderBy: [
+            {
+              primary_contractor_name_kana: {
+                sort: sortOrder === 'desc' ? 'desc' : 'asc',
+                nulls: 'last',
+              },
             },
-            take: 1,
-          },
-        },
-      });
-
-      const collator = new Intl.Collator('ja');
-      const keyed = sortRows.map((row) => {
-        const customer = row.saleContractRoles[0]?.customer;
-        return { id: row.id, key: customer?.name_kana || customer?.name || null };
-      });
-      keyed.sort((a, b) => {
-        // 契約者なし（空き区画等）は昇順・降順問わず末尾固定
-        if (a.key === null && b.key === null) return 0;
-        if (a.key === null) return 1;
-        if (b.key === null) return -1;
-        const cmp = collator.compare(a.key, b.key);
-        return sortOrder === 'desc' ? -cmp : cmp;
-      });
-
-      total = keyed.length;
-      const pageIds = keyed.slice(skip, skip + take).map((k) => k.id);
-
-      const rows = await prisma.contractPlot.findMany({
-        where: { id: { in: pageIds } },
-        include: listInclude,
-      });
-      // findMany は順序を保証しないため、ソート済み id 順に並べ直す
-      const rowMap = new Map(rows.map((row) => [row.id, row]));
-      contractPlots = pageIds
-        .map((plotId) => rowMap.get(plotId))
-        .filter((row): row is NonNullable<typeof row> => row !== undefined);
+            // 同カナ・契約者なし同士のページ跨ぎ順序を安定化
+            { id: 'asc' },
+          ],
+          include: listInclude,
+        }),
+      ]);
     } else {
       // 総件数とデータを並列で取得
       [total, contractPlots] = await Promise.all([

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -8,7 +8,11 @@
 import { Request, Response, NextFunction } from 'express';
 import { Prisma, ContractRole } from '@prisma/client';
 import { UpdatePlotRequest } from '@komine/types';
-import { updatePhysicalPlotStatus, buildGravestoneInfoData } from '../utils';
+import {
+  updatePhysicalPlotStatus,
+  buildGravestoneInfoData,
+  syncPrimaryContractorNameKana,
+} from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
 import {
@@ -1484,6 +1488,10 @@ export async function updatePlotCore(
       );
     }
   }
+
+  // 主契約者カナのスナップショット同期（#282）: ロール構成・顧客名の変更を反映する。
+  // 契約者名ソート（sortBy=customerName）の DB 側ページングが参照する。
+  await syncPrimaryContractorNameKana(tx, id);
 }
 
 /**

--- a/src/plots/utils.ts
+++ b/src/plots/utils.ts
@@ -207,6 +207,37 @@ export async function updatePhysicalPlotStatus(
 }
 
 /**
+ * 主契約者カナのスナップショット（primary_contractor_name_kana）を同期する（#282）。
+ *
+ * 契約者名ソートを DB 側 orderBy + take でページングするための非正規化列。
+ * 「最初の有効な contractor ロールの customer.name_kana || name」を書き込む。
+ * ロール・顧客名を書き換える経路（createPlot / createPlotContract / updatePlot）の
+ * トランザクション末尾で呼ぶこと。契約者がいない場合は null（一覧では末尾固定）。
+ *
+ * @param prisma Prismaクライアント（トランザクション対応）
+ * @param contractPlotId 契約区画ID
+ */
+export async function syncPrimaryContractorNameKana(
+  prisma: Prisma.TransactionClient,
+  contractPlotId: string
+): Promise<void> {
+  const role = await prisma.saleContractRole.findFirst({
+    where: { contract_plot_id: contractPlotId, role: 'contractor', deleted_at: null },
+    orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+    select: {
+      customer: { select: { name_kana: true, name: true } },
+    },
+  });
+
+  const kana = role?.customer ? role.customer.name_kana || role.customer.name || null : null;
+
+  await prisma.contractPlot.update({
+    where: { id: contractPlotId },
+    data: { primary_contractor_name_kana: kana },
+  });
+}
+
+/**
  * 物理区画が完全に利用可能か（契約がない状態）
  * @param prisma Prismaクライアント（トランザクション対応）
  * @param physicalPlotId 物理区画ID

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -121,6 +121,7 @@ jest.mock('../../src/plots/utils', () => {
   return {
     validateContractArea: jest.fn(),
     updatePhysicalPlotStatus: jest.fn(),
+    syncPrimaryContractorNameKana: jest.fn(),
     buildGravestoneInfoData: actual.buildGravestoneInfoData,
   };
 });
@@ -267,11 +268,7 @@ describe('Plot Controller (ContractPlot Model)', () => {
       );
     });
 
-    it('should sort by contractor name kana across pages when sortBy=customerName (#216)', async () => {
-      const buildSortRow = (id: string, nameKana: string | null) => ({
-        id,
-        saleContractRoles: nameKana ? [{ customer: { name_kana: nameKana, name: '氏名' } }] : [],
-      });
+    it('should sort by contractor name kana via DB-side paging when sortBy=customerName (#216 → #282)', async () => {
       const buildListRow = (id: string, nameKana: string) => ({
         id,
         physical_plot_id: `pp-${id}`,
@@ -308,20 +305,13 @@ describe('Plot Controller (ContractPlot Model)', () => {
         billings: [],
       });
 
-      // 1回目: ソートキー取得（登録日順とは異なる順序で返す）
-      // 2回目: ページ分の詳細取得（わざと順序をシャッフルして返す）
-      mockPrisma.contractPlot.findMany
-        .mockResolvedValueOnce([
-          buildSortRow('cp1', 'ヤマダ'),
-          buildSortRow('cp2', 'アオキ'),
-          buildSortRow('cp3', null), // 契約者なし → 末尾
-          buildSortRow('cp4', 'サトウ'),
-        ])
-        .mockResolvedValueOnce([
-          buildListRow('cp4', 'サトウ'),
-          buildListRow('cp1', 'ヤマダ'),
-          buildListRow('cp2', 'アオキ'),
-        ]);
+      // DB 側ソート済みのページ分のみ返る（スナップショット列 orderBy + skip/take #282）
+      mockPrisma.contractPlot.findMany.mockResolvedValueOnce([
+        buildListRow('cp2', 'アオキ'),
+        buildListRow('cp4', 'サトウ'),
+        buildListRow('cp1', 'ヤマダ'),
+      ]);
+      mockPrisma.contractPlot.count.mockResolvedValue(4);
 
       mockRequest.query = { page: '1', limit: '3', sortBy: 'customerName', sortOrder: 'asc' };
 
@@ -329,30 +319,37 @@ describe('Plot Controller (ContractPlot Model)', () => {
 
       expect(responseStatus).toHaveBeenCalledWith(200);
       const payload = responseJson.mock.calls[0][0];
-      // 五十音順: アオキ → サトウ → ヤマダ（cp3 は2ページ目=末尾）
       expect(payload.data.data.map((p: { id: string }) => p.id)).toEqual(['cp2', 'cp4', 'cp1']);
-      // total は全件数（ページサイズではない）
+      // total は count から（旧実装は全件ロードから導出していた）
       expect(payload.data.pagination.total).toBe(4);
-      // count は使わない（ソートキー取得結果から導出）
-      expect(mockPrisma.contractPlot.count).not.toHaveBeenCalled();
+
+      // 全件ロード＋アプリ側ソートではなく、スナップショット列への
+      // orderBy + skip/take で DB 側ページングしていることを固定する（#282）
+      expect(mockPrisma.contractPlot.findMany).toHaveBeenCalledTimes(1);
+      const query = mockPrisma.contractPlot.findMany.mock.calls[0][0];
+      // テストはコントローラ直叩きのため limit は query 生文字列のまま渡る
+      expect(Number(query.skip)).toBe(0);
+      expect(Number(query.take)).toBe(3);
+      expect(query.orderBy).toEqual([
+        { primary_contractor_name_kana: { sort: 'asc', nulls: 'last' } },
+        { id: 'asc' },
+      ]);
     });
 
-    it('should place plots without contractor at the end for desc order too (#216)', async () => {
-      mockPrisma.contractPlot.findMany
-        .mockResolvedValueOnce([
-          { id: 'cp1', saleContractRoles: [{ customer: { name_kana: 'アオキ', name: 'a' } }] },
-          { id: 'cp2', saleContractRoles: [] }, // 契約者なし
-          { id: 'cp3', saleContractRoles: [{ customer: { name_kana: 'ヤマダ', name: 'y' } }] },
-        ])
-        .mockResolvedValueOnce([]);
+    it('should keep nulls last for desc order too (#216 → #282)', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
 
       mockRequest.query = { page: '1', limit: '10', sortBy: 'customerName', sortOrder: 'desc' };
 
       await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
 
-      // 2回目の findMany（詳細取得）に渡る id 順: ヤマダ → アオキ → 契約者なし
-      const secondCall = mockPrisma.contractPlot.findMany.mock.calls[1][0];
-      expect(secondCall.where.id.in).toEqual(['cp3', 'cp1', 'cp2']);
+      // 契約者なし（null）は降順でも末尾固定
+      const query = mockPrisma.contractPlot.findMany.mock.calls[0][0];
+      expect(query.orderBy).toEqual([
+        { primary_contractor_name_kana: { sort: 'desc', nulls: 'last' } },
+        { id: 'asc' },
+      ]);
     });
 
     it('should filter by contractStatus when specified (#200)', async () => {

--- a/tests/plots/utils.test.ts
+++ b/tests/plots/utils.test.ts
@@ -1,0 +1,61 @@
+/**
+ * 在庫管理ユーティリティのテスト
+ *
+ * syncPrimaryContractorNameKana（#282）:
+ * 契約者名ソートの DB 側ページングが参照する primary_contractor_name_kana
+ * スナップショット列の同期ロジックを固定する。
+ */
+
+import { syncPrimaryContractorNameKana } from '../../src/plots/utils';
+
+const buildTx = (roleResult: unknown) =>
+  ({
+    saleContractRole: {
+      findFirst: jest.fn().mockResolvedValue(roleResult),
+    },
+    contractPlot: {
+      update: jest.fn().mockResolvedValue({}),
+    },
+  }) as any;
+
+describe('syncPrimaryContractorNameKana (#282)', () => {
+  it('最初の有効な contractor ロールの name_kana を書き込む', async () => {
+    const tx = buildTx({ customer: { name_kana: 'ヤマダタロウ', name: '山田太郎' } });
+
+    await syncPrimaryContractorNameKana(tx, 'cp-1');
+
+    // contractor ロールのみ・削除済み除外・作成順で先頭を選ぶ
+    expect(tx.saleContractRole.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { contract_plot_id: 'cp-1', role: 'contractor', deleted_at: null },
+        orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+      })
+    );
+    expect(tx.contractPlot.update).toHaveBeenCalledWith({
+      where: { id: 'cp-1' },
+      data: { primary_contractor_name_kana: 'ヤマダタロウ' },
+    });
+  });
+
+  it('name_kana が空文字なら name へフォールバックする', async () => {
+    const tx = buildTx({ customer: { name_kana: '', name: '山田太郎' } });
+
+    await syncPrimaryContractorNameKana(tx, 'cp-1');
+
+    expect(tx.contractPlot.update).toHaveBeenCalledWith({
+      where: { id: 'cp-1' },
+      data: { primary_contractor_name_kana: '山田太郎' },
+    });
+  });
+
+  it('contractor ロールが無い場合は null を書き込む（一覧で末尾固定）', async () => {
+    const tx = buildTx(null);
+
+    await syncPrimaryContractorNameKana(tx, 'cp-1');
+
+    expect(tx.contractPlot.update).toHaveBeenCalledWith({
+      where: { id: 'cp-1' },
+      data: { primary_contractor_name_kana: null },
+    });
+  });
+});

--- a/tests/scripts/legacy-migration/steps/idempotency.test.ts
+++ b/tests/scripts/legacy-migration/steps/idempotency.test.ts
@@ -175,6 +175,8 @@ describe('step06 別人申込者パスの冪等性 (#221, #222)', () => {
         findFirst: jest.fn().mockResolvedValue(null),
         create: jest.fn().mockResolvedValue({}),
       },
+      // 主契約者カナの一括 backfill（#282）が使う raw クエリ
+      $executeRaw: jest.fn().mockResolvedValue(0),
       ...overrides,
     }) as unknown as PrismaClient;
 


### PR DESCRIPTION
## 概要

`GET /plots` の `sortBy=customerName`（#216）が、whereCondition 一致の非vacant ContractPlot を **skip/take 無しで全件ロード**→ アプリ側 `Intl.Collator('ja')` ソート → ページ分 id 抽出 → 再 findMany という構成で、本番想定の数千区画ではページ送りの度にデータセット全体をメモリ展開していた問題を修正する。

Closes #282

## 修正内容

issue の第一修正方針（スナップショット列方式）を採用:

1. **`ContractPlot.primary_contractor_name_kana` 列を追加**（VarChar(100)・インデックス付き）
   - 値は「最初の有効な contractor ロールの `customer.name_kana || name`」（旧実装のソートキーと同一）
   - migration に既存データの backfill（`DISTINCT ON` + `COALESCE(NULLIF(...))`）を同梱
2. **同期関数 `syncPrimaryContractorNameKana`** を `plots/utils.ts` に新設
   - ロール・顧客名を書き換える `createPlot` / `createPlotContract` / `updatePlot` の各トランザクション末尾で呼び出し
3. **legacy 移行 step06 の末尾に SQL 一括 backfill を追加** — #163 の本番移行（step07-11 投入）実行時にも snapshot が同期される
4. **getPlots を通常ページング構成に置換** — `count` + `orderBy: [{ primary_contractor_name_kana: { sort, nulls: 'last' } }, { id: 'asc' }]` + skip/take

## 性能

| | 旧 | 新 |
|---|---|---|
| クエリ数 | 3〜4（全件キー取得 + ページ詳細 + 並べ直し） | 2（count + ページ詳細） |
| メモリ | O(全件) | O(ページサイズ) |
| ソート | アプリ側 O(N log N) / リクエスト毎 | DB 側（インデックス利用可） |

## 挙動の変更点（許容）

- 並び順の照合が `Intl.Collator('ja')` → **DB 照合順**（カナはコードポイント順 ≒ 五十音順）に変わる。カタカナ氏名カナでは実質同等だが、ひらがな・記号混在時の相対順序が変わりうる。
- 契約者なし（null）は昇順・降順問わず末尾固定 — 従来挙動を維持。

## 本番反映の注意

`prisma migrate deploy` で backfill 込みの migration が走る（#163 の本番 migrate 作業に同梱される）。migration 適用後は書込み経路が同期を維持するため再実行は不要。

## テスト

- `npm test`: **1115 pass**（新規5件: sync 単体3件 + DB側ページング・nulls last 固定2件）
- `npm run lint`: clean / `npm run swagger:validate`: valid
- scripts/legacy-migration の型チェック: 既存エラー（cleanup-legacy-data.ts の readonly、main 由来）以外なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)