### PR TITLE
feat: 区画更新の changeReason 受理＋スキーマ欠落キー（applicant/gravestoneInfo/workInfo）の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=a516e99d096810ea8e783075ef6468533d3399d3
+ARG TYPES_REF=e3d4d374b812a32fccb59bb5cd47ba7627f546e0
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -72,6 +72,9 @@ export async function updatePlotCore(
   const physicalPlotId = existingContractPlot.physical_plot_id;
   const oldContractArea = existingContractPlot.contract_area_sqm.toNumber();
 
+  // 変更理由（#261）。指定があれば本更新で記録される全履歴エントリに反映する。
+  const changeReason = input.changeReason;
+
   // 1.5. 物理区画情報の更新
   const physicalPlotInput = input.physicalPlot;
   if (physicalPlotInput) {
@@ -109,6 +112,7 @@ export async function updatePlotCore(
           status: updatedPp.status,
           notes: updatedPp.notes,
         },
+        changeReason,
         req,
       });
     }
@@ -256,6 +260,7 @@ export async function updatePlotCore(
           role: oldRole.role,
           customer_id: oldRole.customer_id,
         },
+        changeReason,
         req,
       });
     }
@@ -286,6 +291,7 @@ export async function updatePlotCore(
           role: created.role,
           customer_id: created.customer_id,
         },
+        changeReason,
         req,
       });
     }
@@ -373,6 +379,7 @@ export async function updatePlotCore(
                 work_address: existingWorkInfo.work_address,
                 work_phone_number: existingWorkInfo.work_phone_number,
               },
+              changeReason,
               req,
             });
           }
@@ -425,6 +432,7 @@ export async function updatePlotCore(
                   address_type: updated.address_type,
                   notes: updated.notes,
                 },
+                changeReason,
                 req,
               });
             } else {
@@ -447,6 +455,7 @@ export async function updatePlotCore(
                   customer_id: customerId,
                   ...workInfoData,
                 },
+                changeReason,
                 req,
               });
             }
@@ -483,6 +492,7 @@ export async function updatePlotCore(
             role: existingApplicantRole.role,
             customer_id: existingApplicantRole.customer_id,
           },
+          changeReason,
           req,
         });
       }
@@ -529,7 +539,8 @@ export async function updatePlotCore(
           applicantCustomerId,
           id,
           physicalPlotId,
-          req
+          req,
+          changeReason
         );
         // 申込者として編集した顧客が他区画の契約者を兼ねる場合（共有 Customer）も
         // snapshot が陳腐化するため、氏名・カナ変更時は顧客起点で再同期する（#301）
@@ -568,7 +579,7 @@ export async function updatePlotCore(
           role: ContractRole.applicant,
         },
       });
-      await recordCustomerCreated(tx, applicantCustomer, id, physicalPlotId, req);
+      await recordCustomerCreated(tx, applicantCustomer, id, physicalPlotId, req, changeReason);
       await recordEntityCreated(tx, {
         entityType: 'SaleContractRole',
         entityId: createdRole.id,
@@ -579,6 +590,7 @@ export async function updatePlotCore(
           role: createdRole.role,
           customer_id: createdRole.customer_id,
         },
+        changeReason,
         req,
       });
     }
@@ -606,6 +618,7 @@ export async function updatePlotCore(
             unit_price: before.unit_price,
             payment_method: before.payment_method,
           },
+          changeReason,
           req,
         });
       }
@@ -650,6 +663,7 @@ export async function updatePlotCore(
               unit_price: updated.unit_price,
               payment_method: updated.payment_method,
             },
+            changeReason,
             req,
           });
         } else {
@@ -675,6 +689,7 @@ export async function updatePlotCore(
               unit_price: created.unit_price,
               payment_method: created.payment_method,
             },
+            changeReason,
             req,
           });
         }
@@ -701,6 +716,7 @@ export async function updatePlotCore(
             billing_type: before.billing_type,
             billing_years: before.billing_years,
           },
+          changeReason,
           req,
         });
       }
@@ -763,6 +779,7 @@ export async function updatePlotCore(
               last_billing_month: updated.last_billing_month,
               payment_method: updated.payment_method,
             },
+            changeReason,
             req,
           });
         } else {
@@ -781,6 +798,7 @@ export async function updatePlotCore(
               id: created.id,
               ...managementFeeData,
             },
+            changeReason,
             req,
           });
         }
@@ -810,6 +828,7 @@ export async function updatePlotCore(
             direction_id: existingGravestone.direction_id,
             position_id: existingGravestone.position_id,
           },
+          changeReason,
           req,
         });
       }
@@ -854,6 +873,7 @@ export async function updatePlotCore(
               direction_id: updated.direction_id,
               position_id: updated.position_id,
             },
+            changeReason,
             req,
           });
         } else {
@@ -876,6 +896,7 @@ export async function updatePlotCore(
               direction_id: created.direction_id,
               position_id: created.position_id,
             },
+            changeReason,
             req,
           });
         }
@@ -927,6 +948,7 @@ export async function updatePlotCore(
             billing_amount: existingCB.billing_amount,
             notes: existingCB.notes,
           },
+          changeReason,
           req,
         });
       }
@@ -976,6 +998,7 @@ export async function updatePlotCore(
             billing_amount: updated.billing_amount,
             notes: updated.notes,
           },
+          changeReason,
           req,
         });
       } else {
@@ -1025,6 +1048,7 @@ export async function updatePlotCore(
             billing_amount: input.collectiveBurial.billingAmount ?? null,
             notes: input.collectiveBurial.notes || null,
           },
+          changeReason,
           req,
         });
       }
@@ -1088,6 +1112,7 @@ export async function updatePlotCore(
             relationship: before.relationship,
             phone_number: before.phone_number,
           },
+          changeReason,
           req,
         });
       }
@@ -1179,6 +1204,7 @@ export async function updatePlotCore(
             notes: before.notes,
           },
           afterRecord: serializeFc(fcData),
+          changeReason,
           req,
         });
       } else {
@@ -1195,6 +1221,7 @@ export async function updatePlotCore(
           contractPlotId: id,
           actionType: 'CREATE',
           afterRecord: { id: created.id, ...serializeFc(fcData) },
+          changeReason,
           req,
         });
       }
@@ -1236,6 +1263,7 @@ export async function updatePlotCore(
             death_date: before.death_date?.toISOString() ?? null,
             burial_date: before.burial_date?.toISOString() ?? null,
           },
+          changeReason,
           req,
         });
       }
@@ -1299,6 +1327,7 @@ export async function updatePlotCore(
             notes: before.notes,
           },
           afterRecord: serialize(bpData),
+          changeReason,
           req,
         });
       } else {
@@ -1315,6 +1344,7 @@ export async function updatePlotCore(
           contractPlotId: id,
           actionType: 'CREATE',
           afterRecord: { id: created.id, ...serialize(bpData) },
+          changeReason,
           req,
         });
       }
@@ -1365,6 +1395,7 @@ export async function updatePlotCore(
             start_date: before.start_date?.toISOString() ?? null,
             completion_date: before.completion_date?.toISOString() ?? null,
           },
+          changeReason,
           req,
         });
       }
@@ -1430,6 +1461,7 @@ export async function updatePlotCore(
           actionType: 'UPDATE',
           beforeRecord: beforeSerialized,
           afterRecord: serializeCi(ciData),
+          changeReason,
           req,
         });
       } else {
@@ -1446,6 +1478,7 @@ export async function updatePlotCore(
           contractPlotId: id,
           actionType: 'CREATE',
           afterRecord: { id: created.id, ...serializeCi(ciData) },
+          changeReason,
           req,
         });
       }
@@ -1503,7 +1536,8 @@ export async function updatePlotCore(
       afterContractPlotData,
       physicalPlotId,
       id,
-      req
+      req,
+      changeReason
     );
   }
 
@@ -1547,7 +1581,8 @@ export async function updatePlotCore(
         existingCustomer.id,
         id,
         physicalPlotId,
-        req
+        req,
+        changeReason
       );
     }
   }

--- a/src/plots/services/historyService.ts
+++ b/src/plots/services/historyService.ts
@@ -184,7 +184,8 @@ export async function recordCustomerCreated(
   },
   contractPlotId: string | null,
   physicalPlotId: string | null,
-  req: Request
+  req: Request,
+  changeReason?: string
 ): Promise<void> {
   await createHistory(tx, {
     entityType: 'Customer',
@@ -196,6 +197,7 @@ export async function recordCustomerCreated(
       id: customer.id,
       name: customer.name,
     },
+    changeReason,
     req,
   });
 }

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  applicantSchema as sharedApplicantSchema,
   customerSchema as sharedCustomerSchema,
   familyContactSchema as sharedFamilyContactSchema,
   buriedPersonSchema as sharedBuriedPersonSchema,
@@ -219,13 +220,29 @@ const customerSchema = sharedCustomerSchema.omit({ role: true });
 
 /**
  * 勤務先情報のバリデーションスキーマ
- * バックエンドでは最小サブセットのみ受け付ける（shared workInfoSchema と構造が異なるため独自定義）。
+ * （shared workInfoSchema と構造が異なるため独自定義）。
+ * controller が読む全キーを受理する。最小サブセット時代は companyName/dmSetting 等が
+ * ネストレベルで剥がされ、勤務先名称等の編集が静かに破棄されていた（#320）。
+ * 各上限は DB の VarChar 長（company_name/company_name_kana=100, work_address=200）に整合。
  */
 const workInfoSchema = z
   .object({
+    companyName: z
+      .string()
+      .max(100, '勤務先名称は100文字以内で入力してください')
+      .optional()
+      .or(z.literal('')),
+    companyNameKana: z
+      .string()
+      .max(100, '勤務先名称カナは100文字以内で入力してください')
+      .optional()
+      .or(z.literal('')),
     workPostalCode: z.string().max(10).optional().or(z.literal('')),
     workAddress: z.string().max(200).optional().or(z.literal('')),
     workPhoneNumber: phoneSchema,
+    dmSetting: z.string().max(20).optional().or(z.literal('')),
+    addressType: z.string().max(20).optional().or(z.literal('')),
+    notes: z.string().max(1000).optional().or(z.literal('')),
   })
   .optional()
   .or(z.null());
@@ -271,10 +288,14 @@ export const createPlotSchema = z.object({
   contractPlot: contractPlotSchema,
   saleContract: saleContractSchema,
   customer: customerSchema,
+  // 申込者（任意）。スキーマ欠落により validate() で剥がされ controller に届かなかった（#320）
+  applicant: sharedApplicantSchema.optional(),
   workInfo: workInfoSchema,
   billingInfo: contractPlotBillingInfoSchema,
   usageFee: contractPlotUsageFeeSchema,
   managementFee: contractPlotManagementFeeSchema,
+  // 墓石情報（任意）。スキーマ欠落により validate() で剥がされ controller に届かなかった（#320）
+  gravestoneInfo: gravestoneInfoSchema,
   collectiveBurial: collectiveBurialSchema,
   familyContacts: z.array(familyContactSchema).optional(),
 });
@@ -288,14 +309,22 @@ export const updatePlotSchema = z.object({
   contractPlot: contractPlotSchema.partial().optional(),
   saleContract: saleContractSchema.partial().optional(),
   customer: customerSchema.partial().optional(),
+  // 申込者。undefined=変更なし / null=既存 applicant の解除 / object=upsert（既存は部分更新可）。
+  // スキーマ欠落により validate() で剥がされ、申込者編集が静かに破棄されていた（#320）
+  applicant: sharedApplicantSchema.partial().optional().or(z.null()),
   workInfo: workInfoSchema,
   billingInfo: contractPlotBillingInfoSchema,
   usageFee: contractPlotUsageFeeSchema,
   managementFee: contractPlotManagementFeeSchema,
+  // 墓石情報。undefined=変更なし / null=削除 / object=upsert（#154 の更新永続化の受け口）。
+  // スキーマ欠落により validate() で剥がされていた（#320）
+  gravestoneInfo: gravestoneInfoSchema.or(z.null()),
   familyContacts: z.array(familyContactSchema).optional(),
   buriedPersons: z.array(buriedPersonSchema).optional(),
   constructionInfos: z.array(constructionInfoUpdateSchema).optional(),
   collectiveBurial: collectiveBurialSchema,
+  // 変更理由（#261）。本更新で記録される履歴（History.change_reason VarChar(200)）に反映する
+  changeReason: z.string().trim().max(200, '変更理由は200文字以内で入力してください').optional(),
 });
 
 /**

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4219,6 +4219,50 @@ components:
               type: string
               maxLength: 50
               nullable: true
+        applicant:
+          type: object
+          description: 申込者情報。null で既存 applicant の解除、省略で変更なし（#320）
+          nullable: true
+          properties:
+            name:
+              type: string
+              maxLength: 100
+            nameKana:
+              type: string
+              maxLength: 100
+            phoneNumber:
+              type: string
+              maxLength: 11
+              nullable: true
+            email:
+              type: string
+              maxLength: 254
+              nullable: true
+        gravestoneInfo:
+          type: object
+          description: 墓石情報。null で削除、省略で変更なし（#320）
+          nullable: true
+          properties:
+            gravestoneBase:
+              type: string
+              nullable: true
+            gravestoneDealer:
+              type: string
+              nullable: true
+            gravestoneType:
+              type: string
+              nullable: true
+            directionId:
+              type: integer
+              nullable: true
+            positionId:
+              type: integer
+              nullable: true
+        changeReason:
+          type: string
+          maxLength: 200
+          description: 変更理由。指定すると本更新で記録される履歴（History.change_reason）に反映される（#261）
+          example: "名義変更"
 
     CreatePlotContractInput:
       type: object

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -155,6 +155,10 @@ import {
   getPlotInventory,
 } from '../../src/plots/controllers';
 import {
+  recordEntityUpdated,
+  recordContractPlotUpdated,
+} from '../../src/plots/services/historyService';
+import {
   validateContractArea,
   updatePhysicalPlotStatus,
   syncContractorNameKanaForCustomer,
@@ -1237,6 +1241,85 @@ describe('Plot Controller (ContractPlot Model)', () => {
       await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(ValidationError));
+    });
+
+    it('changeReason がある場合、履歴記録に changeReason を渡す（#261）', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        location_description: null,
+        contract_date: null,
+        price: 1000,
+        payment_status: 'unpaid',
+        reservation_date: null,
+        acceptance_number: null,
+        permit_date: null,
+        start_date: null,
+        uncollected_amount: 0,
+        notes: null,
+        physicalPlot: {
+          id: 'pp1',
+          plot_number: 'A-1',
+          area_name: '第1期',
+          area_sqm: new Prisma.Decimal(3.6),
+          status: 'available',
+          notes: null,
+        },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+        collectiveBurial: null,
+        gravestoneInfo: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.physicalPlot.update.mockResolvedValue({
+        ...mockExistingPlot.physicalPlot,
+        notes: '更新メモ',
+      });
+      mockPrisma.contractPlot.update.mockResolvedValue({
+        ...mockExistingPlot,
+        price: 2000,
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        physicalPlot: { notes: '更新メモ' },
+        saleContract: { price: 2000 },
+        changeReason: '名義変更',
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      // PhysicalPlot の履歴に changeReason が渡る
+      expect(recordEntityUpdated).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          entityType: 'PhysicalPlot',
+          changeReason: '名義変更',
+        })
+      );
+      // ContractPlot の履歴（位置引数の末尾）にも changeReason が渡る
+      expect(recordContractPlotUpdated).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'pp1',
+        'cp1',
+        expect.anything(),
+        '名義変更'
+      );
     });
 
     it('should create applicant Customer + role when applicant provided and no existing applicant', async () => {

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -397,6 +397,25 @@ describe('Plot Validation (ContractPlot Model)', () => {
 
       expect(() => createPlotSchema.parse(dataWithManagementFee)).not.toThrow();
     });
+
+    // #320: applicant / gravestoneInfo が Zod により黙って strip されていた問題の回帰テスト
+    it('applicant が parse 結果に保持されること（#320）', () => {
+      const data = {
+        ...validCreatePlotData,
+        applicant: { name: '山田花子', nameKana: 'ヤマダハナコ' },
+      };
+      const parsed = createPlotSchema.parse(data);
+      expect(parsed.applicant).toMatchObject({ name: '山田花子', nameKana: 'ヤマダハナコ' });
+    });
+
+    it('gravestoneInfo が parse 結果に保持されること（#320）', () => {
+      const data = {
+        ...validCreatePlotData,
+        gravestoneInfo: { gravestoneDealer: '〇〇石材', gravestoneType: '和型' },
+      };
+      const parsed = createPlotSchema.parse(data);
+      expect(parsed.gravestoneInfo).toMatchObject({ gravestoneDealer: '〇〇石材' });
+    });
   });
 
   describe('updatePlotSchema', () => {
@@ -615,6 +634,84 @@ describe('Plot Validation (ContractPlot Model)', () => {
       it('空配列も許容すること', () => {
         const data = { constructionInfos: [] };
         expect(() => updatePlotSchema.parse(data)).not.toThrow();
+      });
+    });
+
+    // #261: 変更理由の受理
+    describe('changeReason（#261）', () => {
+      it('changeReason を受理し parse 結果に保持すること', () => {
+        const parsed = updatePlotSchema.parse({ changeReason: '名義変更' });
+        expect(parsed.changeReason).toBe('名義変更');
+      });
+
+      it('changeReason 省略時は undefined のまま通過すること', () => {
+        const parsed = updatePlotSchema.parse({});
+        expect(parsed.changeReason).toBeUndefined();
+      });
+
+      it('changeReason が 200 文字を超えるとバリデーションエラーになること', () => {
+        expect(() => updatePlotSchema.parse({ changeReason: 'あ'.repeat(201) })).toThrow();
+      });
+    });
+
+    // #320: applicant / gravestoneInfo / workInfo ネストキーが Zod により黙って strip されていた問題の回帰テスト
+    // （#62 の physicalPlot / constructionInfos と同種）
+    describe('applicant / gravestoneInfo / workInfo の strip 回帰（#320）', () => {
+      it('applicant が parse 結果に保持されること', () => {
+        const data = {
+          applicant: { name: '山田花子', nameKana: 'ヤマダハナコ', phoneNumber: '09012345678' },
+        };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.applicant).toMatchObject({ name: '山田花子', nameKana: 'ヤマダハナコ' });
+      });
+
+      it('applicant の部分更新（name 無し）も受理すること', () => {
+        const parsed = updatePlotSchema.parse({ applicant: { phoneNumber: '09012345678' } });
+        expect(parsed.applicant).toMatchObject({ phoneNumber: '09012345678' });
+      });
+
+      it('applicant: null（既存 applicant の解除）を受理すること', () => {
+        const parsed = updatePlotSchema.parse({ applicant: null });
+        expect(parsed.applicant).toBeNull();
+      });
+
+      it('gravestoneInfo が parse 結果に保持されること', () => {
+        const data = {
+          gravestoneInfo: { gravestoneDealer: '〇〇石材', gravestoneType: '和型' },
+        };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.gravestoneInfo).toMatchObject({ gravestoneDealer: '〇〇石材' });
+      });
+
+      it('gravestoneInfo: null（削除）を受理すること', () => {
+        const parsed = updatePlotSchema.parse({ gravestoneInfo: null });
+        expect(parsed.gravestoneInfo).toBeNull();
+      });
+
+      it('workInfo の companyName / dmSetting 等が strip されないこと', () => {
+        const data = {
+          workInfo: {
+            companyName: '株式会社テスト',
+            companyNameKana: 'カブシキガイシャテスト',
+            workAddress: '東京都港区',
+            dmSetting: 'allow',
+            addressType: 'work',
+            notes: '勤務先メモ',
+          },
+        };
+        const parsed = updatePlotSchema.parse(data);
+        expect(parsed.workInfo).toMatchObject({
+          companyName: '株式会社テスト',
+          dmSetting: 'allow',
+          addressType: 'work',
+          notes: '勤務先メモ',
+        });
+      });
+
+      it('workInfo の companyName が 100 文字を超えるとバリデーションエラーになること', () => {
+        expect(() =>
+          updatePlotSchema.parse({ workInfo: { companyName: 'あ'.repeat(101) } })
+        ).toThrow();
       });
     });
   });


### PR DESCRIPTION
## 概要

2本立て:

1. **changeReason の受理**（frontend zaitsu82/komine-crm-frontend#261 の縦串 backend 部分、types#42 とセット）
2. **zod 未知キー剥がれの修正**（調査中に発見した実害バグ、#62 と同種） — Closes #320

## 変更内容

### #261: 変更理由の履歴記録
- `updatePlotSchema` に `changeReason`（`.trim().max(200)` = `History.change_reason` VarChar(200) に整合）を追加
- `updatePlotCore` で `input.changeReason` を本更新で記録される**全履歴エントリ**に伝播（recordEntityCreated/Updated/Deleted の29箇所 + recordContractPlotUpdated / recordCustomerCreated・Updated の positional 4箇所 + roles/familyContacts/buriedPersons/constructionInfos のバッチ entry）
- `recordCustomerCreated` に `changeReason` 任意引数を追加（他の wrapper は対応済みだった）
- swagger.yaml `UpdatePlotInput` に changeReason / applicant / gravestoneInfo を追記
- Dockerfile `TYPES_REF` を e3d4d37（types#42）へ bump

### #320: スキーマ欠落キーの修正
`validate()` は `req.body = schema.parseAsync(req.body)` のため、スキーマに無いキーは controller に届かない（実測で確認済み）。controller の `input.X` 参照と突き合わせて以下を修正:

| スキーマ | 追加キー | 修正される実害 |
|---|---|---|
| updatePlotSchema | `applicant`（partial、null=解除） | **申込者の編集・解除がフォーム保存で静かに破棄**（#201 の section 6.5 が経路上死んでいた） |
| updatePlotSchema | `gravestoneInfo`（null=削除） | **墓石情報の更新・削除が静かに破棄**（#154 の section 8.5 が再び死んでいた） |
| createPlotSchema | `applicant` / `gravestoneInfo` | 新規作成時の同データ破棄 |
| workInfoSchema | `companyName` / `companyNameKana` / `dmSetting` / `addressType` / `notes` | **勤務先名称・かな・DM設定・宛先区分・備考の編集が（ネストレベルで）静かに破棄** |

各上限は DB VarChar 長に整合（#276 の方針踏襲）。

## テスト

- 新規: changeReason 受理/200超拒否/省略時 undefined、applicant・gravestoneInfo・workInfo ネストキーの strip 回帰（update/create）、controller の changeReason 伝播（recordEntityUpdated / recordContractPlotUpdated）
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run swagger:validate` ✅ / `npm test` **1156/1156** ✅

## 縦串の後続

frontend 側（プリセット＋自由入力 UI + changeReason 送信 + TYPES_REF bump）は frontend PR で対応。

Refs zaitsu82/komine-crm-frontend#261
Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)