### PR TITLE
fix(payments): 未収金額を護持費（管理料）の未集金額に限定する (#325)

### DIFF
--- a/scripts/legacy-migration/steps/12-payment-status.ts
+++ b/scripts/legacy-migration/steps/12-payment-status.ts
@@ -1,9 +1,6 @@
-import type { PaymentStatus } from '@prisma/client';
+import type { BillingCategory, PaymentStatus } from '@prisma/client';
 
-import {
-  paymentStatusFromTotals,
-  uncollectedFromTotals,
-} from '../../../src/plots/services/paymentStatusLogic';
+import { deriveContractPlotPayment } from '../../../src/plots/services/paymentStatusLogic';
 import type { MigrationStep } from '../types';
 
 /**
@@ -13,10 +10,12 @@ import type { MigrationStep } from '../types';
  * Billing / Payment 投入後に、契約区画ごとに「請求額 vs 入金額」を集計して
  * payment_status（paid / partial_paid / unpaid）と未収金額（請求額 − 入金額）を再計算する。
  *
- * 判定ロジックはランタイム（src/plots/services/paymentStatusLogic）と共有している。
+ * 判定ロジックはランタイム（src/plots/services/paymentStatusLogic の deriveContractPlotPayment）と
+ * 共有している。区画×category で集計し、同関数へ渡すことで単一ソースを保つ。
  *  - 解約済み請求（terminated）は債務消滅扱いで集計から除外
  *  - overdue（延滞）は期限超過の業務定義が未確定のため自動付与しない
- *  - 未収金額 = max(0, 請求額 − 入金額)（#170）
+ *  - payment_status は全料金区分で判定
+ *  - 未収金額は護持費（管理料 = management_fee）の未集金額に限定（komine-docs#10 項目2 / 業務確定）
  *
  * 冪等性:
  *   payment_status='unpaid' かつ uncollected=0（＝移行初期値）に収束する区画は更新不要（no-op）。
@@ -34,12 +33,29 @@ export const stepPaymentStatus: MigrationStep = {
   name: 'paymentStatus',
   dependsOn: ['billing', 'payment'],
   async run({ prisma, logger, dryRun }) {
-    // 解約済みを除いた請求を契約区画単位で集計（請求額 / 入金額）
+    // 解約済みを除いた請求を「契約区画 × 料金区分」で集計（請求額 / 入金額）。
+    // payment_status は全区分・未収金額は管理料限定で出すため category 別の内訳が必要。
     const grouped = await prisma.billing.groupBy({
-      by: ['contract_plot_id'],
+      by: ['contract_plot_id', 'category'],
       where: { deleted_at: null, terminated: false },
       _sum: { amount: true, paid_amount: true },
     });
+
+    // 区画ごとに category 別の集計を束ね、deriveContractPlotPayment（ランタイムと共有の単一ソース）へ渡す。
+    const byPlot = new Map<
+      string,
+      { amount: number; paid_amount: number; terminated: boolean; category: BillingCategory }[]
+    >();
+    for (const g of grouped) {
+      const list = byPlot.get(g.contract_plot_id) ?? [];
+      list.push({
+        amount: g._sum.amount ?? 0,
+        paid_amount: g._sum.paid_amount ?? 0,
+        terminated: false, // where で terminated:false 済み
+        category: g.category,
+      });
+      byPlot.set(g.contract_plot_id, list);
+    }
 
     // (payment_status, uncollected) の組ごとに区画 ID をまとめて updateMany を最小化する。
     // 移行初期値（unpaid / 0）に一致する区画は更新不要（no-op）なので除外する。
@@ -52,11 +68,8 @@ export const stepPaymentStatus: MigrationStep = {
     let setUncollected = 0;
     let leftAtInitial = 0;
 
-    for (const g of grouped) {
-      const totalAmount = g._sum.amount ?? 0;
-      const totalPaid = g._sum.paid_amount ?? 0;
-      const status = paymentStatusFromTotals(totalAmount, totalPaid);
-      const uncollected = uncollectedFromTotals(totalAmount, totalPaid, status);
+    for (const [contractPlotId, billings] of byPlot) {
+      const { status, uncollectedAmount: uncollected } = deriveContractPlotPayment(billings);
 
       if (status === 'unpaid' && uncollected === 0) {
         leftAtInitial += 1;
@@ -68,15 +81,15 @@ export const stepPaymentStatus: MigrationStep = {
 
       const key = `${status}|${uncollected}`;
       const bucket = buckets.get(key);
-      if (bucket) bucket.ids.push(g.contract_plot_id);
-      else buckets.set(key, { status, uncollected, ids: [g.contract_plot_id] });
+      if (bucket) bucket.ids.push(contractPlotId);
+      else buckets.set(key, { status, uncollected, ids: [contractPlotId] });
     }
 
-    const updated = grouped.length - leftAtInitial;
+    const updated = byPlot.size - leftAtInitial;
 
     if (dryRun) {
       const notes: Record<string, number> = {
-        contract_plots_with_billing: grouped.length,
+        contract_plots_with_billing: byPlot.size,
         would_set_paid: setPaid,
         would_set_partial_paid: setPartial,
         would_set_uncollected: setUncollected,
@@ -95,7 +108,7 @@ export const stepPaymentStatus: MigrationStep = {
     }
 
     const notes: Record<string, number> = {
-      contract_plots_with_billing: grouped.length,
+      contract_plots_with_billing: byPlot.size,
       set_paid: setPaid,
       set_partial_paid: setPartial,
       set_uncollected: setUncollected,

--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -162,9 +162,10 @@ export const getBillingsSummary = async (
     // 未入金は回収可能な債権のみで算出する（#272）。
     // 解約済み（terminated）・貸倒（written_off）は債務/債権が消滅しており、
     // 含めると回収不能金額が「未入金」に積み上がる。#170 の
-    // deriveContractPlotPayment（terminated 除外）と同一規則を適用し、
-    // 区画詳細の uncollected_amount とサマリー StatCard を整合させる。
-    // AND 合成でユーザー指定の status 等のフィルタは維持する。
+    // deriveContractPlotPayment と同じく terminated を除外する。
+    // AND 合成でユーザー指定の status・category 等のフィルタは維持する。
+    // 注: これは請求台帳サマリーで全料金区分（または指定 category）が対象。
+    // 区画詳細の uncollected_amount は護持費（管理料）限定（komine-docs#10 項目2）で別概念。
     const collectibleWhere: Prisma.BillingWhereInput = {
       AND: [where, { terminated: false, status: { notIn: ['written_off', 'terminated'] } }],
     };

--- a/src/plots/services/paymentStatusLogic.ts
+++ b/src/plots/services/paymentStatusLogic.ts
@@ -1,4 +1,4 @@
-import { PaymentStatus } from '@prisma/client';
+import { BillingCategory, PaymentStatus } from '@prisma/client';
 
 /**
  * ContractPlot.payment_status / uncollected_amount の派生ロジック（DB 非依存の純関数）。
@@ -47,21 +47,42 @@ export const uncollectedFromTotals = (
 };
 
 /**
- * ContractPlot の請求群から payment_status と uncollected_amount を同時に導出する。
+ * ContractPlot の請求群から payment_status と uncollected_amount を導出する。
  *
  * 解約済み請求（terminated）は債務が消滅しているため集計から除外する。
  * これにより「解約前に全額入金 → 解約」の区画が誤って未入金扱いになるのを防ぐ。
- * payment_status と未収金額を同一の集計から導出することで、両者が論理的に矛盾しないことを保証する（#170）。
+ *
+ * 集計の対象範囲は 2 つで異なる（komine-docs#10 項目2 / 業務確定）:
+ *  - payment_status: 全料金区分の active 請求で判定する（契約全体の支払状態を表す）。
+ *  - uncollected_amount: **護持費（管理料 = management_fee）の未集金額に限定**する。
+ *    使用料・合祀料金・工事料金・墓石代の未収は未収金額に含めない。
+ *
+ * このため「使用料は未払いだが管理料は完納」の区画は status=partial_paid（全体としては未払いあり）
+ * でも uncollected_amount=0（護持費は完納）になりうる。両者は意図的に異なる定義を持つ。
  */
 export const deriveContractPlotPayment = (
-  billings: { amount: number; paid_amount: number; terminated: boolean }[],
+  billings: {
+    amount: number;
+    paid_amount: number;
+    terminated: boolean;
+    category: BillingCategory;
+  }[],
   currentStatus?: PaymentStatus
 ): { status: PaymentStatus; uncollectedAmount: number } => {
   const active = billings.filter((b) => !b.terminated);
+
+  // payment_status は全料金区分の active 請求で判定する。
   const totalAmount = active.reduce((sum, b) => sum + b.amount, 0);
   const totalPaid = active.reduce((sum, b) => sum + b.paid_amount, 0);
   const status = paymentStatusFromTotals(totalAmount, totalPaid, currentStatus);
-  return { status, uncollectedAmount: uncollectedFromTotals(totalAmount, totalPaid, status) };
+
+  // 未収金額は護持費（管理料）の未集金額に限定する。
+  const mgmt = active.filter((b) => b.category === BillingCategory.management_fee);
+  const mgmtAmount = mgmt.reduce((sum, b) => sum + b.amount, 0);
+  const mgmtPaid = mgmt.reduce((sum, b) => sum + b.paid_amount, 0);
+  const uncollectedAmount = uncollectedFromTotals(mgmtAmount, mgmtPaid, status);
+
+  return { status, uncollectedAmount };
 };
 
 /**
@@ -69,6 +90,11 @@ export const deriveContractPlotPayment = (
  * @deprecated 集計を二重化しないため {@link deriveContractPlotPayment} を使うこと。後方互換で残置。
  */
 export const deriveContractPlotPaymentStatus = (
-  billings: { amount: number; paid_amount: number; terminated: boolean }[],
+  billings: {
+    amount: number;
+    paid_amount: number;
+    terminated: boolean;
+    category: BillingCategory;
+  }[],
   currentStatus?: PaymentStatus
 ): PaymentStatus => deriveContractPlotPayment(billings, currentStatus).status;

--- a/src/plots/services/paymentStatusService.ts
+++ b/src/plots/services/paymentStatusService.ts
@@ -34,7 +34,8 @@ export const recalculateContractPlotPaymentStatus = async (
 
   const billings = await client.billing.findMany({
     where: { contract_plot_id: contractPlotId, deleted_at: null },
-    select: { amount: true, paid_amount: true, terminated: true },
+    // category も取得する: 未収金額は護持費（管理料）限定で算出するため（komine-docs#10 項目2）。
+    select: { amount: true, paid_amount: true, terminated: true, category: true },
   });
 
   const { status, uncollectedAmount } = deriveContractPlotPayment(

--- a/tests/billings/billingService.test.ts
+++ b/tests/billings/billingService.test.ts
@@ -274,9 +274,10 @@ describe('recalculateBillingPayments', () => {
       { payment_amount: 10000, payment_date: new Date('2026-05-01') },
     ]);
     // 区画には他に未入金の管理料請求が残っている → 区画全体は partial_paid
+    // 未収金額は管理料限定（komine-docs#10 項目2）: 未払いの 5000 は管理料なので未収=5000
     billingFindMany.mockResolvedValue([
-      { amount: 10000, paid_amount: 10000, terminated: false },
-      { amount: 5000, paid_amount: 0, terminated: false },
+      { amount: 10000, paid_amount: 10000, terminated: false, category: 'usage_fee' },
+      { amount: 5000, paid_amount: 0, terminated: false, category: 'management_fee' },
     ]);
 
     await recalculateBillingPayments(client, 'b1');

--- a/tests/plots/paymentStatusService.test.ts
+++ b/tests/plots/paymentStatusService.test.ts
@@ -46,11 +46,11 @@ describe('paymentStatusFromTotals', () => {
 });
 
 describe('deriveContractPlotPaymentStatus', () => {
-  it('sums amount and paid across billings', () => {
+  it('sums amount and paid across billings (全料金区分で判定)', () => {
     expect(
       deriveContractPlotPaymentStatus([
-        { amount: 10000, paid_amount: 10000, terminated: false },
-        { amount: 5000, paid_amount: 0, terminated: false },
+        { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+        { amount: 5000, paid_amount: 0, terminated: false, category: 'usage_fee' },
       ])
     ).toBe('partial_paid');
   });
@@ -58,8 +58,8 @@ describe('deriveContractPlotPaymentStatus', () => {
   it('returns "paid" when every active billing is fully covered', () => {
     expect(
       deriveContractPlotPaymentStatus([
-        { amount: 10000, paid_amount: 10000, terminated: false },
-        { amount: 5000, paid_amount: 5000, terminated: false },
+        { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+        { amount: 5000, paid_amount: 5000, terminated: false, category: 'usage_fee' },
       ])
     ).toBe('paid');
   });
@@ -68,15 +68,17 @@ describe('deriveContractPlotPaymentStatus', () => {
     // 解約済み未払い請求は債務消滅扱い → 残りの全額入金済み請求のみで判定
     expect(
       deriveContractPlotPaymentStatus([
-        { amount: 10000, paid_amount: 10000, terminated: false },
-        { amount: 99999, paid_amount: 0, terminated: true },
+        { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+        { amount: 99999, paid_amount: 0, terminated: true, category: 'usage_fee' },
       ])
     ).toBe('paid');
   });
 
   it('returns "unpaid" when there are no active billings', () => {
     expect(
-      deriveContractPlotPaymentStatus([{ amount: 99999, paid_amount: 0, terminated: true }])
+      deriveContractPlotPaymentStatus([
+        { amount: 99999, paid_amount: 0, terminated: true, category: 'management_fee' },
+      ])
     ).toBe('unpaid');
     expect(deriveContractPlotPaymentStatus([])).toBe('unpaid');
   });
@@ -107,11 +109,11 @@ describe('uncollectedFromTotals', () => {
 });
 
 describe('deriveContractPlotPayment', () => {
-  it('derives status and uncollected from the same aggregation', () => {
+  it('derives status (全区分) and uncollected (管理料のみ) — all management_fee', () => {
     expect(
       deriveContractPlotPayment([
-        { amount: 10000, paid_amount: 10000, terminated: false },
-        { amount: 5000, paid_amount: 0, terminated: false },
+        { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+        { amount: 5000, paid_amount: 0, terminated: false, category: 'management_fee' },
       ])
     ).toEqual({ status: 'partial_paid', uncollectedAmount: 5000 });
   });
@@ -119,15 +121,17 @@ describe('deriveContractPlotPayment', () => {
   it('excludes terminated billings from both status and uncollected', () => {
     expect(
       deriveContractPlotPayment([
-        { amount: 10000, paid_amount: 10000, terminated: false },
-        { amount: 99999, paid_amount: 0, terminated: true },
+        { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+        { amount: 99999, paid_amount: 0, terminated: true, category: 'management_fee' },
       ])
     ).toEqual({ status: 'paid', uncollectedAmount: 0 });
   });
 
-  it('reports the full billed amount as uncollected when nothing is paid (#170 主因)', () => {
+  it('reports the full management_fee as uncollected when nothing is paid (#170 主因)', () => {
     expect(
-      deriveContractPlotPayment([{ amount: 162000, paid_amount: 0, terminated: false }])
+      deriveContractPlotPayment([
+        { amount: 162000, paid_amount: 0, terminated: false, category: 'management_fee' },
+      ])
     ).toEqual({ status: 'unpaid', uncollectedAmount: 162000 });
   });
 
@@ -137,8 +141,52 @@ describe('deriveContractPlotPayment', () => {
 
   it('zeroes uncollected for refunded (currentStatus preserved)', () => {
     expect(
-      deriveContractPlotPayment([{ amount: 10000, paid_amount: 0, terminated: false }], 'refunded')
+      deriveContractPlotPayment(
+        [{ amount: 10000, paid_amount: 0, terminated: false, category: 'management_fee' }],
+        'refunded'
+      )
     ).toEqual({ status: 'refunded', uncollectedAmount: 0 });
+  });
+});
+
+describe('deriveContractPlotPayment — 未収金額は護持費（管理料）限定 (komine-docs#10 項目2)', () => {
+  it('excludes usage_fee arrears from uncollected (使用料未払いは未収に含めない)', () => {
+    // 使用料は未払いだが管理料は完納 → status は全体で partial_paid、未収は管理料のみ=0
+    expect(
+      deriveContractPlotPayment([
+        { amount: 100000, paid_amount: 0, terminated: false, category: 'usage_fee' },
+        { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+      ])
+    ).toEqual({ status: 'partial_paid', uncollectedAmount: 0 });
+  });
+
+  it('counts only management_fee arrears in uncollected (管理料未払いのみ未収)', () => {
+    // 使用料は完納だが管理料は未払い → status は全体で partial_paid、未収は管理料の 10000
+    expect(
+      deriveContractPlotPayment([
+        { amount: 100000, paid_amount: 100000, terminated: false, category: 'usage_fee' },
+        { amount: 10000, paid_amount: 0, terminated: false, category: 'management_fee' },
+      ])
+    ).toEqual({ status: 'partial_paid', uncollectedAmount: 10000 });
+  });
+
+  it('ignores non-management arrears entirely (合祀料金・工事料金・墓石代の未収は0扱い)', () => {
+    // 管理料の請求が無く合祀料金だけ未払い → 未収は 0（status は全体で unpaid）
+    expect(
+      deriveContractPlotPayment([
+        { amount: 50000, paid_amount: 0, terminated: false, category: 'collective_fee' },
+      ])
+    ).toEqual({ status: 'unpaid', uncollectedAmount: 0 });
+  });
+
+  it('sums multiple management_fee billings for uncollected', () => {
+    expect(
+      deriveContractPlotPayment([
+        { amount: 10000, paid_amount: 3000, terminated: false, category: 'management_fee' },
+        { amount: 10000, paid_amount: 0, terminated: false, category: 'management_fee' },
+        { amount: 20000, paid_amount: 20000, terminated: false, category: 'usage_fee' },
+      ])
+    ).toEqual({ status: 'partial_paid', uncollectedAmount: 17000 });
   });
 });
 
@@ -161,8 +209,8 @@ describe('recalculateContractPlotPaymentStatus', () => {
     const client = buildClient();
     contractPlotFindFirst.mockResolvedValue({ payment_status: 'unpaid' });
     billingFindMany.mockResolvedValue([
-      { amount: 10000, paid_amount: 10000, terminated: false },
-      { amount: 5000, paid_amount: 5000, terminated: false },
+      { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+      { amount: 5000, paid_amount: 5000, terminated: false, category: 'usage_fee' },
     ]);
 
     const result = await recalculateContractPlotPaymentStatus(client, 'cp1');
@@ -177,7 +225,9 @@ describe('recalculateContractPlotPaymentStatus', () => {
   it('passes the current status through so manual overdue/refunded is preserved', async () => {
     const client = buildClient();
     contractPlotFindFirst.mockResolvedValue({ payment_status: 'overdue' });
-    billingFindMany.mockResolvedValue([{ amount: 10000, paid_amount: 0, terminated: false }]);
+    billingFindMany.mockResolvedValue([
+      { amount: 10000, paid_amount: 0, terminated: false, category: 'management_fee' },
+    ]);
 
     const result = await recalculateContractPlotPaymentStatus(client, 'cp1');
 
@@ -186,6 +236,38 @@ describe('recalculateContractPlotPaymentStatus', () => {
       where: { id: 'cp1' },
       data: { payment_status: 'overdue', uncollected_amount: 10000 },
     });
+  });
+
+  it('limits uncollected_amount to management_fee while status reflects all categories', async () => {
+    const client = buildClient();
+    contractPlotFindFirst.mockResolvedValue({ payment_status: 'unpaid' });
+    // 使用料は未払い・管理料は完納 → status=partial_paid（全体）/ uncollected=0（管理料のみ）
+    billingFindMany.mockResolvedValue([
+      { amount: 100000, paid_amount: 0, terminated: false, category: 'usage_fee' },
+      { amount: 10000, paid_amount: 10000, terminated: false, category: 'management_fee' },
+    ]);
+
+    const result = await recalculateContractPlotPaymentStatus(client, 'cp1');
+
+    expect(result).toBe('partial_paid');
+    expect(contractPlotUpdate).toHaveBeenCalledWith({
+      where: { id: 'cp1' },
+      data: { payment_status: 'partial_paid', uncollected_amount: 0 },
+    });
+  });
+
+  it('fetches billing category for the management-fee-only uncollected calculation', async () => {
+    const client = buildClient();
+    contractPlotFindFirst.mockResolvedValue({ payment_status: 'unpaid' });
+    billingFindMany.mockResolvedValue([]);
+
+    await recalculateContractPlotPaymentStatus(client, 'cp1');
+
+    expect(billingFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ category: true }),
+      })
+    );
   });
 
   it('returns null and skips update when the contract plot is not found', async () => {


### PR DESCRIPTION
## 概要
区画の未収金額(`uncollected_amount`)を、全料金区分の合算から**護持費（管理料 = `management_fee`）の未集金額に限定**する。komine-docs#10 項目2 の業務確認で「未収金額＝護持費の未集金額」と確定したことに対応。

これまでは利用料・合祀料金・工事料金・墓石代の未収も `uncollected_amount` に合算されていた（`BillingCategory` を絞らず集計）。

## 方針（業務確認スコープに忠実）
- **未収金額** → 管理料(`management_fee`)限定に変更
- **payment_status（支払ステータス）** → 契約全体の支払状態を表すため**全料金区分のまま据え置き**（今回の業務確認スコープ外のため意味を変えない）

このため「使用料は未払いだが管理料は完納」の区画は `payment_status=partial_paid`（全体としては未払いあり）でも `uncollected_amount=0`（護持費は完納）になりうる。両者は意図的に異なる定義を持つ。

## 変更
- `paymentStatusLogic.ts` `deriveContractPlotPayment`: status は全区分・uncollected は `management_fee` 限定（単一ソース）
- `paymentStatusService.ts`: `billing.findMany` の `select` に `category` を追加
- 移行 `steps/12-payment-status.ts`: 区画×`category` で `groupBy` し、`deriveContractPlotPayment` 経由に統一（ロジック二重化を回避）
- `billingController.ts`: 請求台帳サマリーの `unpaidAmount` は従来どおり全区分（または指定 category）対象。区画未収とは別概念であることをコメントで明記（ロジック変更なし）
- テスト: 既存ケースに `category` 付与＋護持費限定の新規ケース追加

## 検証
- `npm run lint` ✅ / `npx tsc --noEmit` ✅
- `npm test` ✅ 全 1195 テスト green（migration step 含む）

## 本番反映（マージ後）
ランタイムはデプロイ後の新規計算から自動で護持費限定になるが、**既存データは backfill 再実行が必要**:
```
npm run migrate:legacy -- --only=paymentStatus   # 先に --dry-run で件数確認
```
（前提: Billing/Payment 投入済 = #163。MEMORY より step07-11+paymentStatus は本番投入済のため再実行で更新される）

Closes #325
Refs komine-docs#10
