### PR TITLE
fix(migration): レガシー値のUI露出を解消（方位/位置・続柄・宗派） (#333)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "migrate:legacy": "ts-node --transpile-only scripts/migrate-from-legacy.ts",
     "backfill:display-number": "ts-node --transpile-only scripts/backfill-display-number.ts",
     "backfill:konryu-establishment": "ts-node --transpile-only scripts/backfill-konryu-establishment.ts",
+    "backfill:legacy-value-cleanup": "ts-node --transpile-only scripts/backfill-legacy-value-cleanup.ts",
     "verify:migration": "ts-node --transpile-only scripts/verify-migration.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/scripts/backfill-legacy-value-cleanup.ts
+++ b/scripts/backfill-legacy-value-cleanup.ts
@@ -1,0 +1,102 @@
+/// <reference types="node" />
+/**
+ * レガシー値の UI 露出を解消する backfill（#333）
+ *
+ * 移行済みデータに残る「未設定センチネル/生レガシーint」を正規化する:
+ *  1. gravestone_infos.direction_id / position_id = 0 → null（方位/位置の「旧コード:0」）
+ *  2. family_contacts.relationship の生int → 続柄マスタ名（'0'/未解決は 'unknown'）
+ *  3. buried_persons.religion = 'legacy-shuuha-*' → null（宗派マスタ不要確定）
+ *
+ * いずれもアプリ作成データには影響しない（0/センチネル/生int は移行由来のみ）。
+ *
+ * 使い方:
+ *   npx ts-node scripts/backfill-legacy-value-cleanup.ts          # dry-run（件数のみ）
+ *   npx ts-node scripts/backfill-legacy-value-cleanup.ts --apply  # 実際に更新
+ *
+ * 冪等: 実行後は対象（0 / 生int / legacy-shuuha-*）が消えるため再実行で 0 件。
+ */
+import 'dotenv/config';
+
+import { prisma } from '../src/db/prisma';
+import {
+  loadRelationshipNameMap,
+  resolveRelationship,
+} from './legacy-migration/lib/relationship-resolver';
+
+const APPLY = process.argv.includes('--apply');
+
+async function backfillDirectionPosition(): Promise<Record<string, number>> {
+  if (!APPLY) {
+    const direction = await prisma.gravestoneInfo.count({ where: { direction_id: 0 } });
+    const position = await prisma.gravestoneInfo.count({ where: { position_id: 0 } });
+    return { direction_id_zero: direction, position_id_zero: position };
+  }
+  const direction = await prisma.gravestoneInfo.updateMany({
+    where: { direction_id: 0 },
+    data: { direction_id: null },
+  });
+  const position = await prisma.gravestoneInfo.updateMany({
+    where: { position_id: 0 },
+    data: { position_id: null },
+  });
+  return { direction_id_nulled: direction.count, position_id_nulled: position.count };
+}
+
+async function backfillRelationship(): Promise<Record<string, unknown>> {
+  const nameMap = await loadRelationshipNameMap(prisma);
+
+  // 生int（数字のみ）の relationship を持つ family_contacts を値ごとに集計
+  const groups = await prisma.familyContact.groupBy({
+    by: ['relationship'],
+    _count: { _all: true },
+  });
+  const numericGroups = groups.filter((g) => /^\d+$/.test(g.relationship));
+
+  const plan = numericGroups.map((g) => ({
+    from: g.relationship,
+    to: resolveRelationship(g.relationship, nameMap),
+    count: g._count._all,
+  }));
+
+  if (!APPLY) {
+    return { numeric_relationship_groups: plan };
+  }
+
+  let updated = 0;
+  for (const p of plan) {
+    const r = await prisma.familyContact.updateMany({
+      where: { relationship: p.from },
+      data: { relationship: p.to },
+    });
+    updated += r.count;
+  }
+  return { updated, plan };
+}
+
+async function backfillReligion(): Promise<Record<string, number>> {
+  const where = { religion: { startsWith: 'legacy-shuuha-' } };
+  if (!APPLY) {
+    return { legacy_shuuha_religion: await prisma.buriedPerson.count({ where }) };
+  }
+  const r = await prisma.buriedPerson.updateMany({ where, data: { religion: null } });
+  return { religion_nulled: r.count };
+}
+
+async function main(): Promise<void> {
+  console.log(`[backfill legacy-value-cleanup] start (apply=${APPLY})`);
+
+  const directionPosition = await backfillDirectionPosition();
+  const relationship = await backfillRelationship();
+  const religion = await backfillReligion();
+
+  console.log(JSON.stringify({ apply: APPLY, directionPosition, relationship, religion }, null, 2));
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR', e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/legacy-migration/lib/relationship-resolver.ts
+++ b/scripts/legacy-migration/lib/relationship-resolver.ts
@@ -1,0 +1,48 @@
+/**
+ * 続柄（zokugara）の生レガシー値 → 続柄マスタ名 解決（#333）
+ *
+ * レガシー t_family.zokugara は続柄マスタ（KBNNO=2009）の NMCODE を数字文字列で
+ * 保持している（例: '13'）。フロントは続柄を「名称」で保存・照合する
+ * （ContactsTab は `value={r.name}` / MasterFallbackSelectItem matchBy='name'）ため、
+ * 移行データも名称で保存しないと詳細画面に生int（'13'）、編集画面に未解決値が露出する。
+ *
+ * 埋葬者(buried_persons.relationship)は元から名称で保存しており、これに揃える。
+ */
+import type { PrismaClient } from '@prisma/client';
+
+const RELATIONSHIP_KBNNO = '2009';
+
+/** 続柄マスタを読み込み NMCODE(文字列) → 名称 の対応表を返す。 */
+export async function loadRelationshipNameMap(
+  prisma: Pick<PrismaClient, 'relationshipMaster'>
+): Promise<Map<string, string>> {
+  const rows = await prisma.relationshipMaster.findMany({
+    select: { code: true, name: true },
+  });
+  const map = new Map<string, string>();
+  for (const r of rows) {
+    // code は `2009-${NMCODE}`。NMCODE で引けるようにする。
+    const m = r.code.match(new RegExp(`^${RELATIONSHIP_KBNNO}-(.+)$`));
+    if (m) map.set(m[1], r.name);
+  }
+  return map;
+}
+
+/**
+ * 生 zokugara 値を保存用の続柄文字列に解決する。
+ *  - 数字（マスタにあり） → マスタ名称
+ *  - 数字（'0' やマスタに無い） → 'unknown'（未設定。relationship は NOT NULL のため）
+ *  - 自由記述（数字でない） → そのまま（既に名称）
+ *  - null/空 → 'unknown'
+ */
+export function resolveRelationship(
+  raw: string | null | undefined,
+  nameMap: Map<string, string>
+): string {
+  const cleaned = raw?.trim();
+  if (!cleaned) return 'unknown';
+  if (/^\d+$/.test(cleaned)) {
+    return nameMap.get(cleaned) ?? 'unknown';
+  }
+  return cleaned;
+}

--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -260,8 +260,10 @@ export const stepContractPlot: MigrationStep = {
           data: {
             contract_plot_id: contractPlot.id,
             gravestone_inscription: cleanStr(row.boshi),
-            direction_id: row.houi_id ?? null,
-            position_id: row.ichi_id ?? null,
+            // 0 は「未設定」センチネル（方位マスタ code=1〜8 / 位置 code=1〜3、0 は無い）。
+            // 0 を残すと UI で「旧コード: 0」が露出するため null に正規化する（#333）。
+            direction_id: row.houi_id || null,
+            position_id: row.ichi_id || null,
             gravestone_cost: row.bosekiryou ?? null,
             establishment_deadline: parseLegacyDate(row.konryu_kigen),
             establishment_date: parseLegacyDate(row.konryu_date),

--- a/scripts/legacy-migration/steps/07-family-contact.ts
+++ b/scripts/legacy-migration/steps/07-family-contact.ts
@@ -3,6 +3,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
 import { assertIdMapsReady } from '../lib/invariants';
+import { loadRelationshipNameMap, resolveRelationship } from '../lib/relationship-resolver';
 import { cleanPhone, cleanStr, joinName, parseLegacyDate, parseLegacyZip } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -76,6 +77,9 @@ export const stepFamilyContact: MigrationStep = {
     for (const c of terminatedCustomers) {
       if (c.legacy_danka_cd != null) terminatedCustomerMap.set(c.legacy_danka_cd, c.id);
     }
+
+    // 続柄マスタ（NMCODE→名称）。生 zokugara int を名称へ解決する（#333）
+    const relationshipNameMap = await loadRelationshipNameMap(prisma);
 
     const rows = await legacyQuery<FamilyRow>(
       `SELECT * FROM t_family WHERE del_flg = 0 OR del_flg IS NULL`
@@ -166,7 +170,7 @@ export const stepFamilyContact: MigrationStep = {
           name,
           name_kana: joinName(row.family_sei_kana, row.family_mei_kana),
           birth_date: parseLegacyDate(row.birthday),
-          relationship: cleanStr(row.zokugara) ?? 'unknown',
+          relationship: resolveRelationship(row.zokugara, relationshipNameMap),
           postal_code: parseLegacyZip(row.zip),
           address: addressParts.length > 0 ? addressParts.join(' ') : null,
           phone_number: cleanPhone(row.tel1),

--- a/scripts/legacy-migration/steps/08-buried-person.ts
+++ b/scripts/legacy-migration/steps/08-buried-person.ts
@@ -111,7 +111,10 @@ export const stepBuriedPerson: MigrationStep = {
           burial_date: parseLegacyDate(row.maisou_date),
           posthumous_name: cleanStr(row.kaimyou),
           report_date: parseLegacyDate(row.request_day),
-          religion: row.shuuha != null ? `legacy-shuuha-${row.shuuha}` : null,
+          // 宗派マスタは不要確定（業務確認済）。レガシー shuuha int は解決先が無く、
+          // `legacy-shuuha-N` センチネルをそのまま入れると UI に露出する（#333）。
+          // shuuha=0 は「未設定」。解決先が無いため全件 null 保存にする。
+          religion: null,
           death_place: cleanStr(row.siboubasyo),
           cause_of_death: cleanStr(row.siin),
           chief_mourner_name: joinName(row.moshu_sei, row.moshu_mei),

--- a/tests/scripts/legacy-migration/relationship-resolver.test.ts
+++ b/tests/scripts/legacy-migration/relationship-resolver.test.ts
@@ -1,0 +1,55 @@
+/**
+ * 続柄解決ヘルパーの単体テスト（#333）
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import {
+  loadRelationshipNameMap,
+  resolveRelationship,
+} from '../../../scripts/legacy-migration/lib/relationship-resolver';
+
+describe('loadRelationshipNameMap', () => {
+  it('code `2009-N` から NMCODE→名称 の対応表を作る', async () => {
+    const prisma = {
+      relationshipMaster: {
+        findMany: jest.fn().mockResolvedValue([
+          { code: '2009-1', name: '本人' },
+          { code: '2009-13', name: '配偶者' },
+          { code: 'other-5', name: '無関係' }, // 2009- 以外は無視
+        ]),
+      },
+    } as unknown as PrismaClient;
+
+    const map = await loadRelationshipNameMap(prisma);
+    expect(map.get('1')).toBe('本人');
+    expect(map.get('13')).toBe('配偶者');
+    expect(map.has('5')).toBe(false);
+  });
+});
+
+describe('resolveRelationship', () => {
+  const nameMap = new Map<string, string>([
+    ['1', '本人'],
+    ['13', '配偶者'],
+  ]);
+
+  it('マスタにある生int は名称へ解決する', () => {
+    expect(resolveRelationship('13', nameMap)).toBe('配偶者');
+    expect(resolveRelationship('1', nameMap)).toBe('本人');
+  });
+
+  it("'0' やマスタ未登録の数字は 'unknown'（未設定）になる", () => {
+    expect(resolveRelationship('0', nameMap)).toBe('unknown');
+    expect(resolveRelationship('99', nameMap)).toBe('unknown');
+  });
+
+  it('null/空は unknown', () => {
+    expect(resolveRelationship(null, nameMap)).toBe('unknown');
+    expect(resolveRelationship('   ', nameMap)).toBe('unknown');
+  });
+
+  it('数字でない自由記述はそのまま（既に名称）', () => {
+    expect(resolveRelationship('配偶者', nameMap)).toBe('配偶者');
+    expect(resolveRelationship('友人', nameMap)).toBe('友人');
+  });
+});

--- a/tests/scripts/legacy-migration/steps/dryrun-resume.test.ts
+++ b/tests/scripts/legacy-migration/steps/dryrun-resume.test.ts
@@ -49,6 +49,7 @@ describe('legacy migration resume + dry-run (issue #163)', () => {
       customer: { findMany: customerFindMany },
       contractPlot: { findMany: contractPlotFindMany },
       familyContact: { create: familyContactCreate },
+      relationshipMaster: { findMany: jest.fn().mockResolvedValue([]) },
     } as unknown as PrismaClient;
 
     // 1回目: t_danka (danka_cd→grave_cd), 2回目: 解約者 danka（del_flg=2 #311）, 3回目: t_family 本体

--- a/tests/scripts/legacy-migration/steps/family-relationship-mapping.test.ts
+++ b/tests/scripts/legacy-migration/steps/family-relationship-mapping.test.ts
@@ -1,0 +1,91 @@
+/**
+ * 回帰テスト: step07 の続柄(zokugara)生int → 続柄マスタ名 解決（#333）
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepFamilyContact } from '../../../../scripts/legacy-migration/steps/07-family-contact';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+const familyRow = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+  family_cd: 1,
+  danka_cd: 100,
+  family_sei: '山田',
+  family_mei: '太郎',
+  addr1: null,
+  addr2: null,
+  addr3: null,
+  job_addr1: null,
+  job_addr2: null,
+  job_addr3: null,
+  ...overrides,
+});
+
+describe('stepFamilyContact: 続柄の名称解決 (#333)', () => {
+  beforeEach(() => {
+    mockedLegacyQuery.mockReset();
+  });
+
+  it('生int zokugara を続柄マスタ名に解決し、0/未解決は unknown にする', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = {
+      customer: { findMany: jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]) },
+      contractPlot: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'cp-1', legacy_grave_cd: 500 }]),
+      },
+      familyContact: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+          created.push(data);
+          return Promise.resolve({ id: `fc-${created.length}` });
+        }),
+      },
+      relationshipMaster: {
+        findMany: jest.fn().mockResolvedValue([
+          { code: '2009-13', name: '配偶者' },
+          { code: '2009-1', name: '本人' },
+        ]),
+      },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([{ danka_cd: 100, grave_cd: 500 }]) // del_flg=0 danka
+      .mockResolvedValueOnce([]) // 解約者 danka なし
+      .mockResolvedValueOnce([
+        familyRow({ family_cd: 1, zokugara: '13' }), // → 配偶者
+        familyRow({ family_cd: 2, zokugara: '0', family_mei: '次郎' }), // → unknown（未設定）
+        familyRow({ family_cd: 3, zokugara: '友人', family_mei: '三郎' }), // 自由記述はそのまま
+      ]);
+
+    await stepFamilyContact.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    const byCd = (cd: number) => created.find((d) => d['legacy_family_cd'] === cd);
+    expect(byCd(1)?.['relationship']).toBe('配偶者');
+    expect(byCd(2)?.['relationship']).toBe('unknown');
+    expect(byCd(3)?.['relationship']).toBe('友人');
+  });
+});

--- a/tests/scripts/legacy-migration/steps/idempotency.test.ts
+++ b/tests/scripts/legacy-migration/steps/idempotency.test.ts
@@ -50,6 +50,7 @@ describe('移行ステップの冪等性 (#220)', () => {
         create: familyContactCreate,
         findUnique: jest.fn().mockResolvedValue({ id: 'fc-existing', legacy_family_cd: 1 }),
       },
+      relationshipMaster: { findMany: jest.fn().mockResolvedValue([]) },
     } as unknown as PrismaClient;
 
     mockedLegacyQuery

--- a/tests/scripts/legacy-migration/steps/terminated-family.test.ts
+++ b/tests/scripts/legacy-migration/steps/terminated-family.test.ts
@@ -79,6 +79,7 @@ describe('stepFamilyContact: 解約者紐づき family の取込 (#311)', () => 
           return Promise.resolve({ id: `fc-${created.length}` });
         }),
       },
+      relationshipMaster: { findMany: jest.fn().mockResolvedValue([]) },
     } as unknown as PrismaClient;
   };
 


### PR DESCRIPTION
## 概要

実DB突き合わせで露出していた3フィールドを移行側で正規化する。**いずれも frontend 変更不要**（0/センチネル → null は InfoField/resolveMasterName が「未登録」表示、続柄は名称を直表示）。

| 項目 | 現状（露出） | 対応 |
|---|---|---|
| 方位/位置 `direction_id`/`position_id` | 全件「旧コード: 0」 | 未設定センチネル `0` → `null`（マスタ code は 1〜8 / 1〜3 で 0 は無い） |
| 続柄(連絡先) `relationship` | 生int（'13' 等） | 続柄マスタ名へ解決（'0'/未解決は `unknown`）。frontend は続柄を**名称**で保存・照合（ContactsTab `value={r.name}` / matchBy='name'）するため名称に揃える＝埋葬者側と統一 |
| 宗派 `religion` | `legacy-shuuha-0` 等 | 宗派マスタ不要確定のため `legacy-shuuha-*` センチネルを全件 `null` |

## 変更

- 移行: `05-contract-plot`（方位/位置 0→null）、`07-family-contact`（続柄解決）、`08-buried-person`（宗派 null）
- 共有ヘルパー `scripts/legacy-migration/lib/relationship-resolver.ts`（マスタ NMCODE→名称 / 生int解決）
- backfill: `scripts/backfill-legacy-value-cleanup.ts`（3項目一括・default dry-run・`--apply`・冪等・**アプリ作成データ非対象**）。`npm run backfill:legacy-value-cleanup`
- テスト: resolver 単体 + step07 統合 + 既存 step07 モックに `relationshipMaster` 補完

## スコープ外（確認済）

`chief_mourner_relationship`(`legacy-zokugara-*`)・`death_place`・`cause_of_death` は **UI 非表示**（plot-detail-view / plot-form に出力箇所なし）のため #333 対象外。

## 残（本番運用）

コードマージ後に `npm run backfill:legacy-value-cleanup -- --apply` を本番DBに実行（#163 同梱可）。

## 検証

- `npx tsc --noEmit` clean / `npm run lint` clean
- `npm test` → 1203 passed（新規3件）

Closes #333
Refs #46, #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)