### PR TITLE
feat(plots): 表示用区画番号 display_number を追加 (#158)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bootstrap:admin": "ts-node --transpile-only prisma/seed.ts",
     "seed:masters": "ts-node --transpile-only prisma/seedMasters.ts",
     "migrate:legacy": "ts-node --transpile-only scripts/migrate-from-legacy.ts",
+    "backfill:display-number": "ts-node --transpile-only scripts/backfill-display-number.ts",
     "verify:migration": "ts-node --transpile-only scripts/verify-migration.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/prisma/migrations/20260608100000_add_physical_plot_display_number/migration.sql
+++ b/prisma/migrations/20260608100000_add_physical_plot_display_number/migration.sql
@@ -1,0 +1,4 @@
+-- 表示用区画番号 display_number を追加（#158）
+-- plot_number はユニークキー兼一括取込キーで legacy-{grave_cd} のまま維持し、
+-- レガシー grave_name_cd 由来の表示用番号（例: "A-100"）を非ユニーク列として保持する。
+ALTER TABLE "physical_plots" ADD COLUMN "display_number" VARCHAR(100);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,7 +129,10 @@ enum StaffRole {
 // 物理区画マスタ: 霊園の土地の境界線で区切られた最小単位（3.6㎡区画）
 model PhysicalPlot {
   id          String             @id @default(uuid()) @map("physical_plot_id")
-  plot_number String             @unique @db.VarChar(50) // 区画番号（例: A-56）
+  plot_number String             @unique @db.VarChar(50) // 区画番号（例: A-56）※ユニークキー兼一括取込キー。移行データは legacy-{grave_cd}
+  // 表示用区画番号（レガシー grave_name_cd 由来、例: "A-100"）。grave_name_cd は
+  // 一意でないため plot_number には使えず、表示専用の非ユニーク列として保持。#158
+  display_number String?         @db.VarChar(100)
   area_name   String             @db.VarChar(100) // 区画（期）（例: 1期、2期）
   area_sqm    Decimal            @default(3.6) @db.Decimal(5, 2) // 区画の総面積（基本3.6㎡）
   status      PhysicalPlotStatus @default(available) // 区画ステータス

--- a/scripts/backfill-display-number.ts
+++ b/scripts/backfill-display-number.ts
@@ -1,0 +1,124 @@
+/// <reference types="node" />
+/**
+ * 既存 physical_plots の display_number backfill スクリプト（#158）
+ *
+ * plot_number が `legacy-{grave_cd}` の物理区画について、レガシー
+ * `m_bochi.grave_name_cd` を正規化（全角→半角）して display_number に投入する。
+ *
+ * 使い方:
+ *   npm run backfill:display-number -- --dry-run   # 更新せず件数だけ確認
+ *   npm run backfill:display-number                # 実投入
+ *
+ * 環境変数: LEGACY_MYSQL_* / DATABASE_URL（migrate:legacy と同じ）
+ *
+ * 冪等: display_number が既に入っている行はスキップ（再実行安全）。
+ */
+import 'dotenv/config';
+
+import { prisma } from '../src/db/prisma';
+import { closeLegacyPool, legacyQuery } from './legacy-migration/legacyDb';
+import { normalizeGraveName } from './legacy-migration/transforms';
+
+interface MaisouNameRow {
+  grave_cd: number;
+  grave_name_cd: string | null;
+}
+
+const BATCH = 500;
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+  console.log(`[backfill display_number] start (dryRun=${dryRun})`);
+
+  // 対象: legacy-{grave_cd} 形式で display_number 未設定の物理区画（削除済み含む）
+  const targets = await prisma.physicalPlot.findMany({
+    where: { plot_number: { startsWith: 'legacy-' }, display_number: null },
+    select: { id: true, plot_number: true },
+  });
+  console.log(`対象 physical_plots: ${targets.length} 件`);
+
+  // plot_number から grave_cd を抽出
+  const graveCdById = new Map<string, number>();
+  for (const t of targets) {
+    const cd = Number(t.plot_number.slice('legacy-'.length));
+    if (Number.isInteger(cd)) graveCdById.set(t.id, cd);
+  }
+
+  // レガシーから grave_cd → grave_name_cd を一括取得
+  const allCds = [...new Set(graveCdById.values())];
+  const nameByCd = new Map<number, string | null>();
+  for (let i = 0; i < allCds.length; i += BATCH) {
+    const chunk = allCds.slice(i, i + BATCH);
+    const rows = await legacyQuery<MaisouNameRow & { constructor: { name: 'RowDataPacket' } }>(
+      `SELECT grave_cd, grave_name_cd FROM m_bochi WHERE grave_cd IN (${chunk.map(() => '?').join(',')})`,
+      chunk
+    );
+    for (const r of rows) nameByCd.set(r.grave_cd, r.grave_name_cd);
+  }
+
+  let updated = 0;
+  let skippedNoName = 0;
+  let skippedNoCd = 0;
+  const updates: Array<{ id: string; display: string }> = [];
+  for (const t of targets) {
+    const cd = graveCdById.get(t.id);
+    if (cd === undefined) {
+      skippedNoCd++;
+      continue;
+    }
+    const display = normalizeGraveName(nameByCd.get(cd));
+    if (display === null) {
+      skippedNoName++;
+      continue;
+    }
+    updates.push({ id: t.id, display });
+  }
+
+  if (!dryRun) {
+    // Supabase pooler のインタラクティブ tx は 5s 制限が厳しいため、
+    // 個別 update（各自コミット）を小チャンクで並列実行する。冪等なので
+    // 途中失敗しても再実行で続行できる。
+    const CONCURRENCY = 25;
+    for (let i = 0; i < updates.length; i += CONCURRENCY) {
+      const chunk = updates.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        chunk.map((u) =>
+          prisma.physicalPlot.update({
+            where: { id: u.id },
+            data: { display_number: u.display },
+          })
+        )
+      );
+      updated += chunk.length;
+      if (updated % 500 === 0 || updated === updates.length) {
+        console.log(`  updated ${updated}/${updates.length}`);
+      }
+    }
+  } else {
+    updated = updates.length;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        targets: targets.length,
+        updated,
+        skip_no_grave_name_cd: skippedNoName,
+        skip_no_grave_cd: skippedNoCd,
+        sample: updates.slice(0, 10).map((u) => u.display),
+      },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR', e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeLegacyPool();
+    await prisma.$disconnect();
+  });

--- a/scripts/legacy-migration/steps/03-physical-plot.ts
+++ b/scripts/legacy-migration/steps/03-physical-plot.ts
@@ -1,7 +1,7 @@
 import type { RowDataPacket } from 'mysql2/promise';
 
 import { legacyQuery } from '../legacyDb';
-import { cleanStr } from '../transforms';
+import { cleanStr, normalizeGraveName } from '../transforms';
 import type { MigrationStep } from '../types';
 
 interface BochiPhysicalRow extends RowDataPacket {
@@ -52,6 +52,10 @@ export const stepPhysicalPlot: MigrationStep = {
           ? `${row.chiku_cd}-${row.area_cd}`
           : `unknown-${row.grave_cd}`;
 
+      // 表示用区画番号（grave_name_cd 由来、例: "A-100"）。plot_number は
+      // ユニーク制約・一括取込キーのため legacy-{grave_cd} を維持し、表示はこちら。#158
+      const displayNumber = normalizeGraveName(row.grave_name_cd);
+
       const notes =
         [
           cleanStr(row.note),
@@ -81,6 +85,7 @@ export const stepPhysicalPlot: MigrationStep = {
       const created = await prisma.physicalPlot.create({
         data: {
           plot_number: plotNumber,
+          display_number: displayNumber,
           area_name: areaName,
           area_sqm: 3.6, // デフォルト（実面積はレガシーに無いので 3.6 固定）
           status: 'available', // ContractPlot 側で active があれば後で sold_out に更新

--- a/scripts/legacy-migration/transforms.ts
+++ b/scripts/legacy-migration/transforms.ts
@@ -58,6 +58,21 @@ export function cleanStr(value: unknown): string | null {
 }
 
 /**
+ * 表示用区画番号（grave_name_cd）の正規化。
+ * 全角英数（Ａ-Ｚ ａ-ｚ ０-９）を半角へ変換し、前後空白を除去する。
+ * "A-100" / "1.5-10" 等の区切り・記号や複数区画表記（"3/2・25/2"）はそのまま保持。
+ * 空文字・null は null を返す。#158
+ */
+export function normalizeGraveName(value: unknown): string | null {
+  const s = cleanStr(value);
+  if (s === null) return null;
+  const half = s.replace(/[Ａ-Ｚａ-ｚ０-９]/g, (ch) =>
+    String.fromCharCode(ch.charCodeAt(0) - 0xfee0)
+  );
+  return cleanStr(half);
+}
+
+/**
  * cleanStr の必須版（必ず空でない文字列を返す）
  * デフォルト値を渡さない場合、未設定なら fallback を使う
  */

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -102,6 +102,7 @@ export const getPlotById = async (
       physicalPlot: {
         id: contractPlot.physicalPlot.id,
         plotNumber: contractPlot.physicalPlot.plot_number,
+        displayNumber: contractPlot.physicalPlot.display_number,
         areaName: contractPlot.physicalPlot.area_name,
         areaSqm: contractPlot.physicalPlot.area_sqm.toNumber(),
         status: contractPlot.physicalPlot.status,

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -126,6 +126,11 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
           },
         },
         {
+          physicalPlot: {
+            display_number: { contains: search, mode: 'insensitive' },
+          },
+        },
+        {
           saleContractRoles: {
             some: {
               deleted_at: null,
@@ -247,6 +252,7 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
       physicalPlot: {
         select: {
           plot_number: true,
+          display_number: true,
           area_name: true,
           area_sqm: true,
           status: true,
@@ -364,6 +370,7 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
 
         // 物理区画情報（表示用）
         plotNumber: contractPlot.physicalPlot.plot_number,
+        displayNumber: contractPlot.physicalPlot.display_number,
         areaName: contractPlot.physicalPlot.area_name,
         physicalPlotAreaSqm: contractPlot.physicalPlot.area_sqm.toNumber(),
         physicalPlotStatus: contractPlot.physicalPlot.status,


### PR DESCRIPTION
## 概要

区画No が `legacy-{grave_cd}` のまま表示される問題（#158）を解消。`plot_number`（ユニークキー兼一括取込キー）は維持し、レガシー `grave_name_cd` 由来の表示用番号を `display_number` 列として追加する。

調査根拠: komine-docs `区画名_区画No_正規化マッピング検討.md`（docs #11）。`grave_name_cd` は 11,879/11,880 で実ラベル（"A-100" 等）あり・非一意のため別列。

## 変更

- `PhysicalPlot.display_number` 列追加（migration `20260608100000_add_physical_plot_display_number` 同梱）
- `normalizeGraveName`（全角→半角）を transforms に追加、移行 step03 で投入
- `getPlots` / `getPlotById` が `displayNumber` を返却、フリーテキスト検索対象にも追加
- 既存データ用 backfill スクリプト `scripts/backfill-display-number.ts`（`npm run backfill:display-number`）

## 検証

- `tsc` clean / `eslint` clean / plot controller・routes 66 tests pass
- **Supabase 反映済み**: migration 適用 + backfill 実行で 6,249/6,255 物理区画に display_number 投入済み（"A-6" / "1.5-218" 等）

## マージ順 / 注意

- types #45 を先にマージ → 本リポ Dockerfile `TYPES_REF` を types 新SHAに bump 後マージ（それまで CI は types main 参照のため displayNumber 型で落ちる、既知フロー）
- DB migration / backfill は適用済みのため、本番反映時の追加作業は不要（再実行は冪等）

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)