### PR TITLE
chore: TYPES_REF を a516e99 に bump（types#40 修正反映）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=6cabaf4a878db97988dca80910b60613e13bae4c
+ARG TYPES_REF=a516e99d096810ea8e783075ef6468533d3399d3
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要

zaitsu82/komine-types#41（constructionInfoSchema の zod max を DB VarChar 長に整合、Closes types#40）のマージに伴う TYPES_REF bump。

- `6cabaf4` → `a516e99d096810ea8e783075ef6468533d3399d3`

backend は `sharedConstructionInfoSchema` を plotValidation.ts で再利用しているため、この bump で Docker ビルドにも修正が反映される（CI は types main を直接 clone するため既に反映済み）。

frontend 側の同 bump: 対応 PR を並行作成。

Refs zaitsu82/komine-types#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)