### PR TITLE
fix: 手動 overdue が部分入金済み請求でサイレント上書きされる問題を修正 (#302)

### DIFF
--- a/src/billings/billingService.ts
+++ b/src/billings/billingService.ts
@@ -9,8 +9,9 @@ import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentS
  *  - written_off (貸倒処理): 自動遷移しない（手動設定を尊重）
  *  - terminated=true: 'terminated'
  *  - 入金合計 >= 請求額 (請求額 > 0): 'paid'
+ *  - 現状 overdue: 'overdue' を維持（手動で設定された延滞ステータスを尊重。
+ *    部分入金があっても全額入金までは延滞のまま — #302。解除は手動 #271）
  *  - 入金合計 > 0: 'partial_paid'
- *  - 現状 overdue: 'overdue' を維持（手動で設定された延滞ステータスを尊重）
  *  - billing_date 設定済: 'billed'
  *  - それ以外: 'pending'
  */
@@ -26,8 +27,11 @@ export const computeBillingStatus = (
   if (billing.status === 'written_off') return 'written_off';
   if (billing.terminated) return 'terminated';
   if (billing.amount > 0 && paidAmount >= billing.amount) return 'paid';
-  if (paidAmount > 0) return 'partial_paid';
+  // 手動 overdue は partial_paid 算出より先に評価する（#302）。
+  // 後に評価すると paid_amount>0 の請求への overdue 設定が 200 のまま
+  // partial_paid に黙って巻き戻り、#271 が解消した無言破棄が残存する。
   if (billing.status === 'overdue') return 'overdue';
+  if (paidAmount > 0) return 'partial_paid';
   if (billing.billing_date) return 'billed';
   return 'pending';
 };

--- a/tests/billings/billingService.test.ts
+++ b/tests/billings/billingService.test.ts
@@ -37,8 +37,17 @@ describe('computeBillingStatus', () => {
     expect(computeBillingStatus({ ...baseBilling, status: 'overdue' }, 0)).toBe('overdue');
   });
 
+  it('preserves "overdue" status with partial payment (manual overdue not silently reverted, #302)', () => {
+    // 部分入金済みの請求に手動 overdue を設定しても partial_paid に巻き戻らないこと。
+    // 旧実装は paidAmount>0 判定が先に評価され、200 を返しつつ別 status が保存される
+    // 無言破棄（#271 が解消したはずの挙動）が残存していた
+    expect(computeBillingStatus({ ...baseBilling, status: 'overdue' }, 5000)).toBe('overdue');
+    expect(computeBillingStatus({ ...baseBilling, status: 'overdue' }, 9999)).toBe('overdue');
+  });
+
   it('transitions from overdue to paid when fully paid', () => {
     expect(computeBillingStatus({ ...baseBilling, status: 'overdue' }, 10000)).toBe('paid');
+    expect(computeBillingStatus({ ...baseBilling, status: 'overdue' }, 12000)).toBe('paid');
   });
 
   it('returns "billed" when billing_date is set and no payment yet', () => {


### PR DESCRIPTION
## 概要

PR#295（#271）で手動 status 変更を written_off/overdue に限定し無言破棄を解消したが、`computeBillingStatus` の評価順序により `paid_amount>0` の請求へ overdue を設定すると **200 を返しつつ partial_paid/paid に黙って巻き戻る** 問題が残存していた。

Closes #302

## 変更内容

`src/billings/billingService.ts` `computeBillingStatus`: 手動 overdue の評価を partial_paid 算出より**先**に移動。

| 条件 | 旧 | 新 |
|---|---|---|
| overdue + 入金0 | overdue | overdue（変わらず） |
| overdue + 部分入金 | **partial_paid（無言破棄）** | **overdue（尊重）** |
| overdue + 全額入金 | paid | paid（変わらず） |

「尊重すべき手動値を先に評価」の原則に準拠。部分入金があっても全額入金までは延滞のまま（延滞解除は #271 の手動解除フロー）。副次効果として、overdue 請求への部分入金記録でも延滞フラグが自動消滅しなくなる（業務的に妥当: 部分入金は延滞解消ではない）。

## テスト

- `computeBillingStatus` の部分入金×overdue 維持テスト追加、全額入金×overdue→paid の境界ケース拡充
- `npm test` 全1116件 pass / `npx tsc --noEmit` / `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)