### PR TITLE
feat(customers): 解約者参照APIと解約者紐づき家族連絡先91件の取込対応

### DIFF
--- a/prisma/migrations/20260607150000_family_contact_nullable_contract_plot/migration.sql
+++ b/prisma/migrations/20260607150000_family_contact_nullable_contract_plot/migration.sql
@@ -1,0 +1,4 @@
+-- 家族連絡先の契約区画リンクを nullable 化（#311）
+-- 業務確認（2026-06-07 Q18/Q20/Q21）: 解約者（is_terminated 顧客）に紐づく
+-- t_family 91件は契約区画を持たないため、customer_id 直リンクのみで取り込む
+ALTER TABLE "family_contacts" ALTER COLUMN "contract_plot_id" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -429,7 +429,9 @@ model ConstructionInfo {
 // 家族・連絡先
 model FamilyContact {
   id                     String       @id @default(uuid()) @map("family_contact_id")
-  contract_plot_id       String // 契約区画ID
+  // 契約区画ID。解約者（is_terminated 顧客）紐づきの連絡先は区画を持たないため
+  // nullable（#311）。その場合は customer_id 直リンクのみで参照する。
+  contract_plot_id       String?
   customer_id            String? // 顧客マスタへの参照（オプショナル）
   emergency_contact_flag Boolean      @default(false) // 緊急連絡先フラグ
   name                   String       @db.VarChar(100)
@@ -457,8 +459,8 @@ model FamilyContact {
   legacy_family_cd Int? @unique // レガシー t_family.family_cd（移行の冪等キー #220）
 
   // Relations
-  contractPlot ContractPlot @relation(fields: [contract_plot_id], references: [id], onDelete: Cascade)
-  customer     Customer?    @relation(fields: [customer_id], references: [id], onDelete: SetNull)
+  contractPlot ContractPlot? @relation(fields: [contract_plot_id], references: [id], onDelete: Cascade)
+  customer     Customer?     @relation(fields: [customer_id], references: [id], onDelete: SetNull)
 
   @@index([contract_plot_id])
   @@index([customer_id])

--- a/scripts/legacy-migration/steps/07-family-contact.ts
+++ b/scripts/legacy-migration/steps/07-family-contact.ts
@@ -60,16 +60,35 @@ export const stepFamilyContact: MigrationStep = {
     const dankaGraveMap = new Map<number, number>();
     for (const r of dankaToGrave) dankaGraveMap.set(r.danka_cd, r.grave_cd);
 
+    // 解約者（del_flg=2、is_terminated=true で step04 取込済み #129）の danka_cd 集合と、
+    // 新DB上の解約者 Customer への対応。解約者紐づきの t_family（91件）は契約区画を
+    // 持たないため、contract_plot_id=null + customer_id 直リンクで取り込む（#311）。
+    // idMaps.customer は契約/請求リンクの誤接続防止のため解約者を除外しており使えない。
+    const terminatedDanka = await legacyQuery<RowDataPacket & { danka_cd: number }>(
+      `SELECT danka_cd FROM t_danka WHERE del_flg = 2`
+    );
+    const terminatedDankaSet = new Set(terminatedDanka.map((r) => r.danka_cd));
+    const terminatedCustomers = await prisma.customer.findMany({
+      where: { is_terminated: true, deleted_at: null, legacy_danka_cd: { not: null } },
+      select: { id: true, legacy_danka_cd: true },
+    });
+    const terminatedCustomerMap = new Map<number, string>();
+    for (const c of terminatedCustomers) {
+      if (c.legacy_danka_cd != null) terminatedCustomerMap.set(c.legacy_danka_cd, c.id);
+    }
+
     const rows = await legacyQuery<FamilyRow>(
       `SELECT * FROM t_family WHERE del_flg = 0 OR del_flg IS NULL`
     );
 
     let inserted = 0;
+    let insertedTerminatedLink = 0;
     let skipped = 0;
     let skipExisting = 0;
     let skipMissingName = 0;
     let skipDankaNotMapped = 0;
     let skipContractPlotNotMapped = 0;
+    let skipTerminatedCustomerNotFound = 0;
 
     for (const row of rows) {
       const name = joinName(row.family_sei, row.family_mei);
@@ -80,8 +99,29 @@ export const stepFamilyContact: MigrationStep = {
       }
 
       const graveCd = dankaGraveMap.get(row.danka_cd);
-      const contractPlotId = graveCd != null ? idMaps.contractPlot.get(graveCd) : undefined;
-      if (!contractPlotId) {
+      let contractPlotId: string | null =
+        graveCd != null ? (idMaps.contractPlot.get(graveCd) ?? null) : null;
+      let customerId: string | null;
+      let isTerminatedLink = false;
+
+      if (contractPlotId) {
+        customerId = idMaps.customer.get(row.danka_cd) ?? null;
+      } else if (terminatedDankaSet.has(row.danka_cd)) {
+        // 解約者紐づき（#311）: 区画リンクなしで解約者 Customer に直リンク
+        isTerminatedLink = true;
+        contractPlotId = null;
+        customerId = terminatedCustomerMap.get(row.danka_cd) ?? null;
+        if (!customerId && !dryRun) {
+          // step04 未実行・解約者取込漏れ等。orphan を作らずスキップする
+          logger.warn(
+            { family_cd: row.family_cd, danka_cd: row.danka_cd },
+            'Terminated customer not found in new DB (run step04 first)'
+          );
+          skipped++;
+          skipTerminatedCustomerNotFound++;
+          continue;
+        }
+      } else {
         logger.debug(
           { family_cd: row.family_cd, danka_cd: row.danka_cd, grave_cd: graveCd ?? null },
           'No contract plot mapped'
@@ -91,7 +131,6 @@ export const stepFamilyContact: MigrationStep = {
         else skipContractPlotNotMapped++;
         continue;
       }
-      const customerId = idMaps.customer.get(row.danka_cd) ?? null;
 
       const addressParts = [row.addr1, row.addr2, row.addr3]
         .map(cleanStr)
@@ -105,6 +144,7 @@ export const stepFamilyContact: MigrationStep = {
 
       if (dryRun) {
         inserted++;
+        if (isTerminatedLink) insertedTerminatedLink++;
         continue;
       }
 
@@ -144,6 +184,7 @@ export const stepFamilyContact: MigrationStep = {
         },
       });
       inserted++;
+      if (isTerminatedLink) insertedTerminatedLink++;
     }
 
     return {
@@ -151,9 +192,12 @@ export const stepFamilyContact: MigrationStep = {
       skipped,
       notes: {
         source_rows: rows.length,
+        // 解約者紐づき（contract_plot_id=null、customer 直リンク #311）の内数
+        inserted_terminated_link: insertedTerminatedLink,
         skip_missing_name: skipMissingName,
         skip_danka_not_mapped: skipDankaNotMapped,
         skip_contract_plot_not_mapped: skipContractPlotNotMapped,
+        skip_terminated_customer_not_found: skipTerminatedCustomerNotFound,
         skip_existing: skipExisting,
       },
     };

--- a/src/customers/customerController.ts
+++ b/src/customers/customerController.ts
@@ -1,0 +1,120 @@
+/**
+ * 顧客（解約者参照）コントローラー（#311）
+ *
+ * 業務確認（2026-06-07 Q18/Q20）: 終了顧客150件は「取り込む」「解約者で情報まとめる」。
+ * 旧システムは解約で中の人情報が全て消えるため、解約者を一覧・検索できるようにし、
+ * notes に記録済みの旧区画手がかり（旧区画cd: X / 区画No: legacy-X）から
+ * 該当区画へ辿れるようにする。
+ *
+ * 解約者（is_terminated=true）は契約・請求・入金にリンクされない独立 Customer
+ * （scripts/legacy-migration の idMaps から除外 #129/Q19）のため、台帳問い合わせ
+ * （/plots）には現れない。本エンドポイントが唯一の参照経路。
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import prisma from '../db/prisma';
+
+/**
+ * 解約者一覧取得
+ * GET /api/v1/customers/terminated
+ *
+ * 解約者に紐づく家族連絡先（contract_plot_id=null、customer_id 直リンク #311）も
+ * 併せて返す（「解約者で情報まとめる」）。
+ */
+export const getTerminatedCustomers = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    // validate ミドルウェアで変換済み（paginationSchema: string → number）
+    const {
+      page = 1,
+      limit = 20,
+      search,
+    } = req.query as unknown as {
+      page?: number;
+      limit?: number;
+      search?: string;
+    };
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.CustomerWhereInput = {
+      deleted_at: null,
+      is_terminated: true,
+    };
+
+    if (search) {
+      const conditions: Prisma.CustomerWhereInput[] = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { name_kana: { contains: search, mode: 'insensitive' } },
+        { phone_number: { contains: search } },
+        // notes には旧区画手がかり（旧区画cd / 区画No: legacy-X）が記録済み
+        { notes: { contains: search, mode: 'insensitive' } },
+      ];
+      // 数値なら旧檀家コード一致も検索対象にする
+      const numeric = Number(search);
+      if (Number.isInteger(numeric) && numeric > 0) {
+        conditions.push({ legacy_danka_cd: numeric });
+      }
+      where.OR = conditions;
+    }
+
+    const [total, customers] = await Promise.all([
+      prisma.customer.count({ where }),
+      prisma.customer.findMany({
+        where,
+        include: {
+          familyContacts: {
+            where: { deleted_at: null },
+            orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+          },
+        },
+        orderBy: [{ name_kana: 'asc' }, { name: 'asc' }, { id: 'asc' }],
+        skip,
+        take: limit,
+      }),
+    ]);
+
+    const items = customers.map((c) => ({
+      id: c.id,
+      name: c.name,
+      nameKana: c.name_kana,
+      postalCode: c.postal_code,
+      address: c.address,
+      phoneNumber: c.phone_number,
+      email: c.email,
+      // 旧区画手がかり（旧区画cd: X / 区画No: legacy-X）を含む
+      notes: c.notes,
+      legacyDankaCd: c.legacy_danka_cd,
+      createdAt: c.created_at,
+      familyContacts: c.familyContacts.map((fc) => ({
+        id: fc.id,
+        name: fc.name,
+        nameKana: fc.name_kana,
+        relationship: fc.relationship,
+        postalCode: fc.postal_code,
+        address: fc.address,
+        phoneNumber: fc.phone_number,
+        email: fc.email,
+        notes: fc.notes,
+      })),
+    }));
+
+    res.json({
+      success: true,
+      data: {
+        items,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/customers/customerRoutes.ts
+++ b/src/customers/customerRoutes.ts
@@ -1,0 +1,28 @@
+/**
+ * 顧客（解約者参照）APIルート（#311）
+ * 認証必須・権限制御付き
+ */
+import { Router } from 'express';
+import { getTerminatedCustomers } from './customerController';
+import { authenticate } from '../middleware/auth';
+import { requirePermission } from '../middleware/permission';
+import { validate } from '../middleware/validation';
+import { withLogging } from '../middleware/controllerLogger';
+import { terminatedCustomerQuerySchema } from '../validations/customerValidation';
+
+const router = Router();
+
+/**
+ * @route GET /api/v1/customers/terminated
+ * @desc 解約者（is_terminated=true 顧客）一覧・検索
+ * @access 認証必須 - viewer 以上（読み取り専用）
+ */
+router.get(
+  '/terminated',
+  authenticate,
+  requirePermission(['viewer', 'operator', 'manager', 'admin']),
+  validate({ query: terminatedCustomerQuerySchema }),
+  withLogging('Customers', 'getTerminatedCustomers', getTerminatedCustomers)
+);
+
+export default router;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import documentRoutes from './documents/documentRoutes';
 import yuchoRoutes from './yucho/yuchoRoutes';
 import billingRoutes from './billings/billingRoutes';
 import paymentRoutes from './payments/paymentRoutes';
+import customerRoutes from './customers/customerRoutes';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler';
 import { requestLogger, securityHeaders } from './middleware/logger';
 import { requestIdMiddleware } from './middleware/requestId';
@@ -119,6 +120,7 @@ app.use('/api/v1/documents', documentRoutes); // 書類管理ルート
 app.use('/api/v1/yucho', yuchoRoutes); // ゆうちょ連携ルート
 app.use('/api/v1/billings', billingRoutes); // 請求管理ルート
 app.use('/api/v1/payments', paymentRoutes); // 入金管理ルート
+app.use('/api/v1/customers', customerRoutes); // 顧客（解約者参照）ルート #311
 
 // 404エラーハンドラー（すべてのルートの後に配置）
 app.use(notFoundHandler);

--- a/src/validations/customerValidation.ts
+++ b/src/validations/customerValidation.ts
@@ -1,0 +1,16 @@
+/**
+ * 顧客（解約者参照）関連のバリデーションスキーマ（#311）
+ */
+import { z } from 'zod';
+import { paginationSchema } from '../middleware/validation';
+
+/**
+ * 解約者一覧クエリのバリデーションスキーマ
+ * GET /customers/terminated
+ */
+export const terminatedCustomerQuerySchema = paginationSchema.extend({
+  // 氏名・カナ・電話番号・旧檀家コードの部分一致検索
+  search: z.string().max(100).optional(),
+});
+
+export type TerminatedCustomerQuery = z.infer<typeof terminatedCustomerQuerySchema>;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -25,8 +25,127 @@ tags:
     description: 書類管理（PDF生成・ファイルアップロード）
   - name: Yucho
     description: ゆうちょ連携（自動払込み用CSV生成）
+  - name: Customers
+    description: 顧客（解約者参照）
 
 paths:
+  /api/v1/customers/terminated:
+    get:
+      tags:
+        - Customers
+      summary: 解約者一覧・検索
+      description: |
+        解約者（is_terminated=true 顧客、レガシー del_flg=2 由来 #129）を一覧・検索する（#311）。
+        解約者は契約・請求・入金にリンクされない独立した顧客レコードのため、
+        台帳問い合わせ（/plots）には現れず、本エンドポイントが唯一の参照経路。
+        notes には旧区画手がかり（旧区画cd: X / 区画No: legacy-X）が記録済み。
+        解約者に紐づく家族連絡先（contract_plot_id=null、customer 直リンク）も併せて返す。
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: string
+            default: "1"
+        - name: limit
+          in: query
+          schema:
+            type: string
+            default: "20"
+        - name: search
+          in: query
+          description: 氏名・カナ・電話番号・備考（旧区画手がかり）・旧檀家コードの部分一致検索
+          schema:
+            type: string
+            maxLength: 100
+      responses:
+        "200":
+          description: 解約者一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              format: uuid
+                            name:
+                              type: string
+                            nameKana:
+                              type: string
+                              nullable: true
+                            postalCode:
+                              type: string
+                              nullable: true
+                            address:
+                              type: string
+                              nullable: true
+                            phoneNumber:
+                              type: string
+                              nullable: true
+                            email:
+                              type: string
+                              nullable: true
+                            notes:
+                              type: string
+                              nullable: true
+                              description: 旧区画手がかり（旧区画cd / 区画No legacy-X）を含む
+                            legacyDankaCd:
+                              type: integer
+                              nullable: true
+                            createdAt:
+                              type: string
+                              format: date-time
+                            familyContacts:
+                              type: array
+                              description: 解約者に紐づく家族連絡先（区画リンクなし #311）
+                              items:
+                                type: object
+                                properties:
+                                  id:
+                                    type: string
+                                    format: uuid
+                                  name:
+                                    type: string
+                                  nameKana:
+                                    type: string
+                                    nullable: true
+                                  relationship:
+                                    type: string
+                                  phoneNumber:
+                                    type: string
+                                    nullable: true
+                                  address:
+                                    type: string
+                                    nullable: true
+                      pagination:
+                        type: object
+                        properties:
+                          page:
+                            type: integer
+                          limit:
+                            type: integer
+                          total:
+                            type: integer
+                          totalPages:
+                            type: integer
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /api/v1/auth/login:
     post:
       tags:

--- a/tests/customers/customerController.test.ts
+++ b/tests/customers/customerController.test.ts
@@ -1,0 +1,198 @@
+/**
+ * 顧客（解約者参照）コントローラのテスト（#311）
+ * GET /api/v1/customers/terminated
+ */
+
+import { Request, Response, NextFunction } from 'express';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      user?: {
+        id: number;
+        email: string;
+        name: string;
+        role: string;
+        is_active: boolean;
+        supabase_uid: string;
+      };
+    }
+  }
+}
+
+const mockPrisma: any = {
+  customer: {
+    count: jest.fn(),
+    findMany: jest.fn(),
+  },
+};
+
+jest.mock('../../src/db/prisma', () => ({
+  __esModule: true,
+  default: mockPrisma,
+}));
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+  Prisma: {},
+}));
+
+import { getTerminatedCustomers } from '../../src/customers/customerController';
+
+const TERMINATED_CUSTOMER = {
+  id: 'cust-t1',
+  name: '山田太郎',
+  name_kana: 'ヤマダタロウ',
+  postal_code: '8000000',
+  address: '北九州市',
+  phone_number: '0931234567',
+  email: null,
+  notes: '[解約済み顧客] 旧システム del_flg=2。旧区画cd: 600（区画No: legacy-600）',
+  legacy_danka_cd: 200,
+  created_at: new Date('2026-06-01'),
+  familyContacts: [
+    {
+      id: 'fc-1',
+      name: '山田花子',
+      name_kana: 'ヤマダハナコ',
+      relationship: '妻',
+      postal_code: null,
+      address: null,
+      phone_number: '0937654321',
+      email: null,
+      notes: null,
+    },
+  ],
+};
+
+describe('getTerminatedCustomers (#311)', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let responseJson: jest.Mock;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    responseJson = jest.fn().mockReturnThis();
+    mockResponse = { json: responseJson, status: jest.fn().mockReturnThis() };
+    mockNext = jest.fn();
+    mockRequest = { params: {}, body: {}, query: {} };
+  });
+
+  it('解約者一覧を items + pagination 形式で返し、家族連絡先も含む', async () => {
+    mockPrisma.customer.count.mockResolvedValue(1);
+    mockPrisma.customer.findMany.mockResolvedValue([TERMINATED_CUSTOMER]);
+
+    // validate ミドルウェア通過後は number に変換済み
+    mockRequest.query = { page: 1, limit: 20 } as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+
+    // is_terminated=true のみに絞っている
+    expect(mockPrisma.customer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { deleted_at: null, is_terminated: true },
+        skip: 0,
+        take: 20,
+      })
+    );
+
+    expect(responseJson).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        items: [
+          expect.objectContaining({
+            id: 'cust-t1',
+            name: '山田太郎',
+            nameKana: 'ヤマダタロウ',
+            notes: expect.stringContaining('旧区画cd: 600'),
+            legacyDankaCd: 200,
+            familyContacts: [
+              expect.objectContaining({
+                id: 'fc-1',
+                name: '山田花子',
+                relationship: '妻',
+                phoneNumber: '0937654321',
+              }),
+            ],
+          }),
+        ],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      },
+    });
+  });
+
+  it('search 指定時は氏名・カナ・電話・備考（旧区画手がかり）の OR 検索になる', async () => {
+    mockPrisma.customer.count.mockResolvedValue(0);
+    mockPrisma.customer.findMany.mockResolvedValue([]);
+
+    mockRequest.query = { page: 1, limit: 20, search: '山田' } as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockPrisma.customer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          is_terminated: true,
+          OR: expect.arrayContaining([
+            { name: { contains: '山田', mode: 'insensitive' } },
+            { name_kana: { contains: '山田', mode: 'insensitive' } },
+            { phone_number: { contains: '山田' } },
+            { notes: { contains: '山田', mode: 'insensitive' } },
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('search が数値なら旧檀家コード一致も検索条件に含める', async () => {
+    mockPrisma.customer.count.mockResolvedValue(0);
+    mockPrisma.customer.findMany.mockResolvedValue([]);
+
+    mockRequest.query = { page: 1, limit: 20, search: '200' } as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockPrisma.customer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([{ legacy_danka_cd: 200 }]),
+        }),
+      })
+    );
+  });
+
+  it('ページネーションが skip/take と totalPages に反映される', async () => {
+    mockPrisma.customer.count.mockResolvedValue(45);
+    mockPrisma.customer.findMany.mockResolvedValue([]);
+
+    mockRequest.query = { page: 2, limit: 20 } as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockPrisma.customer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 20, take: 20 })
+    );
+    expect(responseJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          pagination: { page: 2, limit: 20, total: 45, totalPages: 3 },
+        }),
+      })
+    );
+  });
+
+  it('DB エラーは next に伝播する', async () => {
+    mockPrisma.customer.count.mockRejectedValue(new Error('db down'));
+    mockPrisma.customer.findMany.mockRejectedValue(new Error('db down'));
+
+    mockRequest.query = {} as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -248,9 +248,9 @@ describe('Server Index', () => {
 
     // セキュリティミドルウェア（helmet, cors, rateLimiter, json, urlencoded, hpp, cookieParser, sanitizeInput）
     // + requestIdMiddleware + ログミドルウェア（requestLogger, securityHeaders）
-    // + Swagger UI + 9 API routes (auth, plots, masters, staff, collective-burials, documents, yucho, billings, payments)
-    // + notFoundHandler + errorHandler = 23 use calls
-    expect(mockApp.use).toHaveBeenCalledTimes(23);
+    // + Swagger UI + 10 API routes (auth, plots, masters, staff, collective-burials, documents, yucho, billings, payments, customers #311)
+    // + notFoundHandler + errorHandler = 24 use calls
+    expect(mockApp.use).toHaveBeenCalledTimes(24);
     // 1 health check endpoint
     expect(mockApp.get).toHaveBeenCalledTimes(1);
   });

--- a/tests/scripts/legacy-migration/steps/dryrun-resume.test.ts
+++ b/tests/scripts/legacy-migration/steps/dryrun-resume.test.ts
@@ -51,9 +51,10 @@ describe('legacy migration resume + dry-run (issue #163)', () => {
       familyContact: { create: familyContactCreate },
     } as unknown as PrismaClient;
 
-    // 1回目: t_danka (danka_cd→grave_cd) のルックアップ, 2回目: t_family 本体
+    // 1回目: t_danka (danka_cd→grave_cd), 2回目: 解約者 danka（del_flg=2 #311）, 3回目: t_family 本体
     mockedLegacyQuery
       .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
           family_cd: 1,
@@ -76,7 +77,8 @@ describe('legacy migration resume + dry-run (issue #163)', () => {
     const result = await stepFamilyContact.run(ctx);
 
     // dry-run でも idMap が新DBから再構築された（= 旧挙動ではここが空で throw していた）
-    expect(customerFindMany).toHaveBeenCalledTimes(1);
+    // customer.findMany は rebuildIdMap + 解約者マップ構築（#311）の2回
+    expect(customerFindMany).toHaveBeenCalledTimes(2);
     expect(contractPlotFindMany).toHaveBeenCalledTimes(1);
     expect(idMaps.customer.size).toBe(1);
     expect(idMaps.contractPlot.size).toBe(1);

--- a/tests/scripts/legacy-migration/steps/idempotency.test.ts
+++ b/tests/scripts/legacy-migration/steps/idempotency.test.ts
@@ -54,6 +54,8 @@ describe('移行ステップの冪等性 (#220)', () => {
 
     mockedLegacyQuery
       .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      // 解約者 danka（del_flg=2）ルックアップ（#311）
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
           family_cd: 1,

--- a/tests/scripts/legacy-migration/steps/terminated-family.test.ts
+++ b/tests/scripts/legacy-migration/steps/terminated-family.test.ts
@@ -1,0 +1,179 @@
+/**
+ * 回帰テスト: 解約者紐づき家族連絡先の取込（#311）
+ *
+ * 業務確認（2026-06-07 Q18/Q20/Q21）: 解約者150件は取り込み「解約者で情報まとめる」。
+ * 解約者（del_flg=2）に紐づく t_family 91件は契約区画を持たないため、
+ * contract_plot_id=null + customer_id 直リンクで取り込む。
+ * PR #309 時点では FamilyContact.contract_plot_id が NOT NULL のため見送られていた。
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepFamilyContact } from '../../../../scripts/legacy-migration/steps/07-family-contact';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+const familyRow = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+  family_cd: 1,
+  danka_cd: 100,
+  family_sei: '山田',
+  family_mei: '太郎',
+  addr1: null,
+  addr2: null,
+  addr3: null,
+  job_addr1: null,
+  job_addr2: null,
+  job_addr3: null,
+  ...overrides,
+});
+
+/**
+ * legacyQuery のモック順序（07-family-contact.ts の呼び出し順）:
+ *   1. t_danka (danka_cd→grave_cd, del_flg=0)
+ *   2. 解約者 danka (del_flg=2)
+ *   3. t_family 本体
+ */
+describe('stepFamilyContact: 解約者紐づき family の取込 (#311)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  const buildPrisma = (created: Array<Record<string, unknown>>): PrismaClient => {
+    // customer.findMany は rebuildIdMap（is_terminated:false 側）と
+    // 解約者マップ構築（is_terminated:true 側）の両方で呼ばれるため where で出し分ける
+    const customerFindMany = jest
+      .fn()
+      .mockImplementation(({ where }: { where: Record<string, unknown> }) => {
+        if (where['is_terminated'] === true) {
+          return Promise.resolve([{ id: 'cust-terminated', legacy_danka_cd: 200 }]);
+        }
+        return Promise.resolve([{ id: 'cust-active', legacy_danka_cd: 100 }]);
+      });
+    return {
+      customer: { findMany: customerFindMany },
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      familyContact: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+          created.push(data);
+          return Promise.resolve({ id: `fc-${created.length}` });
+        }),
+      },
+    } as unknown as PrismaClient;
+  };
+
+  it('解約者（del_flg=2）紐づきの family は contract_plot_id=null + customer 直リンクで取り込む', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }]) // del_flg=0 danka
+      .mockResolvedValueOnce([{ danka_cd: 200 }]) // del_flg=2（解約者）danka
+      .mockResolvedValueOnce([
+        familyRow({ family_cd: 1, danka_cd: 100 }), // 現役顧客紐づき（従来どおり区画リンク）
+        familyRow({ family_cd: 2, danka_cd: 200, family_mei: '次郎' }), // 解約者紐づき（#311）
+      ]);
+
+    const result = await stepFamilyContact.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    expect(result.inserted).toBe(2);
+    expect(result.notes?.['inserted_terminated_link']).toBe(1);
+    expect(result.notes?.['skip_danka_not_mapped']).toBe(0);
+
+    const activeLinked = created.find((d) => d['legacy_family_cd'] === 1);
+    const terminatedLinked = created.find((d) => d['legacy_family_cd'] === 2);
+    expect(activeLinked?.['contract_plot_id']).toBe('cp-1');
+    expect(activeLinked?.['customer_id']).toBe('cust-active');
+    expect(terminatedLinked?.['contract_plot_id']).toBeNull();
+    expect(terminatedLinked?.['customer_id']).toBe('cust-terminated');
+  });
+
+  it('解約者 Customer が新DBに無い場合は orphan を作らずスキップする（step04 未実行ガード）', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      // 解約者 danka 201 はレガシーに存在するが、新DBの解約者マップ（200のみ）に無い
+      .mockResolvedValueOnce([{ danka_cd: 201 }])
+      .mockResolvedValueOnce([familyRow({ family_cd: 3, danka_cd: 201 })]);
+
+    const result = await stepFamilyContact.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.notes?.['skip_terminated_customer_not_found']).toBe(1);
+    expect(created).toHaveLength(0);
+  });
+
+  it('解約者でも区画マップにも無い danka は従来どおり skip_danka_not_mapped（挙動回帰なし）', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      .mockResolvedValueOnce([]) // 解約者なし
+      .mockResolvedValueOnce([familyRow({ family_cd: 4, danka_cd: 999 })]);
+
+    const result = await stepFamilyContact.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.notes?.['skip_danka_not_mapped']).toBe(1);
+  });
+
+  it('dry-run でも解約者紐づき件数を inserted に計上する', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }])
+      .mockResolvedValueOnce([{ danka_cd: 200 }])
+      .mockResolvedValueOnce([familyRow({ family_cd: 2, danka_cd: 200 })]);
+
+    const result = await stepFamilyContact.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: true,
+    });
+
+    expect(result.inserted).toBe(1);
+    expect(result.notes?.['inserted_terminated_link']).toBe(1);
+    expect(created).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 概要

Closes #311

業務確認シート回答（2026-06-07 Q18/Q20/Q21）「解約者で情報まとめる」「解約場所と分かるようにしたい」の残り2点を実装。PR #309（終了顧客150件取込）の続き。

## 1. 解約者の参照機能

**`GET /api/v1/customers/terminated`**（新設、viewer 以上）

- `is_terminated=true` 顧客の一覧・検索（氏名 / カナ / 電話番号 / 備考 / 旧檀家コードの部分一致）
- notes に記録済みの旧区画手がかり（`旧区画cd: X / 区画No: legacy-X`）をそのまま返却 — 該当区画へ辿れる
- 紐づく家族連絡先も併せて返す（「解約者で情報まとめる」）
- レスポンスは `{ items, pagination }` 形式、swagger.yaml 追記済み

**通常業務へのノイズについて（issue の検討事項）**: 解約者は契約・請求・入金にリンクされない独立 Customer（idMaps から除外 #129/Q19）のため、台帳問い合わせ（/plots）には元々現れない。既存検索へのフィルタ追加は不要で、本エンドポイントが唯一の参照経路。

## 2. family 91件の取込

- **`FamilyContact.contract_plot_id` を nullable 化**（migration `20260607150000_family_contact_nullable_contract_plot` 同梱）
- **step07**: 解約者（del_flg=2）紐づきの t_family を `contract_plot_id=null` + `customer_id` 直リンクで取込
  - 空き器契約・再販売契約への誤リンクは構造上不可（区画リンク自体を持たない）
  - 解約者 Customer 未取込（step04 未実行）時は orphan を作らず `skip_terminated_customer_not_found` でスキップ
  - サマリーに `inserted_terminated_link` を別掲
- nullable 化の影響: `npx tsc --noEmit` clean — 既存 controllers / validations は contract_plot_id を自動注入する側で null を扱わないため影響なし。**@komine/types の変更も不要**（区画ビューのレスポンス形は不変。解約者向けレスポンスは backend ローカル整形）

## 本番反映時の手順（#163 と同梱可）

```bash
npx prisma migrate deploy   # contract_plot_id nullable 化
npm run migrate:legacy -- --only=familyContact   # 91件取込（冪等）
```

取込後の FamilyContact 件数は 2641 → 約2732（verify-migration の判定はレガシー2744比で ✅ 圏内）。

## 未対応事項（スコープ外）

- frontend の解約者一覧画面（API は本 PR で準備済み。frontend リポジトリで別 issue 起票推奨）

## テスト

- `tests/customers/customerController.test.ts` 5件（フィルタ・検索OR・旧檀家コード・ページネーション・エラー伝播）
- `tests/scripts/legacy-migration/steps/terminated-family.test.ts` 4件（直リンク取込・orphanガード・回帰なし・dry-run）
- 既存 idempotency / dryrun-resume テストを新クエリ順に追従

- [x] `npm test` 全 1152 テスト pass
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run swagger:validate` valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)