### PR TITLE
fix(migration): konryu を建立期限/建立日へ再マップ (#326)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "seed:masters": "ts-node --transpile-only prisma/seedMasters.ts",
     "migrate:legacy": "ts-node --transpile-only scripts/migrate-from-legacy.ts",
     "backfill:display-number": "ts-node --transpile-only scripts/backfill-display-number.ts",
+    "backfill:konryu-establishment": "ts-node --transpile-only scripts/backfill-konryu-establishment.ts",
     "verify:migration": "ts-node --transpile-only scripts/verify-migration.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/scripts/backfill-konryu-establishment.ts
+++ b/scripts/backfill-konryu-establishment.ts
@@ -1,0 +1,128 @@
+/// <reference types="node" />
+/**
+ * 建立期限/建立日の器ずれ backfill スクリプト（#326）
+ *
+ * レガシー移行（step05）が建立期限(konryu_kigen)/建立日(konryu_date) を
+ * 誤って ContractPlot.permit_date(許可日)/start_date(開始日) に投入していた。
+ * 正しい器は GravestoneInfo.establishment_deadline/establishment_date。
+ *
+ * 本スクリプトはレガシーDB不要で、移行済み行（legacy_grave_cd IS NOT NULL）の
+ * permit_date → establishment_deadline / start_date → establishment_date へ
+ * DB 内で移送し、ContractPlot.permit_date/start_date を null に戻す。
+ *
+ * アプリ作成行（legacy_grave_cd IS NULL）は正規の許可日/開始日が入りうるため対象外。
+ *
+ * 使い方:
+ *   npx ts-node scripts/backfill-konryu-establishment.ts          # dry-run（件数のみ）
+ *   npx ts-node scripts/backfill-konryu-establishment.ts --apply  # 実際に更新
+ *
+ * 冪等: 実行後は対象行の permit_date/start_date が null になるため再実行で 0 件。
+ *       establishment 側に既存値があれば上書きしない（?? で温存）。
+ */
+import 'dotenv/config';
+
+import { prisma } from '../src/db/prisma';
+
+const APPLY = process.argv.includes('--apply');
+const CONCURRENCY = 25;
+
+async function main(): Promise<void> {
+  console.log(`[backfill konryu→establishment] start (apply=${APPLY})`);
+
+  // 対象: 移行行で permit_date か start_date が入っているもの（= 誤投入された建立期限/建立日）
+  const targets = await prisma.contractPlot.findMany({
+    where: {
+      legacy_grave_cd: { not: null },
+      deleted_at: null,
+      OR: [{ permit_date: { not: null } }, { start_date: { not: null } }],
+    },
+    select: {
+      id: true,
+      permit_date: true,
+      start_date: true,
+      gravestoneInfo: {
+        select: { id: true, establishment_deadline: true, establishment_date: true },
+      },
+    },
+  });
+  console.log(`対象 contract_plots: ${targets.length} 件`);
+
+  let updated = 0;
+  let createdGravestone = 0;
+
+  if (!APPLY) {
+    const missingGravestone = targets.filter((t) => !t.gravestoneInfo).length;
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          targets: targets.length,
+          would_create_gravestone_info: missingGravestone,
+          sample: targets.slice(0, 5).map((t) => ({
+            id: t.id,
+            permit_date: t.permit_date,
+            start_date: t.start_date,
+            has_gravestone: !!t.gravestoneInfo,
+          })),
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  for (let i = 0; i < targets.length; i += CONCURRENCY) {
+    const chunk = targets.slice(i, i + CONCURRENCY);
+    await Promise.all(
+      chunk.map(async (t) => {
+        const deadline = t.gravestoneInfo?.establishment_deadline ?? t.permit_date;
+        const date = t.gravestoneInfo?.establishment_date ?? t.start_date;
+
+        // GravestoneInfo へ建立期限/建立日を移送（無ければ作成）
+        if (t.gravestoneInfo) {
+          await prisma.gravestoneInfo.update({
+            where: { id: t.gravestoneInfo.id },
+            data: { establishment_deadline: deadline, establishment_date: date },
+          });
+        } else {
+          await prisma.gravestoneInfo.create({
+            data: {
+              contract_plot_id: t.id,
+              establishment_deadline: deadline,
+              establishment_date: date,
+            },
+          });
+          createdGravestone++;
+        }
+
+        // 誤投入された permit_date/start_date を null に戻す
+        await prisma.contractPlot.update({
+          where: { id: t.id },
+          data: { permit_date: null, start_date: null },
+        });
+      })
+    );
+    updated += chunk.length;
+    if (updated % 500 === 0 || updated === targets.length) {
+      console.log(`  updated ${updated}/${targets.length}`);
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      { targets: targets.length, updated, created_gravestone_info: createdGravestone },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR', e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -143,7 +143,16 @@ export const stepContractPlot: MigrationStep = {
         inserted++;
         if (row.shiyouryou) usageFeeInserted++;
         if (row.kanriryou) managementFeeInserted++;
-        if (row.boshi || row.houi_id || row.ichi_id) gravestoneInserted++;
+        // 実挿入条件（下記 GravestoneInfo.create のガード）と一致させる（#326）
+        if (
+          row.boshi ||
+          row.houi_id != null ||
+          row.ichi_id != null ||
+          row.bosekiryou != null ||
+          row.konryu_kigen != null ||
+          row.konryu_date != null
+        )
+          gravestoneInserted++;
         continue;
       }
 
@@ -172,8 +181,12 @@ export const stepContractPlot: MigrationStep = {
         reservation_date: parseLegacyDate(row.reserve_date),
         acceptance_number: row.auth_no != null ? String(row.auth_no) : null,
         acceptance_date: parseLegacyDate(row.auth_date),
-        permit_date: parseLegacyDate(row.konryu_kigen),
-        start_date: parseLegacyDate(row.konryu_date),
+        // 許可日(permit_date)/開始日(start_date) はレガシーの真の対応列が未確定（komine-docs#10 項目5）。
+        // 以前は konryu_kigen(建立期限)/konryu_date(建立日) を誤って入れていた（#326）。
+        // 建立期限/建立日は GravestoneInfo.establishment_deadline/establishment_date へ移す（下記）。
+        // 真の許可日列が確定するまで null。
+        permit_date: null,
+        start_date: null,
         notes: cleanStr(row.note),
       };
 
@@ -233,8 +246,16 @@ export const stepContractPlot: MigrationStep = {
         managementFeeInserted++;
       }
 
-      // GravestoneInfo（boshi/houi_id/ichi_id/bosekiryou のどれかがあれば作成）
-      if (row.boshi || row.houi_id != null || row.ichi_id != null || row.bosekiryou != null) {
+      // GravestoneInfo（boshi/houi_id/ichi_id/bosekiryou/konryu_kigen/konryu_date のどれかがあれば作成）
+      // 建立期限(konryu_kigen)/建立日(konryu_date) は establishment_deadline/establishment_date が正しい器（#326）。
+      if (
+        row.boshi ||
+        row.houi_id != null ||
+        row.ichi_id != null ||
+        row.bosekiryou != null ||
+        row.konryu_kigen != null ||
+        row.konryu_date != null
+      ) {
         await prisma.gravestoneInfo.create({
           data: {
             contract_plot_id: contractPlot.id,
@@ -242,6 +263,8 @@ export const stepContractPlot: MigrationStep = {
             direction_id: row.houi_id ?? null,
             position_id: row.ichi_id ?? null,
             gravestone_cost: row.bosekiryou ?? null,
+            establishment_deadline: parseLegacyDate(row.konryu_kigen),
+            establishment_date: parseLegacyDate(row.konryu_date),
           },
         });
         gravestoneInserted++;

--- a/tests/scripts/legacy-migration/steps/konryu-establishment-mapping.test.ts
+++ b/tests/scripts/legacy-migration/steps/konryu-establishment-mapping.test.ts
@@ -1,0 +1,84 @@
+/**
+ * 回帰テスト: 建立期限/建立日のマッピング修正（#326）
+ *
+ * step05 は以前 konryu_kigen(建立期限)/konryu_date(建立日) を
+ * ContractPlot.permit_date(許可日)/start_date(開始日) に誤投入していた。
+ * 正しい器は GravestoneInfo.establishment_deadline/establishment_date。
+ * permit_date/start_date は真の許可日列が未確定（komine-docs#10 項目5）のため null。
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepContractPlot } from '../../../../scripts/legacy-migration/steps/05-contract-plot';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+describe('step05 konryu → establishment マッピング (#326)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  it('konryu_kigen/konryu_date を GravestoneInfo へ入れ、permit_date/start_date は null にする', async () => {
+    const contractPlotCreate = jest.fn().mockResolvedValue({ id: 'cp-1' });
+    const gravestoneInfoCreate = jest.fn().mockResolvedValue({ id: 'gi-1' });
+
+    const prisma = {
+      physicalPlot: { findMany: jest.fn(), update: jest.fn() },
+      contractPlot: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: contractPlotCreate,
+      },
+      usageFee: { create: jest.fn() },
+      managementFee: { create: jest.fn() },
+      gravestoneInfo: { create: gravestoneInfoCreate },
+    } as unknown as PrismaClient;
+
+    // boshi/houi_id/ichi_id/bosekiryou は無し → 建立期限/建立日のみで GravestoneInfo が作られる
+    mockedLegacyQuery.mockResolvedValueOnce([
+      {
+        grave_cd: 500,
+        danka_cd: 100,
+        status: 1, // active
+        konryu_kigen: 20200101,
+        konryu_date: 20200201,
+        note: null,
+      },
+    ]);
+
+    const idMaps = createIdMaps();
+    idMaps.physicalPlot.set(500, 'pp-1'); // rebuildIdMap を no-op にする
+
+    await stepContractPlot.run({ prisma, logger: buildLogger(), idMaps, dryRun: false });
+
+    // permit_date/start_date は null（誤投入しない）
+    expect(contractPlotCreate).toHaveBeenCalledTimes(1);
+    const cpData = contractPlotCreate.mock.calls[0][0].data;
+    expect(cpData.permit_date).toBeNull();
+    expect(cpData.start_date).toBeNull();
+
+    // GravestoneInfo に建立期限/建立日が入る
+    expect(gravestoneInfoCreate).toHaveBeenCalledTimes(1);
+    const giData = gravestoneInfoCreate.mock.calls[0][0].data;
+    expect(giData.establishment_deadline).toBeInstanceOf(Date);
+    expect(giData.establishment_date).toBeInstanceOf(Date);
+    expect(giData.contract_plot_id).toBe('cp-1');
+  });
+});


### PR DESCRIPTION
## 概要

レガシー移行 step05 が建立期限(`konryu_kigen`)/建立日(`konryu_date`) を **誤って** `ContractPlot.permit_date`(許可日)/`start_date`(開始日) に投入していた（komine-docs#10 項目4・5）。正しい器は `GravestoneInfo.establishment_deadline`/`establishment_date`。

## 変更

- **再マップ**: `konryu_kigen → establishment_deadline` / `konryu_date → establishment_date`。GravestoneInfo の作成ガードに konryu 系を追加（boshi/houi/ichi/bosekiryou が無くても建立日があれば作成）。dry-run カウント条件も実挿入条件に一致。
- **permit_date/start_date は null** に変更。レガシーの真の「許可日」列が未確定（komine-docs#10 項目5）。確定後に別途投入。
- **backfill スクリプト** `scripts/backfill-konryu-establishment.ts`（`npm run backfill:konryu-establishment`）。移行済み行（`legacy_grave_cd IS NOT NULL`）の `permit_date → establishment_deadline` / `start_date → establishment_date` を **レガシーDB不要でDB内移送**し、permit_date/start_date を null に戻す。アプリ作成行（`legacy_grave_cd IS NULL`）は正規の許可日が入りうるため対象外。default dry-run・`--apply` で実行・冪等。
- 回帰テスト追加。

## 残（本番運用）

コードマージ後に `npm run backfill:konryu-establishment -- --apply` を本番DBに実行（#163 のデプロイに同梱可）。

## 検証

- `npx tsc --noEmit` clean / `npm run lint` clean
- migration テスト 33 passed（新規1件含む）

Closes #326
Refs komine-docs#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)