### PR TITLE
fix: 共有契約者の snapshot 再同期 + 一覧の contractor 選択順統一 (#301, #303)

### DIFF
--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -254,6 +254,11 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
       },
       saleContractRoles: {
         where: { deleted_at: null },
+        // 表示名の contractor 選択を snapshot（syncPrimaryContractorNameKana）の
+        // 「最初の有効な contractor ロール（created_at asc, id asc）」と同一順序に
+        // 揃える（#303）。orderBy 無しだと DB 返却順が任意のため、同一区画に
+        // contractor ロールが複数ある場合にソートキーのカナと表示名が別人になる。
+        orderBy: [{ created_at: 'asc' as const }, { id: 'asc' as const }],
         include: {
           customer: {
             select: {

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -12,6 +12,7 @@ import {
   updatePhysicalPlotStatus,
   buildGravestoneInfoData,
   syncPrimaryContractorNameKana,
+  syncContractorNameKanaForCustomer,
 } from '../utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
@@ -341,6 +342,12 @@ export async function updatePlotCore(
           where: { id: customerId },
           data: customerUpdateData,
         });
+        // 共有契約者（レガシー移行で複数区画が同一 Customer を契約者として参照）の
+        // 氏名・カナ変更は編集対象外の区画の snapshot も陳腐化させるため、
+        // 顧客起点で該当する全契約区画を再同期する（#301）
+        if (customerUpdateData.name !== undefined || customerUpdateData.name_kana !== undefined) {
+          await syncContractorNameKanaForCustomer(tx, customerId);
+        }
       }
 
       // 5. WorkInfoの更新/作成/削除
@@ -521,6 +528,11 @@ export async function updatePlotCore(
           physicalPlotId,
           req
         );
+        // 申込者として編集した顧客が他区画の契約者を兼ねる場合（共有 Customer）も
+        // snapshot が陳腐化するため、氏名・カナ変更時は顧客起点で再同期する（#301）
+        if (applicantUpdateData.name !== undefined || applicantUpdateData.name_kana !== undefined) {
+          await syncContractorNameKanaForCustomer(tx, applicantCustomerId);
+        }
       }
     } else {
       // 新規 Customer + applicant role を作成

--- a/src/plots/utils.ts
+++ b/src/plots/utils.ts
@@ -238,6 +238,32 @@ export async function syncPrimaryContractorNameKana(
 }
 
 /**
+ * 指定顧客を契約者とする全契約区画のスナップショットを再同期する（#301）。
+ *
+ * レガシー移行は 1 danka_cd = 1 Customer のため、同一顧客が複数区画の契約者を
+ * 兼ねる実データが生じる。顧客の氏名・カナを書き換えると編集対象以外の区画の
+ * primary_contractor_name_kana も陳腐化するので、顧客名を更新した経路では
+ * contractPlotId 起点の同期に加えてこちらを呼ぶこと。
+ *
+ * @param prisma Prismaクライアント（トランザクション対応）
+ * @param customerId 顧客ID
+ */
+export async function syncContractorNameKanaForCustomer(
+  prisma: Prisma.TransactionClient,
+  customerId: string
+): Promise<void> {
+  const roles = await prisma.saleContractRole.findMany({
+    where: { customer_id: customerId, role: 'contractor', deleted_at: null },
+    select: { contract_plot_id: true },
+  });
+  // 同一区画に重複ロールがあっても再同期は1回で足りる
+  const contractPlotIds = [...new Set(roles.map((r) => r.contract_plot_id))];
+  for (const contractPlotId of contractPlotIds) {
+    await syncPrimaryContractorNameKana(prisma, contractPlotId);
+  }
+}
+
+/**
  * 物理区画が完全に利用可能か（契約がない状態）
  * @param prisma Prismaクライアント（トランザクション対応）
  * @param physicalPlotId 物理区画ID

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -122,6 +122,7 @@ jest.mock('../../src/plots/utils', () => {
     validateContractArea: jest.fn(),
     updatePhysicalPlotStatus: jest.fn(),
     syncPrimaryContractorNameKana: jest.fn(),
+    syncContractorNameKanaForCustomer: jest.fn(),
     buildGravestoneInfoData: actual.buildGravestoneInfoData,
   };
 });
@@ -148,7 +149,11 @@ import {
   createPlotContract,
   getPlotInventory,
 } from '../../src/plots/controllers';
-import { validateContractArea, updatePhysicalPlotStatus } from '../../src/plots/utils';
+import {
+  validateContractArea,
+  updatePhysicalPlotStatus,
+  syncContractorNameKanaForCustomer,
+} from '../../src/plots/utils';
 import { ValidationError, NotFoundError } from '../../src/middleware/errorHandler';
 
 describe('Plot Controller (ContractPlot Model)', () => {
@@ -348,6 +353,24 @@ describe('Plot Controller (ContractPlot Model)', () => {
       const query = mockPrisma.contractPlot.findMany.mock.calls[0][0];
       expect(query.orderBy).toEqual([
         { primary_contractor_name_kana: { sort: 'desc', nulls: 'last' } },
+        { id: 'asc' },
+      ]);
+    });
+
+    it('一覧 include の saleContractRoles を snapshot と同一順序（created_at asc, id asc）で取得する (#303)', async () => {
+      // 同一区画に contractor ロールが複数ある場合、orderBy 無しでは DB 返却順が
+      // 任意のため、ソートキー（snapshot は created_at asc の顧客）と表示名
+      // （find の先頭一致）が別人になりうる。表示側を snapshot の選択順に揃える
+      mockPrisma.contractPlot.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: '1', limit: '10' };
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const query = mockPrisma.contractPlot.findMany.mock.calls[0][0];
+      expect(query.include.saleContractRoles.orderBy).toEqual([
+        { created_at: 'asc' },
         { id: 'asc' },
       ]);
     });
@@ -1305,6 +1328,85 @@ describe('Plot Controller (ContractPlot Model)', () => {
         })
       );
       expect(mockPrisma.saleContractRole.create).not.toHaveBeenCalled();
+      // 申込者として編集した顧客が他区画の契約者を兼ねるケース（共有 Customer）の
+      // snapshot 陳腐化を防ぐため、氏名変更時は顧客起点の再同期も呼ばれる（#301）
+      expect(syncContractorNameKanaForCustomer).toHaveBeenCalledWith(expect.anything(), 'c2');
+    });
+
+    it('契約者氏名・カナの更新で顧客起点の snapshot 再同期が呼ばれる (#301)', async () => {
+      // 共有契約者（同一 Customer が複数区画の契約者）の氏名編集は、編集対象の
+      // 区画だけ再同期すると他区画の primary_contractor_name_kana が陳腐化し、
+      // 五十音ソート位置と表示名が乖離する
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null, billingInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.customer.update.mockResolvedValue({ id: 'c1', name: '山田改' });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        customer: { name: '山田改', nameKana: 'ヤマダカイ' },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.customer.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'c1' },
+          data: expect.objectContaining({ name: '山田改', name_kana: 'ヤマダカイ' }),
+        })
+      );
+      expect(syncContractorNameKanaForCustomer).toHaveBeenCalledWith(expect.anything(), 'c1');
+    });
+
+    it('契約者の氏名以外（電話番号等）の更新では顧客起点の再同期は呼ばれない (#301)', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null, billingInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.customer.update.mockResolvedValue({ id: 'c1' });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        customer: { phoneNumber: '0312345678' },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.customer.update).toHaveBeenCalled();
+      expect(syncContractorNameKanaForCustomer).not.toHaveBeenCalled();
     });
 
     it('should soft-delete applicant role when applicant=null', async () => {

--- a/tests/plots/utils.test.ts
+++ b/tests/plots/utils.test.ts
@@ -6,12 +6,16 @@
  * スナップショット列の同期ロジックを固定する。
  */
 
-import { syncPrimaryContractorNameKana } from '../../src/plots/utils';
+import {
+  syncPrimaryContractorNameKana,
+  syncContractorNameKanaForCustomer,
+} from '../../src/plots/utils';
 
-const buildTx = (roleResult: unknown) =>
+const buildTx = (roleResult: unknown, roleListResult: unknown[] = []) =>
   ({
     saleContractRole: {
       findFirst: jest.fn().mockResolvedValue(roleResult),
+      findMany: jest.fn().mockResolvedValue(roleListResult),
     },
     contractPlot: {
       update: jest.fn().mockResolvedValue({}),
@@ -57,5 +61,51 @@ describe('syncPrimaryContractorNameKana (#282)', () => {
       where: { id: 'cp-1' },
       data: { primary_contractor_name_kana: null },
     });
+  });
+});
+
+describe('syncContractorNameKanaForCustomer (#301)', () => {
+  it('顧客を契約者とする全契約区画のスナップショットを再同期する', async () => {
+    // 共有契約者: cust-1 が cp-1 / cp-2 / cp-3 の契約者を兼ねる
+    const tx = buildTx({ customer: { name_kana: 'ヤマダタロウ', name: '山田太郎' } }, [
+      { contract_plot_id: 'cp-1' },
+      { contract_plot_id: 'cp-2' },
+      { contract_plot_id: 'cp-3' },
+    ]);
+
+    await syncContractorNameKanaForCustomer(tx, 'cust-1');
+
+    // 顧客起点で contractor ロールを検索すること
+    expect(tx.saleContractRole.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { customer_id: 'cust-1', role: 'contractor', deleted_at: null },
+      })
+    );
+    // 3区画すべての snapshot が更新されること（編集対象以外も陳腐化させない）
+    expect(tx.contractPlot.update).toHaveBeenCalledTimes(3);
+    for (const id of ['cp-1', 'cp-2', 'cp-3']) {
+      expect(tx.contractPlot.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id } })
+      );
+    }
+  });
+
+  it('同一区画の重複ロールは1回だけ再同期する', async () => {
+    const tx = buildTx({ customer: { name_kana: 'ヤマダタロウ', name: '山田太郎' } }, [
+      { contract_plot_id: 'cp-1' },
+      { contract_plot_id: 'cp-1' },
+    ]);
+
+    await syncContractorNameKanaForCustomer(tx, 'cust-1');
+
+    expect(tx.contractPlot.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('contractor ロールを持たない顧客（申込者のみ等）では何も更新しない', async () => {
+    const tx = buildTx(null, []);
+
+    await syncContractorNameKanaForCustomer(tx, 'cust-1');
+
+    expect(tx.contractPlot.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 概要

PR#297（#282 契約者名ソート snapshot 列）のフォロー2件。どちらも「snapshot の contractor 選択」と「他の経路」の不整合。

- Closes #301 — 共有契約者の氏名編集で他区画の `primary_contractor_name_kana` が陳腐化
- Closes #303 — 一覧表示の contractor 選択（orderBy なし find 先頭一致）が snapshot の選択（created_at asc）と不一致

## 変更内容

### #301: 顧客起点の snapshot 再同期

- `src/plots/utils.ts`: `syncContractorNameKanaForCustomer(tx, customerId)` を新設 — 指定顧客を contractor とする全 ContractPlot の snapshot を再同期（重複ロールは1回に dedupe）
- `src/plots/controllers/updatePlot.ts`: 契約者（§4 `input.customer`）・申込者（`input.applicant` 部分更新）で **name / name_kana を変更した場合のみ** 顧客起点の再同期を追加（従来の編集対象区画の末尾同期は維持）
  - 申込者経路も対象にしたのは、申込者として編集した共有 Customer が他区画の契約者を兼ねるケースがあるため（contractor ロールが無ければ findMany 1回で no-op）

### #303: 一覧 include の orderBy 付与

- `src/plots/controllers/getPlots.ts`: `listInclude.saleContractRoles` に `orderBy: [{created_at:'asc'},{id:'asc'}]` を付与し、表示名の contractor 選択を snapshot と同一順序に

## テスト

- `syncContractorNameKanaForCustomer` 単体3件（全区画再同期 / 重複 dedupe / contractor 無し no-op）
- updatePlot 配線3件（契約者氏名更新で発火 / 申込者氏名更新で発火 / 氏名以外では発火しない）
  - ※ 既存の utils モックに新関数を追加（無いと TypeError → next(error) でテストが無言 pass する罠を確認済み）
- getPlots の include orderBy 固定1件
- `npm test` 全1121件 pass / `npx tsc --noEmit` / `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)