### PR TITLE
fix(collective-burials): 合祀請求予定日を契約日起点に変更（業務確認反映）

### DIFF
--- a/scripts/backfill-collective-burial-schedule.ts
+++ b/scripts/backfill-collective-burial-schedule.ts
@@ -1,0 +1,99 @@
+/**
+ * 合祀請求予定日のバックフィルスクリプト（#164）
+ *
+ * 請求起点を「埋葬上限到達日」から「契約日」へ変更したことに伴い、
+ * 旧ロジック下で billing_scheduled_date が null のままの合祀情報を
+ * 契約日起点（contract_date + validity_period_years）で埋める。
+ *
+ * - billing_scheduled_date が **null の行のみ**対象（手動の例外設定や
+ *   旧ロジックで設定済みの値は上書きしない）
+ * - 契約日が未設定の区画はスキップ（契約日設定時に updatePlot が再計算する）
+ *
+ * 使い方:
+ *   npx ts-node scripts/backfill-collective-burial-schedule.ts           # dry-run（対象の表示のみ）
+ *   npx ts-node scripts/backfill-collective-burial-schedule.ts --apply   # 実際に更新
+ */
+
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+import { resolveBillingScheduledDate } from '../src/collective-burials/utils';
+
+const APPLY = process.argv.includes('--apply');
+
+export async function backfillCollectiveBurialSchedule(
+  prisma: PrismaClient,
+  apply: boolean = APPLY
+): Promise<{
+  scanned: number;
+  updated: number;
+  skippedNoContractDate: number;
+}> {
+  const targets = await prisma.collectiveBurial.findMany({
+    where: {
+      deleted_at: null,
+      billing_scheduled_date: null,
+      contractPlot: { deleted_at: null },
+    },
+    include: {
+      contractPlot: { select: { contract_date: true } },
+    },
+  });
+
+  let updated = 0;
+  let skippedNoContractDate = 0;
+
+  for (const cb of targets) {
+    const scheduled = resolveBillingScheduledDate(
+      cb.contractPlot.contract_date,
+      cb.validity_period_years
+    );
+    if (!scheduled) {
+      skippedNoContractDate++;
+      console.log(`  skip (契約日未設定): collective_burial=${cb.id}`);
+      continue;
+    }
+
+    console.log(
+      `  ${apply ? 'update' : 'would update'}: collective_burial=${cb.id} ` +
+        `billing_scheduled_date=${scheduled.toISOString().split('T')[0]} ` +
+        `(契約日 + ${cb.validity_period_years}年)`
+    );
+    if (apply) {
+      await prisma.collectiveBurial.update({
+        where: { id: cb.id },
+        data: { billing_scheduled_date: scheduled },
+      });
+    }
+    updated++;
+  }
+
+  return { scanned: targets.length, updated, skippedNoContractDate };
+}
+
+async function main(): Promise<void> {
+  const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+  const prisma = new PrismaClient({ adapter });
+
+  console.log(`合祀請求予定日バックフィル（#164、${APPLY ? 'APPLY' : 'dry-run'}）`);
+  try {
+    const result = await backfillCollectiveBurialSchedule(prisma);
+    console.log(
+      `完了: 対象 ${result.scanned} 件 / ${APPLY ? '更新' : '更新予定'} ${result.updated} 件 / ` +
+        `契約日未設定スキップ ${result.skippedNoContractDate} 件`
+    );
+    if (!APPLY && result.updated > 0) {
+      console.log('実際に更新するには --apply を付けて再実行してください。');
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -6,7 +6,7 @@ import { Request, Response, NextFunction } from 'express';
 import { BillingStatus } from '@prisma/client';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
 import prisma from '../db/prisma';
-import { updateCollectiveBurialCount } from './utils';
+import { updateCollectiveBurialCount, resolveBillingScheduledDate } from './utils';
 
 /** リクエストボディの型（Express の req.body は any のため、境界で明示的に型付けする） */
 interface CreateCollectiveBurialBody {
@@ -322,6 +322,12 @@ export const createCollectiveBurial = async (
       throw new ValidationError('この契約区画には既に合祀情報が登録されています');
     }
 
+    // 請求予定日は契約日起点で導出する（#164）。契約日未設定なら null（契約日設定時に再計算）
+    const billingScheduledDate = resolveBillingScheduledDate(
+      contractPlot.contract_date,
+      validityPeriodYears
+    );
+
     // 合祀情報作成（ソフトデリート済み行があれば新規値で復活させる）
     const collectiveBurial = existingCollectiveBurial
       ? await prisma.collectiveBurial.update({
@@ -331,7 +337,7 @@ export const createCollectiveBurial = async (
             current_burial_count: 0,
             validity_period_years: validityPeriodYears,
             capacity_reached_date: null,
-            billing_scheduled_date: null,
+            billing_scheduled_date: billingScheduledDate,
             billing_status: 'pending',
             billing_amount: billingAmount || null,
             notes: notes || null,
@@ -344,16 +350,17 @@ export const createCollectiveBurial = async (
             burial_capacity: burialCapacity,
             current_burial_count: 0,
             validity_period_years: validityPeriodYears,
+            billing_scheduled_date: billingScheduledDate,
             billing_status: 'pending',
             billing_amount: billingAmount || null,
             notes: notes || null,
           },
         });
 
-    // 実埋葬者から件数・上限到達日・請求予定日を再同期する（#281）。
+    // 実埋葬者から件数・上限到達日を再同期する（#281）。
     // BuriedPerson は ContractPlot 紐付けのため合祀のソフトデリートでは消えない。
-    // 復活時に 0 固定のままだと「count=0 なのに埋葬者一覧に実データが並ぶ」矛盾や、
-    // 上限到達済みでも billing_scheduled_date が null でゆうちょ請求対象から漏れる。
+    // 復活時に 0 固定のままだと「count=0 なのに埋葬者一覧に実データが並ぶ」矛盾が出る。
+    // （請求予定日は契約日起点（#164）のため同期では変更されない）
     const synced = await updateCollectiveBurialCount(prisma, contractPlotId);
     const result = synced ?? collectiveBurial;
 
@@ -397,9 +404,10 @@ export const updateCollectiveBurial = async (
       notes,
     } = req.body as UpdateCollectiveBurialBody;
 
-    // 存在確認
+    // 存在確認（契約日起点の請求予定日再計算用に contractPlot も取得 #164）
     const existing = await prisma.collectiveBurial.findFirst({
       where: { id, deleted_at: null },
+      include: { contractPlot: { select: { contract_date: true } } },
     });
 
     if (!existing) {
@@ -428,9 +436,19 @@ export const updateCollectiveBurial = async (
         : null;
     }
     if (billingScheduledDate !== undefined) {
+      // 手動指定（例外運用: 決まった年数より短くする等、業務確認 2026-06-07 Q17）を優先
       updateData['billing_scheduled_date'] = billingScheduledDate
         ? new Date(billingScheduledDate)
         : null;
+    } else if (
+      validityPeriodYears !== undefined &&
+      validityPeriodYears !== existing.validity_period_years
+    ) {
+      // 有効期間が変わった場合は契約日起点で請求予定日を再計算する（#164）
+      updateData['billing_scheduled_date'] = resolveBillingScheduledDate(
+        existing.contractPlot.contract_date,
+        validityPeriodYears
+      );
     }
     if (billingStatus !== undefined) updateData['billing_status'] = billingStatus;
     if (billingAmount !== undefined) updateData['billing_amount'] = billingAmount;

--- a/src/collective-burials/utils.ts
+++ b/src/collective-burials/utils.ts
@@ -3,18 +3,36 @@ import { todayJstAsUtcDate, addYearsUtc } from '../utils/dateUtils';
 
 /**
  * 請求予定日を計算
- * @param capacityReachedDate 上限到達日（UTC 00:00 正規化済みの Date を渡すこと #214）
+ *
+ * 起点は契約日（#164、業務確認 2026-06-07: 合祀は契約から一定年数後・年数はお墓のタイプで決まる。
+ * 旧設計の「埋葬上限到達日」起点は廃止 — 埋葬者数に依存すると上限未到達の区画で
+ * 請求予定日が永久に null になり請求が発火しない）。
+ *
+ * @param baseDate 起点日（契約日。UTC 00:00 正規化済みの Date を渡すこと #214）
  * @param validityPeriodYears 有効期間（年単位）
  * @returns 請求予定日（UTC 00:00 を維持）
  */
 export const calculateBillingScheduledDate = (
-  capacityReachedDate: Date,
+  baseDate: Date,
   validityPeriodYears: number
 ): Date => {
   // setFullYear（ローカル時刻ベース）は JST 環境で @db.Date 保存時に
   // 前日へずれるため、UTC ベースで年加算する（#214）
-  return addYearsUtc(capacityReachedDate, validityPeriodYears);
+  return addYearsUtc(baseDate, validityPeriodYears);
 };
+
+/**
+ * 契約日と有効期間から請求予定日を導出する（#164: 契約日起点）
+ *
+ * @param contractDate 契約日（未設定なら null → 請求予定日も null。
+ *   契約日が後から設定された時点で再計算する運用）
+ * @param validityPeriodYears 有効期間（年単位）
+ */
+export const resolveBillingScheduledDate = (
+  contractDate: Date | null,
+  validityPeriodYears: number
+): Date | null =>
+  contractDate ? calculateBillingScheduledDate(contractDate, validityPeriodYears) : null;
 
 /**
  * 合祀情報の埋葬人数と関連日付を自動更新
@@ -43,7 +61,9 @@ export const updateCollectiveBurialCount = async (
     },
   });
 
-  // 3. 上限到達判定と日付計算
+  // 3. 上限到達判定と日付記録
+  // 請求予定日は契約日起点（#164）のため埋葬数では変更しない。
+  // capacity_reached_date は埋葬状況の記録としてのみ管理する。
   const capacityReached = currentCount >= collectiveBurial.burial_capacity;
   const wasCapacityReached = collectiveBurial.capacity_reached_date !== null;
 
@@ -52,18 +72,12 @@ export const updateCollectiveBurialCount = async (
   };
 
   if (capacityReached && !wasCapacityReached) {
-    // 上限到達（初回）: 上限到達日と請求予定日を設定
+    // 上限到達（初回）: 上限到達日を記録
     // @db.Date 列への保存のため JST 暦日を UTC 00:00 に正規化（#214）
-    const capacityReachedDate = todayJstAsUtcDate();
-    updateData.capacity_reached_date = capacityReachedDate;
-    updateData.billing_scheduled_date = calculateBillingScheduledDate(
-      capacityReachedDate,
-      collectiveBurial.validity_period_years
-    );
+    updateData.capacity_reached_date = todayJstAsUtcDate();
   } else if (!capacityReached && wasCapacityReached) {
-    // 上限を下回った: 日付をリセット
+    // 上限を下回った: 到達日をリセット
     updateData.capacity_reached_date = null;
-    updateData.billing_scheduled_date = null;
   }
 
   // 4. 合祀情報を更新

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -22,6 +22,7 @@ import {
   buildGravestoneInfoData,
   syncPrimaryContractorNameKana,
 } from '../utils';
+import { resolveBillingScheduledDate } from '../../collective-burials/utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
 import {
@@ -200,6 +201,11 @@ export async function createPlotCore(
         contract_plot_id: contractPlot.id,
         burial_capacity: input.collectiveBurial.burialCapacity,
         validity_period_years: input.collectiveBurial.validityPeriodYears,
+        // 請求予定日は契約日起点（#164）。契約日未設定なら null（契約日の設定時に再計算）
+        billing_scheduled_date: resolveBillingScheduledDate(
+          contractPlot.contract_date,
+          input.collectiveBurial.validityPeriodYears
+        ),
         billing_amount: input.collectiveBurial.billingAmount ?? null,
         notes: input.collectiveBurial.notes || null,
       },

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -26,7 +26,10 @@ import {
   recordHistoryBatch,
   type CreateHistoryInput,
 } from '../services/historyService';
-import { updateCollectiveBurialCount } from '../../collective-burials/utils';
+import {
+  updateCollectiveBurialCount,
+  resolveBillingScheduledDate,
+} from '../../collective-burials/utils';
 
 type Tx = Prisma.TransactionClient;
 
@@ -881,6 +884,10 @@ export async function updatePlotCore(
   }
 
   // 9. CollectiveBurial
+  // 請求予定日（billing_scheduled_date）は契約日起点の導出値（#164）。
+  // 契約日の変更・合祀情報の新規作成/復活・有効期間の変更で再計算する。
+  // PUT /collective-burials/:id での手動指定（例外運用）は、これらが変わらない限り保持される。
+  let cbScheduleRecompute = input.saleContract?.contractDate !== undefined;
   if (input.collectiveBurial !== undefined) {
     const existingCB = existingContractPlot.collectiveBurial;
 
@@ -922,6 +929,13 @@ export async function updatePlotCore(
       });
 
       if (existingCB && !existingCB.deleted_at) {
+        if (
+          input.collectiveBurial.validityPeriodYears !== undefined &&
+          input.collectiveBurial.validityPeriodYears !== existingCB.validity_period_years
+        ) {
+          // 有効期間が変わった → 請求予定日を契約日起点で再計算（#164）
+          cbScheduleRecompute = true;
+        }
         const updated = await tx.collectiveBurial.update({
           where: { id: existingCB.id },
           data: {
@@ -962,6 +976,9 @@ export async function updatePlotCore(
           );
         }
 
+        // 新規作成・復活 → 請求予定日を契約日起点で導出（#164）
+        cbScheduleRecompute = true;
+
         let cbCreated: { id: string };
         if (existingCB?.deleted_at) {
           cbCreated = await tx.collectiveBurial.update({
@@ -1000,6 +1017,29 @@ export async function updatePlotCore(
           req,
         });
       }
+    }
+  }
+
+  // 9.1. 請求予定日の再計算（#164: 契約日起点）
+  // 契約日（step 2 適用後の値）＋有効期間から導出する。合祀情報の削除時は対象なし。
+  if (cbScheduleRecompute) {
+    const aliveCB = await tx.collectiveBurial.findUnique({
+      where: { contract_plot_id: id },
+    });
+    if (aliveCB && !aliveCB.deleted_at) {
+      const effectiveContractDate =
+        updatedContractPlotRecord !== null
+          ? updatedContractPlotRecord.contract_date
+          : existingContractPlot.contract_date;
+      await tx.collectiveBurial.update({
+        where: { id: aliveCB.id },
+        data: {
+          billing_scheduled_date: resolveBillingScheduledDate(
+            effectiveContractDate,
+            aliveCB.validity_period_years
+          ),
+        },
+      });
     }
   }
 

--- a/tests/collective-burials/collectiveBurialBillingBasis.test.ts
+++ b/tests/collective-burials/collectiveBurialBillingBasis.test.ts
@@ -1,0 +1,181 @@
+/**
+ * 回帰テスト: 合祀請求予定日の契約日起点化（#164）
+ *
+ * 業務確認（2026-06-07 Q17 ほか）: 合祀は契約から一定年数後・年数はお墓のタイプで決まる。
+ * 旧設計（埋葬上限到達日起点）は埋葬者数に依存し、上限未到達の区画で請求予定日が
+ * 永久に null になり請求が発火しないため廃止。
+ *
+ * - 作成時: billing_scheduled_date = contract_date + validity_period_years
+ * - 契約日未設定: null（契約日設定時に updatePlot が再計算）
+ * - 更新時: validityPeriodYears 変更で再計算、billingScheduledDate 明示指定（例外運用）が優先
+ */
+import { Request, Response, NextFunction } from 'express';
+
+const mockPrisma = {
+  contractPlot: {
+    findFirst: jest.fn(),
+  },
+  collectiveBurial: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  buriedPerson: {
+    count: jest.fn(),
+  },
+};
+
+jest.mock('../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+jest.mock('@prisma/client', () => ({
+  BillingStatus: { pending: 'pending', billed: 'billed', paid: 'paid' },
+  PrismaClient: jest.fn(),
+}));
+
+import {
+  createCollectiveBurial,
+  updateCollectiveBurial,
+} from '../../src/collective-burials/collectiveBurialController';
+
+const CB_ROW = {
+  id: 'cb1',
+  contract_plot_id: 'cp1',
+  burial_capacity: 10,
+  current_burial_count: 0,
+  capacity_reached_date: null,
+  validity_period_years: 33,
+  billing_scheduled_date: null,
+  billing_status: 'pending',
+  billing_amount: null,
+  notes: null,
+  deleted_at: null,
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-01'),
+};
+
+describe('合祀請求予定日の契約日起点化 (#164)', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseJson: jest.Mock;
+  let responseStatus: jest.Mock;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    responseJson = jest.fn().mockReturnThis();
+    responseStatus = jest.fn().mockReturnThis();
+    mockResponse = { status: responseStatus, json: responseJson };
+    mockNext = jest.fn();
+    mockRequest = { params: {}, body: {}, query: {} };
+  });
+
+  describe('createCollectiveBurial', () => {
+    it('契約日 + 有効期間で billing_scheduled_date を導出して作成する', async () => {
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({
+        id: 'cp1',
+        contract_date: new Date('2026-04-01T00:00:00Z'),
+      });
+      mockPrisma.collectiveBurial.findUnique
+        .mockResolvedValueOnce(null) // 既存チェック
+        .mockResolvedValueOnce({ ...CB_ROW, deleted_at: null }); // 再同期内の取得
+      mockPrisma.collectiveBurial.create.mockResolvedValue(CB_ROW);
+      mockPrisma.collectiveBurial.update.mockResolvedValue(CB_ROW);
+      mockPrisma.buriedPerson.count.mockResolvedValue(0);
+
+      mockRequest.body = { contractPlotId: 'cp1', burialCapacity: 10, validityPeriodYears: 13 };
+      await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const createCall = mockPrisma.collectiveBurial.create.mock.calls[0][0];
+      expect(createCall.data.billing_scheduled_date.toISOString()).toBe('2039-04-01T00:00:00.000Z');
+    });
+
+    it('契約日未設定なら billing_scheduled_date は null（契約日設定時に再計算する運用）', async () => {
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: 'cp1', contract_date: null });
+      mockPrisma.collectiveBurial.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ ...CB_ROW, deleted_at: null });
+      mockPrisma.collectiveBurial.create.mockResolvedValue(CB_ROW);
+      mockPrisma.collectiveBurial.update.mockResolvedValue(CB_ROW);
+      mockPrisma.buriedPerson.count.mockResolvedValue(0);
+
+      mockRequest.body = { contractPlotId: 'cp1', burialCapacity: 10, validityPeriodYears: 33 };
+      await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const createCall = mockPrisma.collectiveBurial.create.mock.calls[0][0];
+      expect(createCall.data.billing_scheduled_date).toBeNull();
+    });
+  });
+
+  describe('updateCollectiveBurial', () => {
+    it('validityPeriodYears 変更時は契約日起点で billing_scheduled_date を再計算する', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue({
+        ...CB_ROW,
+        billing_scheduled_date: new Date('2059-04-01T00:00:00Z'), // 33年で計算済み
+        contractPlot: { contract_date: new Date('2026-04-01T00:00:00Z') },
+      });
+      mockPrisma.collectiveBurial.update.mockResolvedValue({
+        ...CB_ROW,
+        validity_period_years: 13,
+        billing_scheduled_date: new Date('2039-04-01T00:00:00Z'),
+        contractPlot: { physicalPlot: { plot_number: 'A-1' } },
+      });
+
+      mockRequest.params = { id: 'cb1' };
+      mockRequest.body = { validityPeriodYears: 13 };
+      await updateCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
+      expect(updateCall.data.billing_scheduled_date.toISOString()).toBe('2039-04-01T00:00:00.000Z');
+    });
+
+    it('billingScheduledDate の明示指定（例外運用）は再計算より優先される', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue({
+        ...CB_ROW,
+        contractPlot: { contract_date: new Date('2026-04-01T00:00:00Z') },
+      });
+      mockPrisma.collectiveBurial.update.mockResolvedValue({
+        ...CB_ROW,
+        validity_period_years: 13,
+        billing_scheduled_date: new Date('2035-01-01T00:00:00Z'),
+        contractPlot: { physicalPlot: { plot_number: 'A-1' } },
+      });
+
+      mockRequest.params = { id: 'cb1' };
+      // 例外: 決まった年数より短くする（業務確認 2026-06-07 Q17 備考）
+      mockRequest.body = { validityPeriodYears: 13, billingScheduledDate: '2035-01-01' };
+      await updateCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
+      expect(updateCall.data.billing_scheduled_date.toISOString()).toBe('2035-01-01T00:00:00.000Z');
+    });
+
+    it('validityPeriodYears が変わらない更新では billing_scheduled_date を触らない（手動例外の保持）', async () => {
+      mockPrisma.collectiveBurial.findFirst.mockResolvedValue({
+        ...CB_ROW,
+        billing_scheduled_date: new Date('2035-01-01T00:00:00Z'), // 手動例外
+        contractPlot: { contract_date: new Date('2026-04-01T00:00:00Z') },
+      });
+      mockPrisma.collectiveBurial.update.mockResolvedValue({
+        ...CB_ROW,
+        billing_scheduled_date: new Date('2035-01-01T00:00:00Z'),
+        contractPlot: { physicalPlot: { plot_number: 'A-1' } },
+      });
+
+      mockRequest.params = { id: 'cb1' };
+      mockRequest.body = { notes: 'メモ更新', validityPeriodYears: 33 }; // 33 → 33（変更なし）
+      await updateCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
+      expect(updateCall.data.billing_scheduled_date).toBeUndefined();
+    });
+  });
+});

--- a/tests/collective-burials/collectiveBurialFixes.test.ts
+++ b/tests/collective-burials/collectiveBurialFixes.test.ts
@@ -159,9 +159,12 @@ describe('collectiveBurialController — バグ修正回帰', () => {
       expect(responseStatus).toHaveBeenCalledWith(201);
     });
 
-    it('復活時に残存する埋葬者から count・上限到達日・請求予定日を再同期する (#281)', async () => {
+    it('復活時に残存する埋葬者から count・上限到達日を再同期する (#281)。請求予定日は契約日起点 (#164)', async () => {
       // シナリオ: 合祀のみ削除（BuriedPerson 7名は ContractPlot 紐付けで残存）→ 同区画で再作成
-      mockPrisma.contractPlot.findFirst.mockResolvedValue({ id: 'cp1' });
+      mockPrisma.contractPlot.findFirst.mockResolvedValue({
+        id: 'cp1',
+        contract_date: new Date('2026-04-01T00:00:00Z'),
+      });
       // 1回目: 既存チェック（ソフトデリート済み行）/ 2回目: 再同期内の取得（復活済み行）
       mockPrisma.collectiveBurial.findUnique
         .mockResolvedValueOnce({ ...CB_ROW, deleted_at: new Date('2026-05-01') })
@@ -173,7 +176,6 @@ describe('collectiveBurialController — バグ修正回帰', () => {
         burial_capacity: 5,
         current_burial_count: 7,
         capacity_reached_date: new Date('2026-06-06'),
-        billing_scheduled_date: new Date('2059-06-06'),
       };
       mockPrisma.collectiveBurial.update
         .mockResolvedValueOnce(restoredRow)
@@ -183,12 +185,18 @@ describe('collectiveBurialController — バグ修正回帰', () => {
       mockRequest.body = { ...validBody, burialCapacity: 5 };
       await createCollectiveBurial(mockRequest as Request, mockResponse as Response, mockNext);
 
-      // 再同期 update（2回目）が実埋葬者数で行われ、上限到達日・請求予定日もセットされること
       expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledTimes(2);
+
+      // 復活 update（1回目）で請求予定日が契約日起点で導出されること（#164: 2026-04-01 + 33年）
+      const reviveCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
+      expect(reviveCall.data.billing_scheduled_date.toISOString()).toBe('2059-04-01T00:00:00.000Z');
+
+      // 再同期 update（2回目）が実埋葬者数で行われ、上限到達日がセットされること。
+      // 請求予定日は契約日起点（#164）のため再同期では変更されない
       const syncCall = mockPrisma.collectiveBurial.update.mock.calls[1][0];
       expect(syncCall.data).toMatchObject({ current_burial_count: 7 });
       expect(syncCall.data.capacity_reached_date).toBeInstanceOf(Date);
-      expect(syncCall.data.billing_scheduled_date).toBeInstanceOf(Date);
+      expect(syncCall.data.billing_scheduled_date).toBeUndefined();
 
       // レスポンスは再同期後の値（count=0 固定でない）こと
       expect(responseStatus).toHaveBeenCalledWith(201);
@@ -198,7 +206,7 @@ describe('collectiveBurialController — バグ修正回帰', () => {
   });
 
   describe('syncBurialCount (#203)', () => {
-    it('上限到達後に人数が減ったら上限到達日・請求予定日がリセットされる', async () => {
+    it('上限到達後に人数が減ったら上限到達日がリセットされる（請求予定日は契約日起点で維持 #164）', async () => {
       mockPrisma.collectiveBurial.findFirst.mockResolvedValue({
         ...CB_ROW,
         current_burial_count: 10,
@@ -217,7 +225,7 @@ describe('collectiveBurialController — バグ修正回帰', () => {
         ...CB_ROW,
         current_burial_count: 9,
         capacity_reached_date: null,
-        billing_scheduled_date: null,
+        billing_scheduled_date: new Date('2058-01-01T00:00:00Z'), // 維持される
       });
 
       mockRequest.params = { id: 'cb1' };
@@ -228,10 +236,12 @@ describe('collectiveBurialController — バグ修正回帰', () => {
           data: expect.objectContaining({
             current_burial_count: 9,
             capacity_reached_date: null,
-            billing_scheduled_date: null,
           }),
         })
       );
+      // 請求予定日は契約日起点（#164）のため埋葬数の増減ではリセットされない
+      const syncData = mockPrisma.collectiveBurial.update.mock.calls[0][0].data;
+      expect(syncData.billing_scheduled_date).toBeUndefined();
       expect(responseJson).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
@@ -239,13 +249,13 @@ describe('collectiveBurialController — バグ修正回帰', () => {
             currentBurialCount: 9,
             capacityReached: false,
             capacityReachedDate: null,
-            billingScheduledDate: null,
+            billingScheduledDate: '2058-01-01',
           }),
         })
       );
     });
 
-    it('上限到達（初回）で上限到達日・請求予定日がセットされる', async () => {
+    it('上限到達（初回）で上限到達日がセットされる（請求予定日は変更しない #164）', async () => {
       mockPrisma.collectiveBurial.findFirst.mockResolvedValue(CB_ROW);
       mockPrisma.collectiveBurial.findUnique.mockResolvedValue(CB_ROW);
       mockPrisma.buriedPerson.count.mockResolvedValue(10);
@@ -253,7 +263,6 @@ describe('collectiveBurialController — バグ修正回帰', () => {
         ...CB_ROW,
         current_burial_count: 10,
         capacity_reached_date: new Date('2026-06-05'),
-        billing_scheduled_date: new Date('2059-06-05'),
       });
 
       mockRequest.params = { id: 'cb1' };
@@ -264,10 +273,11 @@ describe('collectiveBurialController — バグ修正回帰', () => {
           data: expect.objectContaining({
             current_burial_count: 10,
             capacity_reached_date: expect.any(Date),
-            billing_scheduled_date: expect.any(Date),
           }),
         })
       );
+      const syncData = mockPrisma.collectiveBurial.update.mock.calls[0][0].data;
+      expect(syncData.billing_scheduled_date).toBeUndefined();
       expect(responseJson).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({ capacityReached: true }),

--- a/tests/scripts/backfill-collective-burial-schedule.test.ts
+++ b/tests/scripts/backfill-collective-burial-schedule.test.ts
@@ -1,0 +1,75 @@
+/**
+ * テスト: 合祀請求予定日バックフィル（#164）
+ *
+ * - billing_scheduled_date が null の行のみ対象（手動例外・設定済みは上書きしない =
+ *   where 条件で除外）
+ * - 契約日未設定はスキップ
+ * - dry-run では update しない
+ */
+import { PrismaClient } from '@prisma/client';
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(),
+}));
+jest.mock('@prisma/adapter-pg', () => ({
+  PrismaPg: jest.fn(),
+}));
+
+import { backfillCollectiveBurialSchedule } from '../../scripts/backfill-collective-burial-schedule';
+
+const makePrisma = (targets: unknown[]) => {
+  const findMany = jest.fn().mockResolvedValue(targets);
+  const update = jest.fn().mockResolvedValue({});
+  return {
+    prisma: { collectiveBurial: { findMany, update } } as unknown as PrismaClient,
+    findMany,
+    update,
+  };
+};
+
+describe('backfillCollectiveBurialSchedule (#164)', () => {
+  it('billing_scheduled_date が null の行を契約日起点で埋める（apply）', async () => {
+    const { prisma, findMany, update } = makePrisma([
+      {
+        id: 'cb-1',
+        validity_period_years: 13,
+        contractPlot: { contract_date: new Date('2026-04-01T00:00:00Z') },
+      },
+      {
+        id: 'cb-2',
+        validity_period_years: 33,
+        contractPlot: { contract_date: null }, // 契約日未設定 → スキップ
+      },
+    ]);
+
+    const result = await backfillCollectiveBurialSchedule(prisma, true);
+
+    // 対象は null 行のみ（手動例外・設定済みの行は where で除外）
+    expect(findMany.mock.calls[0][0].where).toMatchObject({
+      deleted_at: null,
+      billing_scheduled_date: null,
+    });
+
+    expect(result).toEqual({ scanned: 2, updated: 1, skippedNoContractDate: 1 });
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0][0]).toMatchObject({ where: { id: 'cb-1' } });
+    expect(update.mock.calls[0][0].data.billing_scheduled_date.toISOString()).toBe(
+      '2039-04-01T00:00:00.000Z'
+    );
+  });
+
+  it('dry-run では update を実行しない', async () => {
+    const { prisma, update } = makePrisma([
+      {
+        id: 'cb-1',
+        validity_period_years: 13,
+        contractPlot: { contract_date: new Date('2026-04-01T00:00:00Z') },
+      },
+    ]);
+
+    const result = await backfillCollectiveBurialSchedule(prisma, false);
+
+    expect(result.updated).toBe(1); // 更新予定としてカウント
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/utils/collectiveBurialUtils.test.ts
+++ b/tests/utils/collectiveBurialUtils.test.ts
@@ -1,5 +1,6 @@
 import {
   calculateBillingScheduledDate,
+  resolveBillingScheduledDate,
   updateCollectiveBurialCount,
   isCapacityReached,
   getBillingTargets,
@@ -68,6 +69,19 @@ describe('collectiveBurialUtils', () => {
     });
   });
 
+  describe('resolveBillingScheduledDate (#164: 契約日起点)', () => {
+    it('契約日 + 有効期間で請求予定日を導出する', () => {
+      const result = resolveBillingScheduledDate(new Date('2026-04-01T00:00:00Z'), 13);
+
+      expect(result).not.toBeNull();
+      expect(result!.toISOString()).toBe('2039-04-01T00:00:00.000Z');
+    });
+
+    it('契約日が null なら null を返す（契約日設定時に再計算する運用）', () => {
+      expect(resolveBillingScheduledDate(null, 33)).toBeNull();
+    });
+  });
+
   describe('@db.Date 列への JST 暦日正規化 (#214)', () => {
     afterEach(() => {
       jest.useRealTimers();
@@ -95,7 +109,8 @@ describe('collectiveBurialUtils', () => {
       const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
       // JST の暦日 2027-01-01 が UTC 00:00 で保存される（2026-12-31 にならない）
       expect(updateCall.data.capacity_reached_date.toISOString()).toBe('2027-01-01T00:00:00.000Z');
-      expect(updateCall.data.billing_scheduled_date.toISOString()).toBe('2030-01-01T00:00:00.000Z');
+      // 請求予定日は契約日起点（#164）のため埋葬数同期では設定されない
+      expect(updateCall.data.billing_scheduled_date).toBeUndefined();
     });
 
     it('getBillingTargets の基準日も JST 暦日の UTC 00:00 に正規化される', async () => {
@@ -198,12 +213,8 @@ describe('collectiveBurialUtils', () => {
       const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
       expect(updateCall.data.current_burial_count).toBe(10);
       expect(updateCall.data.capacity_reached_date).toBeInstanceOf(Date);
-      expect(updateCall.data.billing_scheduled_date).toBeInstanceOf(Date);
-
-      // 請求予定日が3年後であることを確認
-      const capacityDate = updateCall.data.capacity_reached_date;
-      const billingDate = updateCall.data.billing_scheduled_date;
-      expect(billingDate.getFullYear()).toBe(capacityDate.getFullYear() + 3);
+      // 請求予定日は契約日起点（#164）のため上限到達では設定しない
+      expect(updateCall.data.billing_scheduled_date).toBeUndefined();
     });
 
     it('should not update dates if already reached capacity', async () => {
@@ -231,7 +242,7 @@ describe('collectiveBurialUtils', () => {
       expect(updateCall.data.current_burial_count).toBe(10);
     });
 
-    it('should reset dates when falling below capacity', async () => {
+    it('should reset capacity_reached_date when falling below capacity (請求予定日は維持 #164)', async () => {
       const mockCollectiveBurial = {
         id: 'cb-1',
         contract_plot_id: 'plot-1',
@@ -249,7 +260,6 @@ describe('collectiveBurialUtils', () => {
         ...mockCollectiveBurial,
         current_burial_count: 8,
         capacity_reached_date: null,
-        billing_scheduled_date: null,
       });
 
       await updateCollectiveBurialCount(mockPrisma as any, 'plot-1');
@@ -257,7 +267,8 @@ describe('collectiveBurialUtils', () => {
       const updateCall = mockPrisma.collectiveBurial.update.mock.calls[0][0];
       expect(updateCall.data.current_burial_count).toBe(8);
       expect(updateCall.data.capacity_reached_date).toBeNull();
-      expect(updateCall.data.billing_scheduled_date).toBeNull();
+      // 請求予定日は契約日起点（#164）のため埋葬数の増減ではリセットしない
+      expect(updateCall.data.billing_scheduled_date).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## 概要

合祀の請求予定日（`billing_scheduled_date`）の起点を**埋葬上限到達日 → 契約日**に変更する（Refs #164）。

### 業務根拠（業務確認シート回答 2026-06-07）

- Q17:「合祀までの年数は**お墓のタイプで自動的に決まる**」＋ 備考「決まった年数より短くて良い人も出るので例外対応できるように」
- 上限人数到達という概念への言及は回答全体を通じて一切なし
- 13/15年の切替（2023年4月〜）は**契約日**基準で運用されている

### 現行の重大な副作用（修正動機）

旧設計では `capacity_reached_date`（埋葬者数が上限到達した日）が立って初めて請求予定日が計算されるため、**埋葬者がほぼ0件の本番想定データでは請求予定日が永久に null → 合祀請求が一切発火しない**。

## 変更内容

| 項目 | 変更 |
|---|---|
| 導出ルール | `billing_scheduled_date = contract_date + validity_period_years`（作成時に設定） |
| `updateCollectiveBurialCount` | 埋葬数と `capacity_reached_date`（記録用）のみ管理。請求予定日に触れない |
| 再計算トリガ | 契約日変更（updatePlot step 9.1）／有効期間変更／合祀の新規・復活 |
| 例外運用（Q17備考） | `PUT /collective-burials/:id` の `billingScheduledDate` 手動指定が最優先。再計算トリガに該当しない限り保持 |
| 契約日未設定 | `null` のまま（契約日設定時に自動再計算）。レガシー契約日45%欠損を考慮 |
| バックフィル | `scripts/backfill-collective-burial-schedule.ts`（dry-run デフォルト／`--apply`、**null の行のみ**埋める＝手動値・設定済み値は不変） |

バッチ（`generate-collective-burial-invoices`）・ゆうちょ抽出は `billing_scheduled_date` 基準のため**変更不要**。API レスポンス形状も不変。

## スコープ外

- `burialCapacity` 必須の解除（年数のみ登録）: スキーマ・types・フロントの縦串になるため、V3 Q36 の回答確定後に別対応
- frontend 側の年数推定ルール修正: frontend #259

## 業務確認の残り

起点の最終確認質問を**業務確認シート第3版 Q36** に追加済み（未配布）。回答が「上限到達日から数える」だった場合は2モデル併存へ再設計する（issue は回答まで open 維持）。

## テスト

- 新規: `collectiveBurialBillingBasis.test.ts`（導出・null契約日・有効期間変更の再計算・手動例外優先・例外保持）+ `backfill-collective-burial-schedule.test.ts`
- 既存更新: utils／#281復活同期／#203同期の期待値を新仕様へ（請求予定日は同期で不変）
- **全1138テスト pass / tsc clean / lint clean**

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)