### PR TITLE
feat(plots): 名義変更エンドポイントを追加（契約者roleの交代＋履歴記録）

### DIFF
--- a/src/plots/controllers/changeContractor.ts
+++ b/src/plots/controllers/changeContractor.ts
@@ -1,0 +1,190 @@
+/**
+ * 名義変更エンドポイント
+ * POST /api/v1/plots/:id/change-contractor
+ *
+ * 同一 SaleContract 上で契約者（contractor role）を旧契約者から新契約者へ
+ * 交代させる（#310、業務確認 2026-06-07 Q7: 契約はそのままで契約者名だけ
+ * 書き換え、履歴情報として残す）。解約→新契約（#110 の区画再利用フロー）とは
+ * 別の操作で、契約・申込者（applicant role）・区画情報は不変のまま残る。
+ *
+ * 設計判断（issue #310 検討事項）:
+ * 「現在の契約者」の解決は全箇所 role='contractor' AND deleted_at IS NULL
+ * （created_at 昇順）に依存しているため、role 行に有効期間を持たせて現役判定を
+ * 変える案は影響範囲が広すぎる。updatePlot の roles 入替と同じ
+ * soft-delete + 新規作成方式を採り、旧 role 行には role_end_date を刻んで
+ * 保存し、History に change_reason「名義変更」で before/after を記録する。
+ * 過去の契約者は History（および soft-delete された role 行）から遡れる。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { ContractRole, ContractStatus, Prisma } from '@prisma/client';
+import prisma from '../../db/prisma';
+import { NotFoundError, ConflictError, ValidationError } from '../../middleware/errorHandler';
+import { recordEntityUpdated } from '../services/historyService';
+import { syncPrimaryContractorNameKana } from '../utils';
+import type { ChangeContractorRequest } from '../../validations/plotValidation';
+
+export const changeContractor = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id = (req.params as Record<string, string>)['id'] as string;
+    const input = req.body as ChangeContractorRequest;
+
+    // 現契約者の読取り・検証・付け替えを単一の Serializable トランザクションで
+    // 原子化する（terminateContract #278 と同方針）。並行する名義変更・解約・
+    // フォーム保存（roles 入替）と交錯すると contractor role の二重生成が成立しうる。
+    const result = await prisma.$transaction(
+      async (tx) => {
+        const contractPlot = await tx.contractPlot.findUnique({
+          where: { id, deleted_at: null },
+          include: {
+            saleContractRoles: {
+              where: { role: ContractRole.contractor, deleted_at: null },
+              include: { customer: true },
+              // 「現在の契約者」の選定順は snapshot 同期（#282/#303）と揃える
+              orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+            },
+          },
+        });
+
+        if (!contractPlot) {
+          throw new NotFoundError('指定された契約区画が見つかりません');
+        }
+
+        // 名義変更は有効な契約（active）のみ対象。空き区画には契約者がおらず、
+        // 解約済みは区画再利用フロー（#110: terminate → 新契約）が正規経路。
+        if (contractPlot.contract_status !== ContractStatus.active) {
+          throw new ConflictError(
+            `現在のステータス '${contractPlot.contract_status}' では名義変更できません（active のみ可能）`
+          );
+        }
+
+        const currentRoles = contractPlot.saleContractRoles;
+        if (currentRoles.length === 0) {
+          throw new ConflictError('現在の契約者が存在しないため名義変更できません');
+        }
+        // 複数 contractor role が併存する場合も契約の名義は一括で交代する
+        // （updatePlot の roles 全件入替と同じ考え方）。表示上の主契約者は先頭。
+        const primaryRole = currentRoles[0]!;
+
+        // 新契約者の解決: 既存顧客の指定 or 新規顧客の作成
+        let newCustomer: { id: string; name: string; name_kana: string | null };
+        if (input.newCustomerId !== undefined) {
+          const existing = await tx.customer.findUnique({
+            where: { id: input.newCustomerId, deleted_at: null },
+          });
+          if (!existing) {
+            throw new NotFoundError('指定された顧客が見つかりません');
+          }
+          // 終了顧客（is_terminated、del_flg=2 由来 #129）は契約者に指定不可
+          if (existing.is_terminated) {
+            throw new ValidationError('解約済み（終了）顧客は契約者に指定できません');
+          }
+          if (currentRoles.some((r) => r.customer_id === existing.id)) {
+            throw new ConflictError('指定された顧客は既にこの契約の契約者です');
+          }
+          newCustomer = existing;
+        } else {
+          // バリデーション（changeContractorSchema の refine）で newCustomer の存在は保証済み
+          const nc = input.newCustomer!;
+          newCustomer = await tx.customer.create({
+            data: {
+              name: nc.name,
+              name_kana: nc.nameKana,
+              birth_date: nc.birthDate ? new Date(nc.birthDate) : null,
+              gender: nc.gender || null,
+              postal_code: nc.postalCode,
+              address: nc.address,
+              address_line_2: nc.addressLine2 || null,
+              registered_postal_code: nc.registeredPostalCode || null,
+              registered_address: nc.registeredAddress || null,
+              phone_number: nc.phoneNumber ?? null,
+              fax_number: nc.faxNumber || null,
+              email: nc.email || null,
+              // 振込先情報（ゆうちょ自動払込 CSV 出力用）
+              bank_name: nc.bankName || null,
+              branch_name: nc.branchName || null,
+              account_type: nc.accountType || null,
+              account_number: nc.accountNumber || null,
+              account_holder: nc.accountHolder || null,
+              notes: nc.notes || null,
+              staff_id: nc.staffId ?? null,
+            },
+          });
+        }
+
+        const changeDate = input.changeDate ? new Date(input.changeDate) : new Date();
+
+        // 旧契約者 role を soft-delete。role_end_date に交代日を刻み、
+        // role 行自体からも在任期間を遡れるようにする
+        for (const role of currentRoles) {
+          await tx.saleContractRole.update({
+            where: { id: role.id },
+            data: { deleted_at: new Date(), role_end_date: changeDate },
+          });
+        }
+
+        // 新契約者 role を作成（申込者 role は不変: 申込者 = 最初の契約者のまま残す）
+        const newRole = await tx.saleContractRole.create({
+          data: {
+            contract_plot_id: id,
+            customer_id: newCustomer.id,
+            role: ContractRole.contractor,
+            role_start_date: changeDate,
+          },
+        });
+
+        // History に change_reason「名義変更」で before/after を記録（過去の契約者を遡る用）
+        await recordEntityUpdated(tx, {
+          entityType: 'ContractPlot',
+          entityId: id,
+          physicalPlotId: contractPlot.physical_plot_id,
+          contractPlotId: id,
+          beforeRecord: {
+            contractor_customer_id: primaryRole.customer_id,
+            contractor_name: primaryRole.customer.name,
+            contractor_name_kana: primaryRole.customer.name_kana,
+          },
+          afterRecord: {
+            contractor_customer_id: newCustomer.id,
+            contractor_name: newCustomer.name,
+            contractor_name_kana: newCustomer.name_kana,
+          },
+          changeReason: input.reason ? `名義変更: ${input.reason}` : '名義変更',
+          req,
+        });
+
+        // 契約者名カナ snapshot（#282/#297）を新契約者で再同期
+        await syncPrimaryContractorNameKana(tx, id);
+
+        return {
+          oldContractor: {
+            customerId: primaryRole.customer_id,
+            name: primaryRole.customer.name,
+          },
+          newContractor: {
+            customerId: newCustomer.id,
+            name: newCustomer.name,
+            roleId: newRole.id,
+          },
+          changeDate,
+        };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+
+    res.status(200).json({
+      success: true,
+      data: {
+        message: '名義変更を実施しました',
+        id,
+        ...result,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/plots/controllers/index.ts
+++ b/src/plots/controllers/index.ts
@@ -11,6 +11,7 @@ export { updatePlot } from './updatePlot';
 export { deletePlot } from './deletePlot';
 export { restoreContract } from './restoreContract';
 export { terminateContract } from './terminateContract';
+export { changeContractor } from './changeContractor';
 export { getPlotContracts } from './getPlotContracts';
 export { createPlotContract } from './createPlotContract';
 export { getPlotInventory } from './getPlotInventory';

--- a/src/plots/plotRoutes.ts
+++ b/src/plots/plotRoutes.ts
@@ -8,6 +8,7 @@ import {
   deletePlot,
   restoreContract,
   terminateContract,
+  changeContractor,
   getPlotContracts,
   createPlotContract,
   getPlotInventory,
@@ -29,6 +30,7 @@ import {
   createPlotContractSchema,
   restoreContractSchema,
   terminateContractSchema,
+  changeContractorSchema,
 } from '../validations/plotValidation';
 import {
   inventorySummaryQuerySchema,
@@ -152,6 +154,15 @@ router.post(
   requirePermission(['operator', 'manager', 'admin']),
   validate({ params: plotIdParamsSchema, body: restoreContractSchema }),
   withLogging('Plots', 'restoreContract', restoreContract)
+);
+
+// 名義変更（契約はそのままで契約者roleを交代 #310。解約→新契約の区画再利用とは別経路）
+router.post(
+  '/:id/change-contractor',
+  authenticate,
+  requirePermission(['operator', 'manager', 'admin']),
+  validate({ params: plotIdParamsSchema, body: changeContractorSchema }),
+  withLogging('Plots', 'changeContractor', changeContractor)
 );
 
 // 物理区画の契約一覧取得

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -340,6 +340,24 @@ export const terminateContractSchema = z.object({
 });
 
 /**
+ * 名義変更リクエストのバリデーションスキーマ（#310）
+ * POST /plots/:id/change-contractor
+ * 新契約者は既存顧客の指定（newCustomerId）か新規顧客の作成（newCustomer）の
+ * どちらか一方のみ。reason は任意（履歴の change_reason に「名義変更」へ付記）。
+ */
+export const changeContractorSchema = z
+  .object({
+    newCustomerId: uuidSchema.optional(),
+    newCustomer: customerSchema.optional(),
+    changeDate: optionalDateSchema.nullable(),
+    reason: z.string().trim().max(200, '名義変更理由は200文字以内で入力してください').optional(),
+  })
+  .refine((v) => (v.newCustomerId !== undefined) !== (v.newCustomer !== undefined), {
+    message:
+      '新契約者は newCustomerId（既存顧客）または newCustomer（新規顧客）のどちらか一方を指定してください',
+  });
+
+/**
  * 型エクスポート
  */
 export type PlotSearchQuery = z.infer<typeof plotSearchQuerySchema>;
@@ -349,6 +367,7 @@ export type UpdatePlotRequest = z.infer<typeof updatePlotSchema>;
 export type CreatePlotContractRequest = z.infer<typeof createPlotContractSchema>;
 export type RestoreContractRequest = z.infer<typeof restoreContractSchema>;
 export type TerminateContractRequest = z.infer<typeof terminateContractSchema>;
+export type ChangeContractorRequest = z.infer<typeof changeContractorSchema>;
 
 // dateSchema も従来通り再エクスポート（他モジュールからの参照互換性維持）
 export { dateSchema };

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -527,6 +527,129 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /api/v1/plots/{id}/change-contractor:
+    post:
+      tags:
+        - Plots
+      summary: 名義変更（契約者roleの交代）
+      description: |
+        同一販売契約上で契約者（contractor role）を旧契約者から新契約者へ交代させる（#310）。
+        契約・申込者（applicant role）・区画情報は不変のまま残り、
+        変更は履歴に change_reason「名義変更」で記録される（過去の契約者を遡れる）。
+        新契約者は既存顧客の指定（newCustomerId）か新規顧客の作成（newCustomer）の
+        どちらか一方のみ指定可能。
+        現在のステータスが active でない場合、または現在の契約者が存在しない場合は 409 を返す。
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: 契約区画ID（UUID）
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newCustomerId:
+                  type: string
+                  format: uuid
+                  description: 新契約者にする既存顧客のID（newCustomer と排他）
+                newCustomer:
+                  type: object
+                  description: 新契約者として新規作成する顧客情報（newCustomerId と排他）
+                  required:
+                    - name
+                    - nameKana
+                    - postalCode
+                    - address
+                  properties:
+                    name:
+                      type: string
+                      maxLength: 100
+                    nameKana:
+                      type: string
+                      maxLength: 100
+                    postalCode:
+                      type: string
+                    address:
+                      type: string
+                      maxLength: 200
+                    phoneNumber:
+                      type: string
+                      nullable: true
+                changeDate:
+                  type: string
+                  format: date
+                  nullable: true
+                  description: 名義変更日（旧roleのrole_end_date / 新roleのrole_start_date。省略時は当日）
+                reason:
+                  type: string
+                  maxLength: 200
+                  description: 名義変更理由（任意。履歴の change_reason に「名義変更」へ付記）
+      responses:
+        "200":
+          description: 名義変更成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                        example: 名義変更を実施しました
+                      id:
+                        type: string
+                        format: uuid
+                      oldContractor:
+                        type: object
+                        properties:
+                          customerId:
+                            type: string
+                            format: uuid
+                          name:
+                            type: string
+                      newContractor:
+                        type: object
+                        properties:
+                          customerId:
+                            type: string
+                            format: uuid
+                          name:
+                            type: string
+                          roleId:
+                            type: string
+                            format: uuid
+                      changeDate:
+                        type: string
+                        format: date-time
+        "400":
+          description: バリデーションエラー（newCustomerId/newCustomer の排他違反、解約済み顧客の指定等）
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: active 以外のステータス / 現契約者不在 / 指定顧客が既に契約者
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/v1/plots/{id}/contracts:
     get:
       tags:

--- a/tests/plots/controllers/changeContractor.test.ts
+++ b/tests/plots/controllers/changeContractor.test.ts
@@ -1,0 +1,445 @@
+/**
+ * changeContractor コントローラのテスト（#310）
+ * POST /api/v1/plots/:id/change-contractor
+ *
+ * 名義変更 = 同一販売契約上で contractor role を旧契約者から新契約者へ交代。
+ * 契約・申込者（applicant role）・区画情報は不変。履歴に change_reason
+ * 「名義変更」で before/after を記録する。
+ */
+
+import { Request, Response } from 'express';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma: any = {
+  contractPlot: {
+    findUnique: jest.fn(),
+  },
+  customer: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
+  saleContractRole: {
+    update: jest.fn(),
+    create: jest.fn(),
+  },
+  $transaction: jest.fn((callback: any) => Promise.resolve(callback(mockPrisma))),
+};
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: {
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
+  },
+  ContractStatus: {
+    vacant: 'vacant',
+    active: 'active',
+    terminated: 'terminated',
+  },
+  ContractRole: {
+    applicant: 'applicant',
+    contractor: 'contractor',
+  },
+}));
+
+const mockRecordEntityUpdated = jest.fn();
+jest.mock('../../../src/plots/services/historyService', () => ({
+  recordEntityUpdated: (...args: unknown[]) => mockRecordEntityUpdated(...args),
+}));
+
+const mockSyncPrimaryContractorNameKana = jest.fn();
+jest.mock('../../../src/plots/utils', () => ({
+  syncPrimaryContractorNameKana: (...args: unknown[]) => mockSyncPrimaryContractorNameKana(...args),
+}));
+
+import { changeContractor } from '../../../src/plots/controllers/changeContractor';
+import {
+  NotFoundError,
+  ConflictError,
+  ValidationError,
+} from '../../../src/middleware/errorHandler';
+
+const buildRes = (): Response => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  return res;
+};
+
+const buildReq = (body: Record<string, unknown>): Request => {
+  const req = {
+    params: { id: 'cp-1' },
+    body,
+    user: {
+      id: 1,
+      email: 'staff@example.com',
+      name: 'Test Staff',
+      role: 'operator',
+      is_active: true,
+      supabase_uid: 'sup-1',
+    },
+    ip: '127.0.0.1',
+    get: jest.fn().mockReturnValue(undefined),
+  } as unknown as Request;
+  return req;
+};
+
+const OLD_CUSTOMER = {
+  id: 'cust-old',
+  name: '山田太郎',
+  name_kana: 'ヤマダタロウ',
+};
+
+const buildContractPlot = (overrides: Record<string, unknown> = {}) => ({
+  id: 'cp-1',
+  physical_plot_id: 'pp-1',
+  contract_status: 'active',
+  deleted_at: null,
+  saleContractRoles: [
+    {
+      id: 'role-old',
+      contract_plot_id: 'cp-1',
+      customer_id: 'cust-old',
+      role: 'contractor',
+      role_start_date: null,
+      role_end_date: null,
+      deleted_at: null,
+      customer: OLD_CUSTOMER,
+    },
+  ],
+  ...overrides,
+});
+
+const NEW_CUSTOMER = {
+  id: 'cust-new',
+  name: '佐藤次郎',
+  name_kana: 'サトウジロウ',
+  is_terminated: false,
+  deleted_at: null,
+};
+
+describe('changeContractor (#310)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation((callback: any) =>
+      Promise.resolve(callback(mockPrisma))
+    );
+    mockPrisma.saleContractRole.update.mockResolvedValue({});
+    mockPrisma.saleContractRole.create.mockResolvedValue({
+      id: 'role-new',
+      contract_plot_id: 'cp-1',
+      customer_id: 'cust-new',
+      role: 'contractor',
+    });
+  });
+
+  describe('成功ケース（既存顧客の指定）', () => {
+    it('旧roleをsoft-delete + role_end_date設定し、新roleを作成して履歴に「名義変更」を記録する', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.findUnique.mockResolvedValue(NEW_CUSTOMER);
+
+      const req = buildReq({ newCustomerId: 'cust-new', changeDate: '2026-06-01' });
+      const res = buildRes();
+      const next = jest.fn();
+
+      await changeContractor(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+
+      // Serializable tx で原子化されている
+      expect(mockPrisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        isolationLevel: 'Serializable',
+      });
+
+      // 旧 role: soft-delete + role_end_date = changeDate
+      expect(mockPrisma.saleContractRole.update).toHaveBeenCalledWith({
+        where: { id: 'role-old' },
+        data: {
+          deleted_at: expect.any(Date),
+          role_end_date: new Date('2026-06-01'),
+        },
+      });
+
+      // 新 role: contractor として作成、role_start_date = changeDate
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledWith({
+        data: {
+          contract_plot_id: 'cp-1',
+          customer_id: 'cust-new',
+          role: 'contractor',
+          role_start_date: new Date('2026-06-01'),
+        },
+      });
+
+      // 新規 Customer は作成しない
+      expect(mockPrisma.customer.create).not.toHaveBeenCalled();
+
+      // 履歴: change_reason「名義変更」+ before/after で過去の契約者を遡れる
+      expect(mockRecordEntityUpdated).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({
+          entityType: 'ContractPlot',
+          entityId: 'cp-1',
+          changeReason: '名義変更',
+          beforeRecord: {
+            contractor_customer_id: 'cust-old',
+            contractor_name: '山田太郎',
+            contractor_name_kana: 'ヤマダタロウ',
+          },
+          afterRecord: {
+            contractor_customer_id: 'cust-new',
+            contractor_name: '佐藤次郎',
+            contractor_name_kana: 'サトウジロウ',
+          },
+        })
+      );
+
+      // 契約者名カナ snapshot の再同期（#282/#297）
+      expect(mockSyncPrimaryContractorNameKana).toHaveBeenCalledWith(mockPrisma, 'cp-1');
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: expect.objectContaining({
+          message: '名義変更を実施しました',
+          id: 'cp-1',
+          oldContractor: { customerId: 'cust-old', name: '山田太郎' },
+          newContractor: expect.objectContaining({
+            customerId: 'cust-new',
+            name: '佐藤次郎',
+            roleId: 'role-new',
+          }),
+        }),
+      });
+    });
+
+    it('reason 指定時は change_reason に「名義変更: 理由」で付記される', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.findUnique.mockResolvedValue(NEW_CUSTOMER);
+
+      const req = buildReq({ newCustomerId: 'cust-new', reason: '相続のため' });
+      const res = buildRes();
+      const next = jest.fn();
+
+      await changeContractor(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(mockRecordEntityUpdated).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({ changeReason: '名義変更: 相続のため' })
+      );
+    });
+
+    it('changeDate 省略時は当日が role_end_date / role_start_date に入る', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.findUnique.mockResolvedValue(NEW_CUSTOMER);
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const res = buildRes();
+      const next = jest.fn();
+
+      await changeContractor(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ role_start_date: expect.any(Date) }),
+      });
+    });
+
+    it('複数 contractor role が併存する場合は全件交代する（applicant は対象外）', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(
+        buildContractPlot({
+          saleContractRoles: [
+            {
+              id: 'role-old',
+              customer_id: 'cust-old',
+              role: 'contractor',
+              deleted_at: null,
+              customer: OLD_CUSTOMER,
+            },
+            {
+              id: 'role-old-2',
+              customer_id: 'cust-old-2',
+              role: 'contractor',
+              deleted_at: null,
+              customer: { id: 'cust-old-2', name: '山田花子', name_kana: 'ヤマダハナコ' },
+            },
+          ],
+        })
+      );
+      mockPrisma.customer.findUnique.mockResolvedValue(NEW_CUSTOMER);
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const res = buildRes();
+      const next = jest.fn();
+
+      await changeContractor(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(mockPrisma.saleContractRole.update).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledTimes(1);
+      // 履歴の before は主契約者（先頭）
+      expect(mockRecordEntityUpdated).toHaveBeenCalledWith(
+        mockPrisma,
+        expect.objectContaining({
+          beforeRecord: expect.objectContaining({ contractor_customer_id: 'cust-old' }),
+        })
+      );
+    });
+  });
+
+  describe('成功ケース（新規顧客の作成）', () => {
+    it('newCustomer 指定で Customer を新規作成して契約者にする', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.create.mockResolvedValue({
+        id: 'cust-created',
+        name: '鈴木三郎',
+        name_kana: 'スズキサブロウ',
+      });
+      mockPrisma.saleContractRole.create.mockResolvedValue({
+        id: 'role-new',
+        customer_id: 'cust-created',
+        role: 'contractor',
+      });
+
+      const req = buildReq({
+        newCustomer: {
+          name: '鈴木三郎',
+          nameKana: 'スズキサブロウ',
+          postalCode: '8100001',
+          address: '福岡県福岡市中央区天神1-1-1',
+          phoneNumber: '092-111-2222',
+        },
+      });
+      const res = buildRes();
+      const next = jest.fn();
+
+      await changeContractor(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(mockPrisma.customer.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.customer.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: '鈴木三郎',
+          name_kana: 'スズキサブロウ',
+          postal_code: '8100001',
+          address: '福岡県福岡市中央区天神1-1-1',
+          phone_number: '092-111-2222',
+        }),
+      });
+      expect(mockPrisma.saleContractRole.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ customer_id: 'cust-created', role: 'contractor' }),
+      });
+    });
+  });
+
+  describe('失敗ケース', () => {
+    it('契約区画が存在しない場合は NotFoundError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(null);
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+      expect(mockPrisma.saleContractRole.update).not.toHaveBeenCalled();
+    });
+
+    it.each(['vacant', 'terminated'])('contract_status=%s では ConflictError', async (status) => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(
+        buildContractPlot({ contract_status: status })
+      );
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ConflictError));
+      expect(mockPrisma.saleContractRole.update).not.toHaveBeenCalled();
+    });
+
+    it('現在の契約者が存在しない場合は ConflictError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(
+        buildContractPlot({ saleContractRoles: [] })
+      );
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ConflictError));
+    });
+
+    it('指定した既存顧客が存在しない場合は NotFoundError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.findUnique.mockResolvedValue(null);
+
+      const req = buildReq({ newCustomerId: 'cust-missing' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(NotFoundError));
+      expect(mockPrisma.saleContractRole.update).not.toHaveBeenCalled();
+    });
+
+    it('終了顧客（is_terminated）を指定した場合は ValidationError（#129）', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.findUnique.mockResolvedValue({
+        ...NEW_CUSTOMER,
+        is_terminated: true,
+      });
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+      expect(mockPrisma.saleContractRole.update).not.toHaveBeenCalled();
+    });
+
+    it('指定顧客が既に契約者の場合は ConflictError', async () => {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(buildContractPlot());
+      mockPrisma.customer.findUnique.mockResolvedValue({
+        ...NEW_CUSTOMER,
+        id: 'cust-old',
+      });
+
+      const req = buildReq({ newCustomerId: 'cust-old' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(ConflictError));
+      expect(mockPrisma.saleContractRole.update).not.toHaveBeenCalled();
+    });
+
+    it('DB エラーは next に伝播する', async () => {
+      mockPrisma.contractPlot.findUnique.mockRejectedValue(new Error('db down'));
+
+      const req = buildReq({ newCustomerId: 'cust-new' });
+      const next = jest.fn();
+
+      await changeContractor(req, buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+});

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -5,6 +5,7 @@ import {
   updatePlotSchema,
   createPlotContractSchema,
   familyContactSchema,
+  changeContractorSchema,
 } from '../../src/validations/plotValidation';
 
 describe('Plot Validation (ContractPlot Model)', () => {
@@ -728,6 +729,56 @@ describe('Plot Validation (ContractPlot Model)', () => {
         familyContactSchema.parse({ ...base, phoneNumber: '', postalCode: '', faxNumber: '' })
       ).not.toThrow();
       expect(() => familyContactSchema.parse(base)).not.toThrow();
+    });
+  });
+
+  describe('changeContractorSchema (#310)', () => {
+    const validNewCustomer = {
+      name: '鈴木三郎',
+      nameKana: 'スズキサブロウ',
+      postalCode: '8100001',
+      address: '福岡県福岡市中央区天神1-1-1',
+      phoneNumber: '09011112222',
+    };
+
+    it('newCustomerId のみの指定は有効', () => {
+      expect(() =>
+        changeContractorSchema.parse({
+          newCustomerId: '550e8400-e29b-41d4-a716-446655440000',
+        })
+      ).not.toThrow();
+    });
+
+    it('newCustomer のみの指定は有効（changeDate / reason は任意）', () => {
+      expect(() =>
+        changeContractorSchema.parse({
+          newCustomer: validNewCustomer,
+          changeDate: '2026-06-01',
+          reason: '相続のため',
+        })
+      ).not.toThrow();
+    });
+
+    it('newCustomerId と newCustomer の同時指定は拒否（排他）', () => {
+      expect(() =>
+        changeContractorSchema.parse({
+          newCustomerId: '550e8400-e29b-41d4-a716-446655440000',
+          newCustomer: validNewCustomer,
+        })
+      ).toThrow(/どちらか一方/);
+    });
+
+    it('どちらも未指定は拒否', () => {
+      expect(() => changeContractorSchema.parse({})).toThrow(/どちらか一方/);
+    });
+
+    it('理由が200文字を超えると拒否', () => {
+      expect(() =>
+        changeContractorSchema.parse({
+          newCustomerId: '550e8400-e29b-41d4-a716-446655440000',
+          reason: 'あ'.repeat(201),
+        })
+      ).toThrow(/200文字以内/);
     });
   });
 });


### PR DESCRIPTION
## 概要

Closes #310

業務確認シート回答（2026-06-07 Q7）「契約はそのままで契約者名だけ書き換え、履歴情報として残す」を実装。`POST /api/v1/plots/:id/change-contractor` を新設。

## 実装内容

- **契約者roleの交代**: 同一 SaleContract 上で contractor role を旧契約者→新契約者へ付け替え。新規 Customer 作成（`newCustomer`）or 既存 Customer 指定（`newCustomerId`）の XOR バリデーション
- **履歴**: History に change_reason「名義変更」（reason 指定時は「名義変更: {reason}」）で before/after（契約者の customer_id / 氏名 / カナ）を記録 — 過去の契約者を遡れる
- **role 行にも在任期間を保存**: 旧 role は soft-delete + `role_end_date`、新 role は `role_start_date`（changeDate 指定可、省略時は当日）
- **申込者は不変**: applicant role（= 最初の契約者）には触らない
- **ガード**:
  - active 契約のみ（vacant / terminated は 409。解約済みは #110 の区画再利用フローが正規経路）
  - 終了顧客（`is_terminated` #129）の契約者指定は 400
  - 既に契約者の顧客の指定は 409
- **既存パターン準拠**: Serializable tx（#278）、operator 以上、Zod validation、契約者名カナ snapshot 再同期（#282/#297）、swagger.yaml 追記

## 設計判断（issue の検討事項への回答）

「現在の契約者」の解決はコードベース全体で `role='contractor' AND deleted_at IS NULL`（created_at 昇順）に依存しているため、role 行に有効期間/終了フラグを持たせて現役判定を変える案は影響範囲が広すぎると判断。updatePlot の roles 入替と同じ **soft-delete + 新規作成** 方式を採用し、履歴は History（+ soft-delete された role 行の role_end_date）で表現する。

## 未対応事項（スコープ外）

- frontend の操作 UI は別 issue（契約者情報セクションに「名義変更」ボタン想定）
- `@komine/types` への API 型追加は frontend 実装時に実施（types リポジトリで並行作業中のため本 PR では backend ローカルの zod infer のみ）

## テスト

- `tests/plots/controllers/changeContractor.test.ts` 13件（成功×5 / 失敗×8: Serializable tx・履歴・snapshot 同期・applicant 不変・各ガード）
- `tests/validations/plotValidation.test.ts` に changeContractorSchema の XOR テスト5件追加

- [x] `npm test` 全 1161 テスト pass
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run swagger:validate` valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)