### PR TITLE
fix(scripts): verify-migration の契約者カウントから終了顧客を除外し別行で検証

### DIFF
--- a/scripts/verify-migration.ts
+++ b/scripts/verify-migration.ts
@@ -190,6 +190,7 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
     staff,
     physicalPlots,
     customers,
+    terminatedCustomers,
     applicantCustomers,
     applicantRoles,
     contractPlots,
@@ -208,8 +209,14 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
     }),
     prisma.physicalPlot.count({ where: { deleted_at: null } }),
     // 契約者由来のみ（#265）: step06 の申込者展開 Customer（1:N）を混ぜると
-    // ベースライン(t_danka=契約者のみ)超過で誤 ❌ になるため legacy_danka_cd で絞る
-    prisma.customer.count({ where: { deleted_at: null, legacy_danka_cd: { not: null } } }),
+    // ベースライン(t_danka=契約者のみ)超過で誤 ❌ になるため legacy_danka_cd で絞る。
+    // 終了顧客（is_terminated、del_flg=2 由来 #129/PR#309）も legacy_danka_cd を持つが
+    // レガシー参照値は del_flg=0 ベースのため除外し、別行で del_flg=2 と突き合わせる（#314）
+    prisma.customer.count({
+      where: { deleted_at: null, legacy_danka_cd: { not: null }, is_terminated: false },
+    }),
+    // 終了顧客（del_flg=2 由来、#129）。13-summary の terminated_customers と同じ粒度
+    prisma.customer.count({ where: { deleted_at: null, is_terminated: true } }),
     // 申込者展開 Customer は別行で検証（applicant ロール数との整合）
     prisma.customer.count({
       where: { deleted_at: null, legacy_applicant_danka_cd: { not: null } },
@@ -224,15 +231,16 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
     prisma.payment.count({ where: { deleted_at: null } }),
   ]);
 
-  // レガシー件数(del_flg=0)。接続できない場合は null。
-  const legacy = async (table: string): Promise<number | null> => {
+  // レガシー件数(既定 del_flg=0)。接続できない場合は null。
+  const legacy = async (table: string, where?: string): Promise<number | null> => {
     if (!legacyOn) return null;
-    return legacyCount(table);
+    return where ? legacyCount(table, where) : legacyCount(table);
   };
 
   const [
     legPhysical,
     legCustomer,
+    legCustomerTerminated,
     legContract,
     legFamily,
     legBuried,
@@ -242,6 +250,8 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
   ] = await Promise.all([
     legacy('m_bochi'),
     legacy('t_danka'),
+    // 終了顧客のレガシー参照値（13-summary の customer_terminated と同じ条件 #314）
+    legacy('t_danka', 'del_flg=2'),
     legacy('m_bochi'),
     legacy('t_family'),
     legacy('t_maisou'),
@@ -283,13 +293,25 @@ async function reconcileCounts(prisma: PrismaClient, legacyOn: boolean): Promise
       judgment: judgeCount(physicalPlots, legPhysical, b.insertedCounts.physical_plots),
     },
     {
-      label: 'Customer (契約者: legacy_danka_cd 有)',
+      label: 'Customer (契約者: legacy_danka_cd 有・終了顧客除く)',
       legacyTable: 't_danka',
       legacy: legCustomer,
       actual: customers,
       baselineLegacy: b.legacyCounts.customers,
       baselineInserted: b.insertedCounts.customers,
       judgment: judgeCount(customers, legCustomer, b.insertedCounts.customers),
+    },
+    {
+      // 終了顧客（del_flg=2 由来、#129/PR#309）。契約者行とは粒度を分けて
+      // レガシー del_flg=2 件数と直接突き合わせる（#314）。
+      // 確定ベースラインは未取得（約150件）のため、レガシー接続なし時は ⚠️ となる
+      label: 'Customer (終了顧客: is_terminated)',
+      legacyTable: 't_danka (del_flg=2)',
+      legacy: legCustomerTerminated,
+      actual: terminatedCustomers,
+      baselineLegacy: null,
+      baselineInserted: null,
+      judgment: judgeCount(terminatedCustomers, legCustomerTerminated, null),
     },
     {
       // 申込者展開（step06: applicant != contractor の場合の別 Customer）。

--- a/tests/scripts/verify-migration.test.ts
+++ b/tests/scripts/verify-migration.test.ts
@@ -85,4 +85,22 @@ describe('judgeCount (#223)', () => {
       expect(judgeCount(11, null, 11)).toBe('✅');
     });
   });
+
+  describe('終了顧客の別掲（#314）', () => {
+    // 修正前: 契約者カウントが is_terminated を区別せず actual≈3637(=3487+150) となり、
+    // del_flg=0 ベースのレガシー参照値 3487 と粒度不一致のまま 105% 上限ギリギリで
+    // たまたま ✅ だった（終了顧客が 5% を超えると誤 ❌）。
+    // 修正後: 契約者行は is_terminated:false で 3487、終了顧客は別行で del_flg=2 と突き合わせる。
+    it('終了顧客行: レガシー del_flg=2 件数と一致すれば ✅', () => {
+      expect(judgeCount(150, 150, null)).toBe('✅');
+    });
+
+    it('終了顧客行: 取込漏れ（0件）は ❌', () => {
+      expect(judgeCount(0, 150, null)).toBe('❌');
+    });
+
+    it('終了顧客行: レガシー接続なしでは ⚠️（確定ベースライン未取得のため）', () => {
+      expect(judgeCount(150, null, null)).toBe('⚠️');
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Closes #314

PR #309（del_flg=2 取込・#129）の周辺ツール追従漏れ。`scripts/verify-migration.ts` の契約者カウントが終了顧客（`is_terminated=true`、レガシー del_flg=2 由来）を混入したまま del_flg=0 ベースのレガシー参照値と比較しており、粒度が不一致だった。

現状 actual≈3637 vs upper=3661 でギリギリ ✅ だが、終了顧客が 5% を超えると誤 ❌ になる。#163 カットオーバー直前の検証ツールなので本投入前に解消。

## 修正

1. 契約者カウント（`Customer (契約者: legacy_danka_cd 有)`）に `is_terminated: false` を追加し、del_flg=0 ベースラインと粒度を統一
2. 13-summary と同様に終了顧客（is_terminated=true）を別行で計上し、レガシー側 `legacyCount('t_danka', 'del_flg=2')` と突き合わせる検証行を追加
   - 確定ベースラインは未取得（約150件）のため、レガシー接続なし時は ⚠️ 表示

## テスト

`tests/scripts/verify-migration.test.ts` に終了顧客別掲（#314）の判定テスト3件追加。

- [x] `npm test -- tests/scripts/verify-migration.test.ts` 18 テスト pass
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)