### PR TITLE
fix: ゆうちょCSV 口座名義のエスケープを30桁切詰めの後に行う (#300)

### DIFF
--- a/src/yucho/yuchoCsv.ts
+++ b/src/yucho/yuchoCsv.ts
@@ -230,10 +230,13 @@ export const buildDataRow = (item: YuchoBillingItem): string => {
   // 口座名義は唯一の二重引用符囲みフィールド。toHalfWidthKana は ASCII を素通し
   // するため、名義に半角 " が残ると囲みが途中で閉じて列ズレを起こす。
   // RFC4180 に従い内部の " を "" に二重化してから囲む（#273）。
+  // 固定幅整形は「論理値を幅に収めてからエスケープ」の順で行うこと（#300）。
+  // エスケープ後に切詰めると "" のペアが30桁境界で割れて単独の " が残り、
+  // 囲みの引用符が不均衡になって #273 が防いだ列ズレが再発する。
   const accountHolder = padRight(
-    toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? '').replace(/"/g, '""'),
+    toHalfWidthKana(info?.accountHolder ?? item.customerNameKana ?? ''),
     ACCOUNT_HOLDER_WIDTH
-  );
+  ).replace(/"/g, '""');
 
   const cells = [
     '', // 1: 空

--- a/tests/yucho/yuchoCsv.test.ts
+++ b/tests/yucho/yuchoCsv.test.ts
@@ -346,4 +346,40 @@ describe('口座名義の二重引用符エスケープ（#273）', () => {
     expect(cells[9]?.startsWith('"')).toBe(true);
     expect(cells[9]?.includes('""')).toBe(false);
   });
+
+  describe('30桁切詰め境界でのエスケープ破損（#300）', () => {
+    it('30桁目に " がある名義でも "" ペアが切詰めで割れず列ズレしない', () => {
+      // 29文字 + " で論理値がちょうど30桁。エスケープ→切詰めの順だと
+      // "" の2文字目が30桁境界で切られ、単独の " が残って囲みが不均衡になる
+      const item = baseItem({
+        billingInfo: {
+          ...baseItem().billingInfo!,
+          accountHolder: 'ア'.repeat(29) + '"' + 'イウ',
+        },
+      });
+      const row = buildDataRow(item);
+      const fields = splitRfc4180(row);
+      // 12列のまま列ズレしないこと（旧実装では10〜11列に化ける）
+      expect(fields.length).toBe(12);
+      // 論理値は30桁に切詰められ、" は復元される
+      expect(fields[9]).toBe('ｱ'.repeat(29) + '"');
+      // 後続フィールド（引落金額・フラグ）が無事なこと
+      expect(fields[10]).toBe('12000');
+      expect(fields[11]).toBe('1');
+    });
+
+    it('切詰めで " が幅外に落ちる場合はエスケープ対象自体が消える', () => {
+      const item = baseItem({
+        billingInfo: {
+          ...baseItem().billingInfo!,
+          accountHolder: 'ア'.repeat(30) + '"タロウ',
+        },
+      });
+      const row = buildDataRow(item);
+      const fields = splitRfc4180(row);
+      expect(fields.length).toBe(12);
+      expect(fields[9]).toBe('ｱ'.repeat(30));
+      expect(fields[10]).toBe('12000');
+    });
+  });
 });


### PR DESCRIPTION
## 概要

#273 修正（口座名義の `"` → `""` 二重化）が**エスケープ→切詰め**の順だったため、エスケープ後文字列が30桁を超えると `padRight` の `slice(0, 30)` が `""` ペアを境界で切断し、単独の `"` が残って引用符が不均衡になり、#273 が防いだはずの列ズレが30桁境界で再発していた（リグレッション）。

Closes #300

## 変更内容

`src/yucho/yuchoCsv.ts` `buildDataRow`: 処理順序を変更

| | 旧 | 新 |
|---|---|---|
| 順序 | `toHalfWidthKana` → **escape** → **slice/pad(30)** | `toHalfWidthKana` → **slice/pad(30)** → **escape** |

固定幅整形の原則「論理値を幅に収めてからエスケープ」に準拠。エスケープによる `""` は幅予算に食い込まず、ペアが割れることがない。

## テスト

- リグレッションテスト2件追加:
  - 論理値30桁目が `"` のケース → 旧実装では列数が12→10〜11に化けることを防止、RFC4180パースで12列・名義復元を検証
  - `"` が幅外に落ちるケース → エスケープ対象ごと消えることを検証
- `npm test -- tests/yucho` 64件 pass / `npx tsc --noEmit` / `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)