### PR TITLE
feat(migration): 終了顧客(del_flg=2)を取込・旧入金35件を除外（業務確認反映）

### DIFF
--- a/prisma/migrations/20260607120000_add_customer_is_terminated/migration.sql
+++ b/prisma/migrations/20260607120000_add_customer_is_terminated/migration.sql
@@ -1,0 +1,3 @@
+-- 解約済み（取引終了）顧客フラグ（#129）
+-- 業務確認（2026-06-07 Q21）: レガシー t_danka.del_flg=2 の終了顧客を「終了」印付きで取り込む
+ALTER TABLE "customers" ADD COLUMN "is_terminated" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -250,6 +250,9 @@ model Customer {
   // 申込者（契約者と別人）として移行時に作成された Customer の識別用（#221）。
   // truncate / cleanup の削除条件と step06 の冪等チェックに使う。
   legacy_applicant_danka_cd Int?
+  // 解約済み（取引終了）顧客フラグ。レガシー t_danka.del_flg=2 由来。
+  // 業務確認（2026-06-07 Q21）:「終了」印付きで取り込み、解約者で情報をまとめて参照できるようにする（#129）
+  is_terminated             Boolean   @default(false)
   created_at                DateTime  @default(now())
   updated_at                DateTime  @updatedAt
   deleted_at                DateTime?

--- a/scripts/legacy-migration/lib/id-map-loader.ts
+++ b/scripts/legacy-migration/lib/id-map-loader.ts
@@ -23,7 +23,8 @@ const STAFF_SUPABASE_UID_PREFIX = 'legacy-tancd-';
 export async function loadIdMapFromDb(
   prisma: PrismaClient,
   modelName: 'customer' | 'contractPlot' | 'billing',
-  legacyColumn: 'legacy_danka_cd' | 'legacy_grave_cd' | 'legacy_seikyu_cd'
+  legacyColumn: 'legacy_danka_cd' | 'legacy_grave_cd' | 'legacy_seikyu_cd',
+  extraWhere?: Record<string, unknown>
 ): Promise<Map<number, string>> {
   // Prisma の型システム上、delegate は引数で動的に決まる。実行時に存在しないキーは
   // テストでも本番でも発生しないため、安全な dynamic dispatch とする。
@@ -39,7 +40,7 @@ export async function loadIdMapFromDb(
     throw new Error(`Unknown Prisma model: ${modelName}`);
   }
   const rows = await delegate.findMany({
-    where: { [legacyColumn]: { not: null }, deleted_at: null },
+    where: { [legacyColumn]: { not: null }, deleted_at: null, ...(extraWhere ?? {}) },
     select: { id: true, [legacyColumn]: true },
   });
 
@@ -71,7 +72,11 @@ export async function rebuildIdMap(
   let loaded = 0;
   switch (key) {
     case 'customer': {
-      const m = await loadIdMapFromDb(prisma, 'customer', 'legacy_danka_cd');
+      // 終了顧客（is_terminated=true、レガシー del_flg=2 由来）は契約/請求/入金のリンク対象外
+      // のため除外する（#129/Q19: 旧入金35件を取り込まない）
+      const m = await loadIdMapFromDb(prisma, 'customer', 'legacy_danka_cd', {
+        is_terminated: false,
+      });
       for (const [k, v] of m) idMaps.customer.set(k, v);
       loaded = m.size;
       break;

--- a/scripts/legacy-migration/steps/04-customer.ts
+++ b/scripts/legacy-migration/steps/04-customer.ts
@@ -14,6 +14,7 @@ import type { MigrationStep } from '../types';
 interface DankaRow extends RowDataPacket {
   danka_cd: number;
   grave_cd: number;
+  del_flg: number | null;
   // 申込者
   request_sei: string | null;
   request_sei_kana: string | null;
@@ -80,13 +81,18 @@ const KOUZA_TYPE_MAP: Record<number, string> = {
  *
  * - WorkInfo は job_name がある場合のみ作成（C-3: 13.2%）
  * - email は 0% 運用 → 空ならスキップ（nullable）
+ *
+ * - 終了顧客（del_flg=2、約150件）も is_terminated=true で取り込む（業務確認 2026-06-07 Q21:
+ *   「取り込む・解約者で情報まとめる」、#129）。ただし idMaps.customer には載せない —
+ *   契約/ロール/請求/入金のリンク対象にせず、旧入金（約35件）の取り込みも防ぐ（Q19: 取り込まない）。
+ *   旧運用は解約時に人情報を消すため（Q18/Q20）、氏名・住所欠損はプレースホルダ/空文字で受け入れる。
  */
 export const stepCustomer: MigrationStep = {
   name: 'customer',
   dependsOn: ['staff'],
   async run({ prisma, logger, idMaps, dryRun }) {
     const rows = await legacyQuery<DankaRow>(
-      `SELECT * FROM t_danka WHERE del_flg = 0 OR del_flg IS NULL`
+      `SELECT * FROM t_danka WHERE del_flg = 0 OR del_flg IS NULL OR del_flg = 2`
     );
 
     let inserted = 0;
@@ -95,45 +101,62 @@ export const stepCustomer: MigrationStep = {
     let skipMissingName = 0;
     let skipMissingRequiredField = 0;
     let skipExisting = 0;
+    let terminatedImported = 0;
+    let terminatedFieldFallback = 0;
 
     for (const row of rows) {
+      const isTerminated = row.del_flg === 2;
+
       // 契約者（owner）として Customer を作る
-      const name = joinName(row.owner_sei, row.owner_mei);
-      const nameKana = joinName(row.owner_sei_kana, row.owner_mei_kana);
+      let name = joinName(row.owner_sei, row.owner_mei);
+      let nameKana = joinName(row.owner_sei_kana, row.owner_mei_kana);
 
       if (!name || !nameKana) {
-        logger.warn(
-          { danka_cd: row.danka_cd },
-          'Skipping t_danka row: owner name/kana missing (data quality issue)'
-        );
-        skipped++;
-        skipMissingName++;
-        continue;
+        if (!isTerminated) {
+          logger.warn(
+            { danka_cd: row.danka_cd },
+            'Skipping t_danka row: owner name/kana missing (data quality issue)'
+          );
+          skipped++;
+          skipMissingName++;
+          continue;
+        }
+        // 終了顧客は氏名が消されている場合がある → プレースホルダで取り込む
+        name = name ?? '（氏名不明）';
+        nameKana = nameKana ?? '（フメイ）';
+        terminatedFieldFallback++;
       }
 
       // 住所組み立て: addr1 + addr2 + addr3
       const addressParts = [row.addr1, row.addr2, row.addr3]
         .map((p) => cleanStr(p))
         .filter((p): p is string => p !== null);
-      const address = addressParts.join(' ');
-      const postalCode = parseLegacyZip(row.zip);
+      let address = addressParts.join(' ');
+      let postalCode = parseLegacyZip(row.zip);
       const phone = cleanPhone(row.tel1) ?? cleanPhone(row.tel2);
 
       // 住所・郵便番号は必須。電話番号は nullable（レガシー実データに 17 件欠損あり、schema 側も nullable）
       if (!address || !postalCode) {
-        logger.warn(
-          { danka_cd: row.danka_cd, address: !!address, postalCode: !!postalCode },
-          'Skipping t_danka row: required field missing'
-        );
-        skipped++;
-        skipMissingRequiredField++;
-        continue;
+        if (!isTerminated) {
+          logger.warn(
+            { danka_cd: row.danka_cd, address: !!address, postalCode: !!postalCode },
+            'Skipping t_danka row: required field missing'
+          );
+          skipped++;
+          skipMissingRequiredField++;
+          continue;
+        }
+        // 終了顧客は住所等が消されている場合がある → 空文字で取り込む（NOT NULL 制約対応）
+        address = address || '';
+        postalCode = postalCode ?? '';
+        terminatedFieldFallback++;
       }
 
       const staffId = row.tancd != null ? (idMaps.staff.get(row.tancd) ?? null) : null;
 
       if (dryRun) {
-        idMaps.customer.set(row.danka_cd, `dry-customer-${row.danka_cd}`);
+        if (isTerminated) terminatedImported++;
+        else idMaps.customer.set(row.danka_cd, `dry-customer-${row.danka_cd}`);
         inserted++;
         if (cleanStr(row.job_name)) workInfoInserted++;
         continue;
@@ -144,7 +167,7 @@ export const stepCustomer: MigrationStep = {
         where: { legacy_danka_cd: row.danka_cd, deleted_at: null },
       });
       if (existing) {
-        idMaps.customer.set(row.danka_cd, existing.id);
+        if (!isTerminated) idMaps.customer.set(row.danka_cd, existing.id);
         skipped++;
         skipExisting++;
         continue;
@@ -171,12 +194,22 @@ export const stepCustomer: MigrationStep = {
           account_type: row.kouza_type ? (KOUZA_TYPE_MAP[row.kouza_type] ?? null) : null,
           account_number: cleanStr(row.kouza_code),
           account_holder: cleanStr(row.kouza_meigi),
-          notes: cleanStr(row.note),
+          // 終了顧客は「解約場所が分かるように」（Q18/Q20）旧区画への手がかりを notes に残す
+          notes: isTerminated
+            ? [
+                `[解約済み顧客] 旧システム del_flg=2。旧区画cd: ${row.grave_cd}（区画No: legacy-${row.grave_cd}）`,
+                cleanStr(row.note),
+              ]
+                .filter(Boolean)
+                .join('\n')
+            : cleanStr(row.note),
           staff_id: staffId,
           legacy_danka_cd: row.danka_cd,
+          is_terminated: isTerminated,
         },
       });
-      idMaps.customer.set(row.danka_cd, customer.id);
+      if (isTerminated) terminatedImported++;
+      else idMaps.customer.set(row.danka_cd, customer.id);
       inserted++;
 
       // WorkInfo（job_name がある場合のみ）
@@ -211,6 +244,8 @@ export const stepCustomer: MigrationStep = {
         skip_missing_name: skipMissingName,
         skip_missing_required_field: skipMissingRequiredField,
         skip_existing: skipExisting,
+        terminated_imported: terminatedImported,
+        terminated_field_fallback: terminatedFieldFallback,
       },
     };
   },

--- a/scripts/legacy-migration/steps/11-payment.ts
+++ b/scripts/legacy-migration/steps/11-payment.ts
@@ -27,6 +27,8 @@ interface NyukinRow extends RowDataPacket {
  *
  * - 孤児入金 16 件（対応する t_seikyu なし）は billing_id=NULL で
  *   customer_id / contract_plot_id 直リンクで保存（推奨方針A）
+ * - 終了顧客（t_danka.del_flg=2）に紐づく旧入金（約35件）は取り込まない
+ *   （業務確認 2026-06-07 Q19。空き器契約への誤リンク防止も兼ねる）
  * - charge (担当者 TANCD) は staff_in_charge 文字列に保持
  *   （Staff FK にはしない。レガシー側は数値、新側は文字列で運用前提）
  */
@@ -42,6 +44,14 @@ export const stepPayment: MigrationStep = {
     await rebuildIdMap(prisma, idMaps, 'billing', logger);
     assertIdMapsReady('payment', idMaps, ['billing', 'contractPlot', 'customer']);
 
+    // 業務確認（2026-06-07 Q19）: もう使っていない区画あての昔の入金記録は「取り込まない」。
+    // 終了顧客は step04 で Customer として取り込まれるが（is_terminated=true）、その旧入金が
+    // grave_cd 経由で空き器契約（vacant ContractPlot）へ誤リンクされるのを danka 単位で防ぐ。
+    const terminatedDanka = await legacyQuery<RowDataPacket & { danka_cd: number }>(
+      `SELECT danka_cd FROM t_danka WHERE del_flg = 2`
+    );
+    const terminatedDankaSet = new Set(terminatedDanka.map((r) => r.danka_cd));
+
     const rows = await legacyQuery<NyukinRow>(
       `SELECT * FROM t_nyukin WHERE del_flg = 0 OR del_flg IS NULL`
     );
@@ -49,8 +59,19 @@ export const stepPayment: MigrationStep = {
     let inserted = 0;
     let skipped = 0;
     let orphanCount = 0;
+    let skipTerminatedDanka = 0;
 
     for (const row of rows) {
+      if (row.danka_cd != null && terminatedDankaSet.has(row.danka_cd)) {
+        logger.debug(
+          { nyukin_cd: row.nyukin_cd, danka_cd: row.danka_cd },
+          'Payment skipped: terminated customer (del_flg=2, 業務確認Q19: 取り込まない)'
+        );
+        skipped++;
+        skipTerminatedDanka++;
+        continue;
+      }
+
       const billingId = row.seikyu_cd != null ? (idMaps.billing.get(row.seikyu_cd) ?? null) : null;
       const customerId = row.danka_cd != null ? (idMaps.customer.get(row.danka_cd) ?? null) : null;
       const contractPlotId =
@@ -119,6 +140,7 @@ export const stepPayment: MigrationStep = {
       notes: {
         source_rows: rows.length,
         orphan_payments: orphanCount,
+        skip_terminated_danka: skipTerminatedDanka,
       },
     };
   },

--- a/scripts/legacy-migration/steps/13-summary.ts
+++ b/scripts/legacy-migration/steps/13-summary.ts
@@ -13,6 +13,10 @@ import type { MigrationStep } from '../types';
  *   - 管理料総額: 555,190,595 円
  *
  * 新DB側の集計と突き合わせて差分を表示する。
+ *
+ * 注意: customers は終了顧客（del_flg=2 由来、is_terminated=true、#129）と
+ * 別人申込者（legacy_applicant_danka_cd、#221）を含むためベースライン 3,487 を上回る。
+ * terminated_customers（新旧）で del_flg=2 分を別掲して突き合わせる。
  */
 export const stepSummary: MigrationStep = {
   name: 'summary',
@@ -28,6 +32,7 @@ export const stepSummary: MigrationStep = {
       paymentCount,
       staffCount,
       orphanPaymentCount,
+      terminatedCustomerCount,
       usageFeeTotal,
       managementFeeTotal,
     ] = await Promise.all([
@@ -41,6 +46,8 @@ export const stepSummary: MigrationStep = {
       prisma.payment.count({ where: { deleted_at: null } }),
       prisma.staff.count({ where: { deleted_at: null } }),
       prisma.payment.count({ where: { deleted_at: null, billing_id: null } }),
+      // 終了顧客（del_flg=2 由来、#129）の取り込み件数検証用
+      prisma.customer.count({ where: { deleted_at: null, is_terminated: true } }),
       prisma.billing.aggregate({
         where: { category: 'usage_fee', deleted_at: null },
         _sum: { amount: true },
@@ -66,6 +73,7 @@ export const stepSummary: MigrationStep = {
     interface LegacyCountsRow {
       physical: number;
       customer: number;
+      customer_terminated: number;
       family: number;
       buried: number;
       billing: number;
@@ -77,6 +85,7 @@ export const stepSummary: MigrationStep = {
       `SELECT
          (SELECT COUNT(*) FROM m_bochi WHERE del_flg=0 OR del_flg IS NULL) AS physical,
          (SELECT COUNT(*) FROM t_danka WHERE del_flg=0 OR del_flg IS NULL) AS customer,
+         (SELECT COUNT(*) FROM t_danka WHERE del_flg=2) AS customer_terminated,
          (SELECT COUNT(*) FROM t_family WHERE del_flg=0 OR del_flg IS NULL) AS family,
          (SELECT COUNT(*) FROM t_maisou WHERE del_flg=0 OR del_flg IS NULL) AS buried,
          (SELECT COUNT(*) FROM t_seikyu WHERE del_flg=0 OR del_flg IS NULL) AS billing,
@@ -97,6 +106,7 @@ export const stepSummary: MigrationStep = {
         billings: billingCount,
         payments: paymentCount,
         orphan_payments: orphanPaymentCount,
+        terminated_customers: terminatedCustomerCount,
         staff: staffCount,
         usage_fee_total: Number(usageFeeTotal._sum.amount ?? 0),
         management_fee_total: Number(managementFeeTotal._sum.amount ?? 0),
@@ -105,6 +115,7 @@ export const stepSummary: MigrationStep = {
       legacy: {
         physical_plots: Number(legacy?.physical ?? 0),
         customers: Number(legacy?.customer ?? 0),
+        terminated_customers: Number(legacy?.customer_terminated ?? 0),
         family_contacts: Number(legacy?.family ?? 0),
         buried_persons: Number(legacy?.buried ?? 0),
         billings: Number(legacy?.billing ?? 0),

--- a/tests/scripts/legacy-migration/steps/terminated-customer.test.ts
+++ b/tests/scripts/legacy-migration/steps/terminated-customer.test.ts
@@ -1,0 +1,292 @@
+/**
+ * 回帰テスト: 終了顧客（t_danka.del_flg=2）の取り込みと旧入金の除外（#129）
+ *
+ * 業務確認（2026-06-07）:
+ *   - Q21: 終了顧客150件は「終了」印付きで取り込む → is_terminated=true
+ *   - Q19: もう使っていない区画あての昔の入金記録（約35件）は取り込まない
+ *
+ * 設計: 終了顧客は idMaps.customer に載せない（契約/請求/入金のリンク対象外）。
+ * step11 は terminated danka の入金を danka 単位で明示除外する
+ * （grave_cd 経由で空き器契約へ誤リンクされるのを防ぐ）。
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepCustomer } from '../../../../scripts/legacy-migration/steps/04-customer';
+import { stepPayment } from '../../../../scripts/legacy-migration/steps/11-payment';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+function buildDankaRow(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    danka_cd: 100,
+    grave_cd: 500,
+    del_flg: 0,
+    owner_sei: '小嶺',
+    owner_sei_kana: 'コミネ',
+    owner_mei: '太郎',
+    owner_mei_kana: 'タロウ',
+    sex_flg: null,
+    birthday: null,
+    honseki_zip: null,
+    honseki_addr1: null,
+    honseki_addr2: null,
+    zip: 8000000,
+    addr1: '北九州市',
+    addr2: null,
+    addr3: null,
+    tel1: '0931234567',
+    tel2: null,
+    fax: null,
+    email1: null,
+    job_name: null,
+    job_name_kana: null,
+    job_zip: null,
+    job_addr1: null,
+    job_addr2: null,
+    job_addr3: null,
+    job_tel1: null,
+    kikan_name: null,
+    shiten_name: null,
+    kouza_type: null,
+    kouza_code: null,
+    kouza_meigi: null,
+    tancd: null,
+    note: null,
+    request_sei: null,
+    request_sei_kana: null,
+    request_mei: null,
+    request_mei_kana: null,
+    request_zip: null,
+    request_addr1: null,
+    request_addr2: null,
+    request_addr3: null,
+    request_tel1: null,
+    request_tel2: null,
+    ...overrides,
+  };
+}
+
+describe('stepCustomer: 終了顧客（del_flg=2）の取り込み (#129/Q21)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  it('del_flg=2 を is_terminated=true で取り込み、idMaps.customer には載せない', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const customerCreate = jest.fn().mockImplementation(({ data }: { data: never }) => {
+      created.push(data);
+      return Promise.resolve({ id: `cust-${created.length}` });
+    });
+    const prisma = {
+      customer: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: customerCreate,
+      },
+      workInfo: { create: jest.fn() },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([
+      buildDankaRow({ danka_cd: 100, del_flg: 0 }),
+      buildDankaRow({ danka_cd: 200, grave_cd: 600, del_flg: 2, note: '旧メモ' }),
+    ]);
+
+    const idMaps = createIdMaps();
+    const result = await stepCustomer.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: false,
+    });
+
+    expect(result.inserted).toBe(2);
+    expect(result.notes?.['terminated_imported']).toBe(1);
+    expect(customerCreate).toHaveBeenCalledTimes(2);
+
+    const active = created.find((d) => d['legacy_danka_cd'] === 100);
+    const terminated = created.find((d) => d['legacy_danka_cd'] === 200);
+    expect(active?.['is_terminated']).toBe(false);
+    expect(terminated?.['is_terminated']).toBe(true);
+    // 解約場所の手がかり（Q18/Q20）を notes に残し、元の note も保持する
+    expect(terminated?.['notes']).toContain('旧区画cd: 600');
+    expect(terminated?.['notes']).toContain('旧メモ');
+
+    // 終了顧客は契約/請求/入金のリンク対象にしない
+    expect(idMaps.customer.has(100)).toBe(true);
+    expect(idMaps.customer.has(200)).toBe(false);
+  });
+
+  it('終了顧客は氏名・住所欠損でもプレースホルダ/空文字で取り込む（旧運用は解約で人情報を消すため）', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = {
+      customer: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockImplementation(({ data }: { data: never }) => {
+          created.push(data);
+          return Promise.resolve({ id: 'cust-t' });
+        }),
+      },
+      workInfo: { create: jest.fn() },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([
+      buildDankaRow({
+        danka_cd: 201,
+        del_flg: 2,
+        owner_sei: null,
+        owner_mei: null,
+        owner_sei_kana: null,
+        owner_mei_kana: null,
+        zip: null,
+        addr1: null,
+        tel1: null,
+      }),
+    ]);
+
+    const idMaps = createIdMaps();
+    const result = await stepCustomer.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: false,
+    });
+
+    expect(result.inserted).toBe(1);
+    expect(created[0]?.['name']).toBe('（氏名不明）');
+    expect(created[0]?.['name_kana']).toBe('（フメイ）');
+    expect(created[0]?.['postal_code']).toBe('');
+    expect(created[0]?.['address']).toBe('');
+    expect(result.notes?.['terminated_field_fallback']).toBe(2);
+  });
+
+  it('現役顧客（del_flg=0）の氏名欠損は従来どおりスキップする（挙動回帰なし）', async () => {
+    const customerCreate = jest.fn();
+    const prisma = {
+      customer: { findFirst: jest.fn().mockResolvedValue(null), create: customerCreate },
+      workInfo: { create: jest.fn() },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([
+      buildDankaRow({ danka_cd: 101, del_flg: 0, owner_sei: null, owner_mei: null }),
+    ]);
+
+    const result = await stepCustomer.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    expect(customerCreate).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+    expect(result.notes?.['skip_missing_name']).toBe(1);
+  });
+
+  it('dry-run でも終了顧客を idMaps.customer に載せない', async () => {
+    const prisma = {} as unknown as PrismaClient;
+    mockedLegacyQuery.mockResolvedValueOnce([
+      buildDankaRow({ danka_cd: 100, del_flg: 0 }),
+      buildDankaRow({ danka_cd: 200, del_flg: 2 }),
+    ]);
+
+    const idMaps = createIdMaps();
+    const result = await stepCustomer.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps,
+      dryRun: true,
+    });
+
+    expect(result.inserted).toBe(2);
+    expect(result.notes?.['terminated_imported']).toBe(1);
+    expect(idMaps.customer.has(100)).toBe(true);
+    expect(idMaps.customer.has(200)).toBe(false);
+  });
+});
+
+describe('stepPayment: 終了顧客の旧入金は取り込まない (#129/Q19)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  function buildNyukinRow(overrides: Record<string, unknown>): Record<string, unknown> {
+    return {
+      nyukin_cd: 1,
+      seikyu_cd: null,
+      danka_cd: null,
+      grave_cd: null,
+      nyukin_yotei_date: null,
+      nyukin_yotei_fee: null,
+      nyukin_date: 20200101,
+      nyukin_fee: 10000,
+      fee_type: null,
+      note: null,
+      charge: null,
+      tekiyou_kubun: null,
+      seikyu_kubun: null,
+      ...overrides,
+    };
+  }
+
+  it('terminated danka の入金は grave_cd でリンク可能でもスキップする', async () => {
+    const paymentCreate = jest.fn().mockResolvedValue({ id: 'pay-1' });
+    const prisma = {
+      customer: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]),
+      },
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      billing: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'bill-1', legacy_seikyu_cd: 900 }]),
+      },
+      payment: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: paymentCreate,
+        count: jest.fn().mockResolvedValue(0), // assertNoOrphanRows 用
+      },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery
+      // ① SELECT danka_cd FROM t_danka WHERE del_flg = 2
+      .mockResolvedValueOnce([{ danka_cd: 200 }])
+      // ② SELECT * FROM t_nyukin ...
+      .mockResolvedValueOnce([
+        // 終了顧客の旧入金: grave_cd=500 は contractPlot にリンク可能だが取り込まない（Q19）
+        buildNyukinRow({ nyukin_cd: 10, danka_cd: 200, grave_cd: 500 }),
+        // 通常の入金: 取り込む
+        buildNyukinRow({ nyukin_cd: 11, seikyu_cd: 900, danka_cd: 100, grave_cd: 500 }),
+      ]);
+
+    const result = await stepPayment.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    expect(result.inserted).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.notes?.['skip_terminated_danka']).toBe(1);
+    expect(paymentCreate).toHaveBeenCalledTimes(1);
+    expect(paymentCreate.mock.calls[0][0].data.legacy_nyukin_cd).toBe(11);
+  });
+});


### PR DESCRIPTION
## 概要

業務確認シート回答（2026-06-07回収）のうち、レガシー移行スコープに関わる2点を反映する。

| 業務回答 | 反映 |
|---|---|
| Q21: 終了顧客150件（`t_danka.del_flg=2`）は「**取り込む**。解約者で情報まとめる」 | step04 で `is_terminated=true` 付きで取込 |
| Q19: もう使っていない区画あての昔の入金記録（約35件）は「**取り込まない**」 | step11 で terminated danka の入金を明示除外 |

## 変更内容

- **`Customer.is_terminated`** カラム追加（migration 同梱、default false）
- **step04**: `del_flg=2` を取込対象に追加。`idMaps.customer` には載せず、契約/ロール/請求/入金のリンク対象外とする（step05/06/07/10/11 の挙動は現役顧客について不変）。旧運用は解約時に人情報を消すため（Q18/Q20）、氏名・住所欠損はプレースホルダ/空文字で受け入れ、「解約場所が分かるように」旧区画cdを notes に記録
- **step11**: terminated danka の旧入金を danka 単位で明示除外。従来の案A（billing_id=NULL 直リンク保存、#126）は Q19 回答により廃止。grave_cd 経由で空き器契約（vacant ContractPlot）へ誤リンクされるのも防ぐ
- **id-map-loader**: `rebuildIdMap('customer')`（resume 用）から `is_terminated=true` を除外し、`--only` 再開時も同一挙動を保証
- **step13 summary**: `terminated_customers` を新旧別掲し件数突き合わせ可能に

## スコープ外（別issueで対応）

- **family 91件の取込**: `FamilyContact.contract_plot_id` が NOT NULL のため、解約者の家族連絡先は契約区画に紐づけられない（空き器契約への誤リンクは不可）。nullable 化＋解約者情報の参照UIとあわせて別issueで設計する
- **解約者一覧（「解約者で情報まとめる」）のUI**: 同上の別issueで対応

## テスト

- 新規 `tests/scripts/legacy-migration/steps/terminated-customer.test.ts`（5件）
  - is_terminated 付与・idMaps 非掲載・notes 手がかり・プレースホルダ取込・現役顧客の従来挙動回帰なし・dry-run・Q19除外（grave_cd リンク可能でもスキップ）
- 全1134テスト pass / `tsc --noEmit` clean / lint clean
- （備考）`scripts/legacy-migration/tsconfig.check.json` での `cleanup-legacy-data.ts` の readonly エラーは main 由来の既存事象でCI gate 外・本PRと無関係

## 本番反映

#163 の本投入時に `migrate deploy`（is_terminated カラム）＋ 移行スクリプト実行で反映される。既存投入済みデータがある場合も step04 は冪等（legacy_danka_cd で skip）。

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)