### PR TITLE
fix(plots): 合祀請求予定日の再計算を契約日の実値変化でのみトリガー

### DIFF
--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -887,7 +887,18 @@ export async function updatePlotCore(
   // 請求予定日（billing_scheduled_date）は契約日起点の導出値（#164）。
   // 契約日の変更・合祀情報の新規作成/復活・有効期間の変更で再計算する。
   // PUT /collective-burials/:id での手動指定（例外運用）は、これらが変わらない限り保持される。
-  let cbScheduleRecompute = input.saleContract?.contractDate !== undefined;
+  // 判定は「フィールドの存在」ではなく「実値の変化」で行う（#313: フォームは契約日を
+  // 常時送信するため、存在判定だと保存のたびに手動例外がサイレント上書きされる）。
+  let cbScheduleRecompute = false;
+  if (input.saleContract?.contractDate !== undefined) {
+    const inputContractDateMs = input.saleContract.contractDate
+      ? new Date(input.saleContract.contractDate).getTime()
+      : null;
+    const existingContractDateMs = existingContractPlot.contract_date
+      ? existingContractPlot.contract_date.getTime()
+      : null;
+    cbScheduleRecompute = inputContractDateMs !== existingContractDateMs;
+  }
   if (input.collectiveBurial !== undefined) {
     const existingCB = existingContractPlot.collectiveBurial;
 

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -83,6 +83,11 @@ const mockPrisma: any = {
     create: jest.fn(),
     createMany: jest.fn(),
   },
+  collectiveBurial: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
   $transaction: jest.fn((callback: any) => Promise.resolve(callback(mockPrisma))),
 };
 
@@ -1574,6 +1579,116 @@ describe('Plot Controller (ContractPlot Model)', () => {
         })
       );
       expect(mockPrisma.saleContractRole.create).toHaveBeenCalledTimes(2);
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('合祀請求予定日の再計算トリガー (issue #313)', () => {
+    // フォームは契約日を常時送信するため、「存在」判定だと保存のたびに
+    // 手動例外（Q17例外運用）の billing_scheduled_date が上書きされる。
+    // 「実値の変化」でのみ再計算することを検証する。
+    const CONTRACT_DATE = '2020-04-01';
+    const buildExistingPlot = () => ({
+      id: 'cp1',
+      physical_plot_id: 'pp1',
+      contract_area_sqm: new Prisma.Decimal(3.6),
+      contract_date: new Date(CONTRACT_DATE),
+      physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+      saleContractRoles: [
+        {
+          id: 'scr1',
+          role: 'contractor',
+          customer: { id: 'c1', workInfo: null },
+          customer_id: 'c1',
+          deleted_at: null,
+        },
+      ],
+      usageFee: null,
+      managementFee: null,
+      collectiveBurial: {
+        id: 'cb1',
+        contract_plot_id: 'cp1',
+        burial_capacity: 10,
+        validity_period_years: 33,
+        // 手動例外値（契約日起点の導出値 2053-04-01 とは異なる）
+        billing_scheduled_date: new Date('2040-01-01'),
+        deleted_at: null,
+      },
+    });
+
+    it('契約日が変わらないフォーム保存では billing_scheduled_date を再計算しない（手動例外の保持）', async () => {
+      const existingPlot = buildExistingPlot();
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(existingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        ...existingPlot,
+        contract_date: new Date(CONTRACT_DATE),
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      // フォームの実挙動: 契約日を変更していなくても常時送信される
+      mockRequest.body = {
+        saleContract: { contractDate: CONTRACT_DATE },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.update).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('契約日が実際に変わった場合は billing_scheduled_date を契約日起点で再計算する', async () => {
+      const existingPlot = buildExistingPlot();
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(existingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        ...existingPlot,
+        contract_date: new Date('2021-04-01'),
+      });
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue(existingPlot.collectiveBurial);
+      mockPrisma.collectiveBurial.update.mockResolvedValue({});
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        saleContract: { contractDate: '2021-04-01' },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // 新契約日 2021-04-01 + 有効期間 33 年 = 2054-04-01
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cb1' },
+          data: { billing_scheduled_date: new Date('2054-04-01') },
+        })
+      );
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('契約日が未設定から設定された場合も再計算する', async () => {
+      const existingPlot = { ...buildExistingPlot(), contract_date: null };
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(existingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        ...existingPlot,
+        contract_date: new Date(CONTRACT_DATE),
+      });
+      mockPrisma.collectiveBurial.findUnique.mockResolvedValue(existingPlot.collectiveBurial);
+      mockPrisma.collectiveBurial.update.mockResolvedValue({});
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        saleContract: { contractDate: CONTRACT_DATE },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cb1' },
+          data: { billing_scheduled_date: new Date('2053-04-01') },
+        })
+      );
       expect(mockNext).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## 概要

Closes #313

PR #312（合祀請求を契約日起点へ・#164）の回帰修正。合祀の請求予定日を手動で例外値に設定していても（Q17例外運用）、区画フォームを保存するたびに契約日起点の値へサイレント上書きされる問題を修正。

## 原因

`updatePlot.ts` の `cbScheduleRecompute` が「リクエストに契約日フィールドが**含まれるか**（存在）」でトリガーされていた。frontend のフォームは全フィールドを常時送信するため、契約日を変更していなくても保存のたびに再計算が走り、手動例外値が喪失していた。

## 修正

- `cbScheduleRecompute` の初期値を「契約日が**実際に変化したか**」に変更
- `existingContractPlot.contract_date` と入力契約日を `getTime()` ベースで比較し、異なる場合のみ再計算
- `collectiveBurialController` の「差分があったときだけ再計算・手動例外は保持」ポリシーと一致

## テスト

回帰テスト3件追加（`tests/plots/plotController.test.ts`）:
- 契約日が変わらないフォーム保存では再計算しない（手動例外の保持）← 修正前は fail
- 契約日が実際に変わった場合は契約日起点で再計算する
- 契約日が未設定→設定された場合も再計算する

- [x] `npm test` 全 1146 テスト pass
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)