### PR TITLE
fix: 認証Cookieの secure/sameSite を COOKIE_SECURE env で制御可能にする (#299)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,14 @@ NODE_ENV=development
 # Render環境では RENDER_EXTERNAL_URL が自動設定されるため不要
 # BASE_URL="https://your-api-domain.com"
 
+# 認証Cookieの Secure 属性制御
+# 平文HTTP（TLSなし）で本番運用する場合は false を設定すること。
+# Secure 属性付きCookieはHTTP接続ではブラウザに保存されず、ログインが成立しない。
+#   true:   secure + SameSite=None（HTTPS提供時）
+#   false:  非secure + SameSite=Lax（平文HTTP・同一オリジン運用。例: 事務所サーバのローカル運用）
+#   未設定: NODE_ENV=production なら true 相当（従来挙動）
+# COOKIE_SECURE=false
+
 # CORS Configuration
 # 本番環境では必ず許可するオリジンを指定してください
 # 複数のオリジンを指定する場合はカンマ区切りで記述

--- a/SETUP.md
+++ b/SETUP.md
@@ -76,6 +76,20 @@ cp .env.example .env
 | `SUPABASE_URL` | SupabaseプロジェクトURL | `https://xxx.supabase.co` |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabaseサービスキー | `eyJ...` |
 
+### 認証Cookieの Secure 属性（COOKIE_SECURE）
+
+認証Cookie（access_token / refresh_token）の `Secure` / `SameSite` 属性を制御します。
+
+| 値 | 挙動 | 用途 |
+|----|------|------|
+| `true` | `Secure` + `SameSite=None` | HTTPS提供（クロスオリジン許容） |
+| `false` | 非Secure + `SameSite=Lax` | 平文HTTP・同一オリジン運用（事務所サーバのローカル運用） |
+| 未設定 | `NODE_ENV=production` なら `true` 相当 | 従来挙動 |
+
+> ⚠️ **平文HTTPで本番運用する場合は必ず `COOKIE_SECURE=false` を設定してください。**
+> `Secure` 属性付きCookieはHTTP接続ではブラウザに保存されず、`SameSite=None` は
+> `Secure` を要求するため、未設定のままだとログインが成立しません。
+
 ### CORS設定
 
 - **開発環境**: `ALLOWED_ORIGINS`未設定で全オリジン許可

--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -4,11 +4,20 @@ import prisma from '../db/prisma';
 import { getRequestLogger, logger } from '../utils/logger';
 
 // Cookie設定の定数
+// secure/sameSite は NODE_ENV ではなく実際の提供スキームに連動させる（#299）。
+// 平文HTTPでは Secure 属性付きCookieがブラウザに保存されず、SameSite=None は
+// Secure を要求するため、HTTPのローカル本番運用では COOKIE_SECURE=false を設定する。
+//   COOKIE_SECURE=true  → secure:true / sameSite:'none'（HTTPS提供）
+//   COOKIE_SECURE=false → secure:false / sameSite:'lax'（平文HTTP・同一オリジン運用）
+//   未設定              → 従来どおり NODE_ENV==='production' で判定
 const isProduction = process.env['NODE_ENV'] === 'production';
+const cookieSecureEnv = process.env['COOKIE_SECURE'];
+const cookieSecure =
+  cookieSecureEnv === 'true' ? true : cookieSecureEnv === 'false' ? false : isProduction;
 const COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: isProduction, // 本番環境ではHTTPS必須
-  sameSite: (isProduction ? 'none' : 'lax') as 'none' | 'lax',
+  secure: cookieSecure,
+  sameSite: (cookieSecure ? 'none' : 'lax') as 'none' | 'lax',
   path: '/',
 };
 

--- a/tests/auth/authController.test.ts
+++ b/tests/auth/authController.test.ts
@@ -917,6 +917,99 @@ describe('Auth Controller', () => {
         expect(mockResponse.status).toHaveBeenCalledWith(200);
       });
     });
+
+    describe('COOKIE_SECURE によるCookie属性制御（#299）', () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+
+      afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+        delete process.env.COOKIE_SECURE;
+      });
+
+      // 指定envでログインを実行し、access_token Cookie のオプションを返す
+      const loginAndGetCookieOptions = async (env: {
+        nodeEnv: string;
+        cookieSecure?: string;
+      }): Promise<Record<string, unknown>> => {
+        process.env.NODE_ENV = env.nodeEnv;
+        if (env.cookieSecure !== undefined) {
+          process.env.COOKIE_SECURE = env.cookieSecure;
+        } else {
+          delete process.env.COOKIE_SECURE;
+        }
+        jest.resetModules();
+        const { login } = await import('../../src/auth/authController');
+
+        mockRequest.body = { email: 'test@example.com', password: 'password123' };
+        mockSupabaseAuth.signInWithPassword.mockResolvedValue({
+          data: {
+            user: { id: 'supabase-uid-123', email: 'test@example.com' },
+            session: {
+              access_token: 'test-access-token',
+              refresh_token: 'test-refresh-token',
+              expires_at: 1234567890,
+            },
+          },
+          error: null,
+        });
+        const mockStaff = {
+          id: 1,
+          name: 'テストユーザー',
+          email: 'test@example.com',
+          role: 'admin',
+          is_active: true,
+          supabase_uid: 'supabase-uid-123',
+        };
+        mockPrisma.staff.findUnique.mockResolvedValue(mockStaff);
+        mockPrisma.staff.update.mockResolvedValue(mockStaff);
+
+        await login(mockRequest as Request, mockResponse as Response);
+
+        const cookieCalls = (mockResponse.cookie as jest.Mock).mock.calls;
+        const accessTokenCall = cookieCalls.find((call) => call[0] === 'access_token');
+        expect(accessTokenCall).toBeDefined();
+        return accessTokenCall![2];
+      };
+
+      it('COOKIE_SECURE未設定 + production では secure:true / sameSite:none（従来挙動）', async () => {
+        const options = await loginAndGetCookieOptions({ nodeEnv: 'production' });
+        expect(options.secure).toBe(true);
+        expect(options.sameSite).toBe('none');
+      });
+
+      it('COOKIE_SECURE=false なら production でも secure:false / sameSite:lax（平文HTTPローカル運用）', async () => {
+        const options = await loginAndGetCookieOptions({
+          nodeEnv: 'production',
+          cookieSecure: 'false',
+        });
+        expect(options.secure).toBe(false);
+        expect(options.sameSite).toBe('lax');
+      });
+
+      it('COOKIE_SECURE=true なら development でも secure:true / sameSite:none', async () => {
+        const options = await loginAndGetCookieOptions({
+          nodeEnv: 'development',
+          cookieSecure: 'true',
+        });
+        expect(options.secure).toBe(true);
+        expect(options.sameSite).toBe('none');
+      });
+
+      it('COOKIE_SECURE未設定 + development では secure:false / sameSite:lax', async () => {
+        const options = await loginAndGetCookieOptions({ nodeEnv: 'development' });
+        expect(options.secure).toBe(false);
+        expect(options.sameSite).toBe('lax');
+      });
+
+      it('COOKIE_SECURE に不正値が設定された場合は NODE_ENV ベースの従来挙動にフォールバックすること', async () => {
+        const options = await loginAndGetCookieOptions({
+          nodeEnv: 'production',
+          cookieSecure: 'yes',
+        });
+        expect(options.secure).toBe(true);
+        expect(options.sameSite).toBe('none');
+      });
+    });
   }); // Supabase環境変数が設定されている場合の終了
 
   describe('Supabase環境変数が設定されていない場合', () => {


### PR DESCRIPTION
## 概要

ローカル本番（平文HTTP・Caddy :80）で認証Cookieが `secure` + `SameSite=None` で発行され、ブラウザがCookieを保存も送信もできずログインが成立しない問題の修正。

Closes #299

## 変更内容

- `src/auth/authController.ts`: `COOKIE_OPTIONS` の secure/sameSite を `NODE_ENV` 直結から `COOKIE_SECURE` env 制御に変更
  - `COOKIE_SECURE=true` → `secure:true` / `sameSite:'none'`（HTTPS提供）
  - `COOKIE_SECURE=false` → `secure:false` / `sameSite:'lax'`（平文HTTP・同一オリジン運用）
  - 未設定 → 従来どおり `NODE_ENV==='production'` で判定（**後方互換**）
  - 不正値 → 従来挙動にフォールバック
- `.env.example` / `SETUP.md`: COOKIE_SECURE の設定ガイド追記
- テスト5件追加（production×未設定/false、development×true/未設定、不正値フォールバック）

## komine-local 側の対応

docker-compose の backend service に `COOKIE_SECURE=false` を渡す変更を komine-local 側の別PRで対応する（このPRマージ後にイメージ再ビルドが必要）。

## 検証

- `npm test` 全1120テスト pass（5件追加）
- `npx tsc --noEmit` clean
- `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)