### PR TITLE
feat(plots): 碑文(inscription) + 合祀年数の人別上書き (komine-docs#10 項目1・8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=e3d4d374b812a32fccb59bb5cd47ba7627f546e0
+ARG TYPES_REF=200f417262f6bc4371b900af8d2a0e9772621eda
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/prisma/migrations/20260608120000_add_inscription_and_burial_validity_override/migration.sql
+++ b/prisma/migrations/20260608120000_add_inscription_and_burial_validity_override/migration.sql
@@ -1,0 +1,7 @@
+-- 碑文（注意書きの一言・一覧表示用）: ContractPlot に追加（komine-docs#10 項目1）
+-- 墓誌(gravestone_inscription)とは別物。一覧で一目で見やすい注意書きの一言。
+ALTER TABLE "contract_plots" ADD COLUMN "inscription" VARCHAR(120);
+
+-- 合祀年数の個別上書き: BuriedPerson に追加（komine-docs#10 項目8）
+-- null=区画の合祀年数(contract_plots.validity_period_years)を継承。人によって短くする運用に対応。
+ALTER TABLE "buried_persons" ADD COLUMN "validity_period_years_override" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,6 +158,7 @@ model ContractPlot {
   // 契約区画情報
   contract_area_sqm    Decimal @db.Decimal(5, 2) // 契約された面積（例: 3.6, 1.8, 0.9）
   location_description String? @db.VarChar(200) // 物理区画内のどの位置か（例: 左半分、右側）
+  inscription          String? @db.VarChar(120) // 碑文（注意書きの一言・一覧表示用）。墓誌(GravestoneInfo)とは別物
 
   // 合祀設定（設定されている場合、この区画は合祀対象）
   burial_capacity       Int? // 埋葬上限人数（nullの場合は合祀対象外）
@@ -486,6 +487,7 @@ model BuriedPerson {
   cause_of_death             String?   @db.VarChar(200) // 死因（レガシー siin、センシティブ情報）
   chief_mourner_name         String?   @db.VarChar(100) // 喪主氏名（レガシー moshu_sei + moshu_mei）
   chief_mourner_relationship String?   @db.VarChar(50) // 喪主続柄（レガシー moshu_zokugara）
+  validity_period_years_override Int? // 合祀年数の個別上書き（null=区画の合祀年数を継承）。komine-docs#10 項目8
   notes                      String?   @db.Text
   created_at                 DateTime  @default(now())
   updated_at                 DateTime  @updatedAt

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -147,6 +147,7 @@ export async function createPlotCore(
       contract_status: ContractStatus.active,
       contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
       location_description: input.contractPlot.locationDescription || null,
+      inscription: input.contractPlot.inscription || null,
       burial_capacity: input.collectiveBurial?.burialCapacity ?? null,
       validity_period_years: input.collectiveBurial?.validityPeriodYears ?? null,
       contract_date: input.saleContract.contractDate

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -125,6 +125,7 @@ export const getPlotById = async (
       startDate: contractPlot.start_date,
       uncollectedAmount: contractPlot.uncollected_amount,
       contractNotes: contractPlot.notes,
+      inscription: contractPlot.inscription,
 
       // レガシー由来の区分コード
       graveKind: contractPlot.grave_kind,
@@ -180,6 +181,7 @@ export const getPlotById = async (
         causeOfDeath: person.cause_of_death,
         chiefMournerName: person.chief_mourner_name,
         chiefMournerRelationship: person.chief_mourner_relationship,
+        validityPeriodYearsOverride: person.validity_period_years_override,
         notes: person.notes,
       })),
 

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -394,6 +394,9 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
         contractNotes: contractPlot.notes || null,
         customerNotes: primaryCustomer?.notes || null,
 
+        // 碑文（注意書きの一言・一覧表示用）
+        inscription: contractPlot.inscription || null,
+
         // 埋葬者名（一覧表示用）
         buriedPersonNames:
           contractPlot.buriedPersons?.map((bp: { name: string }) => bp.name).filter(Boolean) || [],

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -153,6 +153,10 @@ export async function updatePlotCore(
     if (input.contractPlot.locationDescription !== undefined) {
       updateData.location_description = input.contractPlot.locationDescription;
     }
+
+    if (input.contractPlot.inscription !== undefined) {
+      updateData.inscription = input.contractPlot.inscription;
+    }
   }
 
   if (input.saleContract) {
@@ -1282,6 +1286,7 @@ export async function updatePlotCore(
         posthumous_name: bp.posthumousName || null,
         report_date: bp.reportDate ? new Date(bp.reportDate) : null,
         religion: bp.religion || null,
+        validity_period_years_override: bp.validityPeriodYearsOverride ?? null,
         notes: bp.notes || null,
       };
 
@@ -1297,6 +1302,7 @@ export async function updatePlotCore(
         posthumous_name: data.posthumous_name,
         report_date: data.report_date?.toISOString() ?? null,
         religion: data.religion,
+        validity_period_years_override: data.validity_period_years_override,
         notes: data.notes,
       });
 
@@ -1501,6 +1507,7 @@ export async function updatePlotCore(
     const beforeContractPlotData = {
       contract_area_sqm: existingContractPlot.contract_area_sqm.toString(),
       location_description: existingContractPlot.location_description,
+      inscription: existingContractPlot.inscription,
       contract_date: existingContractPlot.contract_date?.toISOString(),
       price: existingContractPlot.price,
       payment_status: existingContractPlot.payment_status,
@@ -1518,6 +1525,7 @@ export async function updatePlotCore(
       ? {
           contract_area_sqm: updatedCp.contract_area_sqm.toString(),
           location_description: updatedCp.location_description,
+          inscription: updatedCp.inscription,
           contract_date: updatedCp.contract_date?.toISOString(),
           price: updatedCp.price,
           payment_status: updatedCp.payment_status,

--- a/src/plots/services/historyLabels.ts
+++ b/src/plots/services/historyLabels.ts
@@ -76,6 +76,7 @@ export const FIELD_LABELS: Record<HistoryEntityType, Record<string, string>> = {
   ContractPlot: {
     contract_area_sqm: '契約面積',
     location_description: '位置情報',
+    inscription: '碑文',
     contract_date: '契約日',
     price: '契約金額',
     payment_status: '支払ステータス',
@@ -158,6 +159,7 @@ export const FIELD_LABELS: Record<HistoryEntityType, Record<string, string>> = {
     posthumous_name: '戒名',
     report_date: '届出日',
     religion: '宗派',
+    validity_period_years_override: '合祀年数（個別）',
     notes: '備考',
   },
   ConstructionInfo: {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3437,6 +3437,12 @@ components:
               maxLength: 200
               nullable: true
               example: 南側
+            inscription:
+              type: string
+              description: 碑文（注意書きの一言・一覧表示用）。墓誌とは別物
+              maxLength: 120
+              nullable: true
+              example: 連絡時は長男へ
         saleContract:
           type: object
           required:
@@ -3943,6 +3949,12 @@ components:
                 description: 埋葬日
                 nullable: true
                 example: "2020-03-20"
+              validityPeriodYearsOverride:
+                type: integer
+                description: 合祀年数の個別上書き（null=区画の合祀年数を継承）。komine-docs#10 項目8
+                minimum: 1
+                nullable: true
+                example: 10
               notes:
                 type: string
                 description: 備考
@@ -3967,6 +3979,11 @@ components:
             locationDescription:
               type: string
               maxLength: 200
+              nullable: true
+            inscription:
+              type: string
+              description: 碑文（注意書きの一言・一覧表示用）。墓誌とは別物
+              maxLength: 120
               nullable: true
         saleContract:
           type: object
@@ -4290,6 +4307,11 @@ components:
             locationDescription:
               type: string
               maxLength: 200
+              nullable: true
+            inscription:
+              type: string
+              description: 碑文（注意書きの一言・一覧表示用）。墓誌とは別物
+              maxLength: 120
               nullable: true
         saleContract:
           type: object

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -609,6 +609,7 @@ describe('Plot Controller (ContractPlot Model)', () => {
         physical_plot_id: 'pp1',
         contract_area_sqm: new Prisma.Decimal(3.6),
         location_description: 'A区画',
+        inscription: '連絡は長男へ',
         created_at: new Date('2024-01-01'),
         updated_at: new Date('2024-01-01'),
         deleted_at: null,
@@ -635,7 +636,28 @@ describe('Plot Controller (ContractPlot Model)', () => {
           map_id: 7,
           notes: null,
         },
-        buriedPersons: [],
+        buriedPersons: [
+          {
+            id: 'bp1',
+            name: '山田次郎',
+            name_kana: 'ヤマダジロウ',
+            relationship: '子',
+            birth_date: null,
+            death_date: null,
+            age: null,
+            gender: null,
+            burial_date: null,
+            posthumous_name: null,
+            report_date: null,
+            religion: null,
+            death_place: null,
+            cause_of_death: null,
+            chief_mourner_name: null,
+            chief_mourner_relationship: null,
+            validity_period_years_override: 10, // 区画既定より短い個別指定（komine-docs#10 項目8）
+            notes: null,
+          },
+        ],
         familyContacts: [],
         gravestoneInfo: null,
         constructionInfos: [],
@@ -689,6 +711,7 @@ describe('Plot Controller (ContractPlot Model)', () => {
             contractStatus: 'active',
             paymentStatus: 'paid',
             requestDate: new Date('2023-12-01'),
+            inscription: '連絡は長男へ',
             graveKind: 1,
             graveKubun: 2,
             graveType: 3,
@@ -697,6 +720,12 @@ describe('Plot Controller (ContractPlot Model)', () => {
               id: 'pp1',
               mapId: 7,
             }),
+            buriedPersons: expect.arrayContaining([
+              expect.objectContaining({
+                id: 'bp1',
+                validityPeriodYearsOverride: 10,
+              }),
+            ]),
           }),
         })
       );
@@ -723,6 +752,7 @@ describe('Plot Controller (ContractPlot Model)', () => {
         contractPlot: {
           contractAreaSqm: 3.6,
           saleStatus: 'contracted',
+          inscription: '連絡は長男へ',
         },
         saleContract: {
           contractDate: '2024-01-01',
@@ -787,6 +817,12 @@ describe('Plot Controller (ContractPlot Model)', () => {
       expect(mockPrisma.$transaction).toHaveBeenCalled();
       expect(validateContractArea).toHaveBeenCalled();
       expect(updatePhysicalPlotStatus).toHaveBeenCalled();
+      // 碑文(inscription)が contractPlot.create の data に渡る（komine-docs#10 項目1）
+      expect(mockPrisma.contractPlot.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ inscription: '連絡は長男へ' }),
+        })
+      );
       expect(responseStatus).toHaveBeenCalledWith(201);
       expect(responseJson).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
## 概要
komine-docs#10 の業務確認回答を反映した backend 縦串（types#43/#44 マージ済みに続く2層目）。

- **碑文**: `ContractPlot.inscription`（VarChar120, nullable）。墓誌(`gravestoneInscription`)とは別の「注意書きの一言」。区画一覧表示用。
- **合祀年数の人別上書き**: `BuriedPerson.validity_period_years_override`（Int, nullable）。`null`=区画の合祀年数を継承。人によって短くする運用に対応。

## 変更
- prisma migration `20260608120000_add_inscription_and_burial_validity_override`（2カラム追加・ともに nullable・無停止）
- `createPlot` / `updatePlot`: inscription の保存（updatePlot は履歴 before/after snapshot にも追加）
- `updatePlot` の buriedPerson 同期: `validity_period_years_override` を `bpData`/`serialize` 両方へ
- `getPlots`(一覧) / `getPlotById`(詳細): 両フィールドを返却
- `historyLabels`: 「碑文」「合祀年数（個別）」
- `swagger.yaml`: contractPlot に inscription、buriedPersons に validityPeriodYearsOverride
- `Dockerfile` TYPES_REF → types main `200f417`
- バリデーションは `@komine/types` 共有スキーマ経由で自動適用（backend 側追加なし）

## 設計（業務確認で確定）
- 合祀予定日 = 契約日 + 解決年数（`override ?? 区画年数`）。frontend 表示で導出（起点=契約日）。
- 請求(合祀料金)は区画単位・契約日起点(#164)のまま据え置き。人別上書きは合祀予定日(運用日程)のみに効く。

## 検証
- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm run swagger:validate` ✅
- `npm test` ✅ 全 1195 テスト green（getPlotById/createPlot に新フィールドのアサーション追加）

## 既知の別課題（本PR対象外・別issue化）
- `createPlot` は `buriedPersons` を一切保存しない既存ギャップあり（#219 の FamilyContact と同種）。そのため人別上書きは当面 **編集(updatePlot)経路でのみ**機能する。別issueで対応予定。

## 本番反映（マージ後）
`prisma migrate deploy`（nullable 追加のみ・バックフィル不要）。frontend PR は本PRマージ後に TYPES_REF を揃えて続く。

Refs komine-docs#10