### PR TITLE
chore: TYPES_REF を 6cabaf4 へ bump（types#39 .max() 追加）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=9814403ca64187af1ff3b657b18c6031bd69c532
+ARG TYPES_REF=6cabaf4a878db97988dca80910b60613e13bae4c
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要

@komine/types PR#39（zaitsu82/komine-types#38 — VarChar 超過で P2000 になるフィールドへの `.max()` 追加）のマージに伴う `TYPES_REF` bump。

| | SHA |
|---|---|
| 旧 | `9814403ca64187af1ff3b657b18c6031bd69c532` |
| 新 | `6cabaf4a878db97988dca80910b60613e13bae4c`（types#39 squash merge） |

バリデーション強化のみ（`acceptanceNumber`/`permitNumber` `.max(50)`、`feeType` `.max(50)`、`staffInCharge` `.max(100)`）で、backend 側のコード変更は不要（共有スキーマを extend しているため自動で適用される）。

frontend 側の bump は別PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)