### PR TITLE
feat(migration): t_dankalog/t_famlog → History 取込ステップを追加 (#324)

### DIFF
--- a/prisma/migrations/20260608140000_add_history_legacy_log_keys/migration.sql
+++ b/prisma/migrations/20260608140000_add_history_legacy_log_keys/migration.sql
@@ -1,0 +1,10 @@
+-- #324: レガシー履歴（t_dankalog / t_famlog）→ History 取込の冪等キーを追加。
+-- 各ログ行の PK（danka_log_cd / family_log_id）をテーブル名と組で一意にし、
+-- 再実行時の重複INSERTを防ぐ（billing/payment の legacy_*_cd と同形の冪等パターン）。
+
+-- AlterTable
+ALTER TABLE "histories" ADD COLUMN "legacy_log_cd" INTEGER;
+ALTER TABLE "histories" ADD COLUMN "legacy_log_table" VARCHAR(20);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "histories_legacy_log_table_legacy_log_cd_key" ON "histories"("legacy_log_table", "legacy_log_cd");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -569,10 +569,16 @@ model History {
   ip_address       String?    @db.VarChar(50) // 変更元IPアドレス
   created_at       DateTime   @default(now())
 
+  // レガシー履歴（t_dankalog / t_famlog）取込の冪等キー（#324）。
+  // 各ログ行の PK（danka_log_cd / family_log_id）をテーブル名と組で一意にし、再実行時の重複INSERTを防ぐ。
+  legacy_log_cd    Int? // ログ行の PK
+  legacy_log_table String? @db.VarChar(20) // 't_dankalog' / 't_famlog'
+
   // Relations
   physicalPlot PhysicalPlot? @relation(fields: [physical_plot_id], references: [id], onDelete: SetNull)
   contractPlot ContractPlot? @relation(fields: [contract_plot_id], references: [id], onDelete: SetNull)
 
+  @@unique([legacy_log_table, legacy_log_cd])
   @@index([entity_type, entity_id])
   @@index([physical_plot_id])
   @@index([contract_plot_id])

--- a/scripts/legacy-migration/steps/14-history.ts
+++ b/scripts/legacy-migration/steps/14-history.ts
@@ -1,0 +1,285 @@
+import type { Prisma } from '@prisma/client';
+import type { RowDataPacket } from 'mysql2/promise';
+
+import { legacyQuery } from '../legacyDb';
+import { rebuildIdMap } from '../lib/id-map-loader';
+import { assertIdMapsReady } from '../lib/invariants';
+import { parseLegacyDate } from '../transforms';
+import type { MigrationStep } from '../types';
+
+/**
+ * t_dankalog / t_famlog → History（#324）
+ *
+ * レガシーの履歴テーブルはスナップショット形式（変更のたびに全カラムを1行で保持）。
+ * 同一エンティティ（danka_cd / family_cd）の連続レコードを世代順に比較して
+ * changed_fields / before_record / after_record(JSON) を生成し History に取り込む。
+ *
+ *   - t_dankalog → entity_type='Customer'（entity_id=Customer UUID）
+ *   - t_famlog   → entity_type='FamilyContact'（entity_id=FamilyContact UUID）
+ *
+ * 設計上の前提（business-confirmation 項目。komine-docs#10 / 本 issue で要確認）:
+ *   - 世代の並び順は rireki_cd ASC（無ければ reg_date / PK）。rireki_cd は名義変更
+ *     世代番号の可能性があり、確定したら並び順の妥当性を再確認する。
+ *   - 各エンティティの最初のスナップショットは CREATE（before=null, after=全項目）、
+ *     以降は UPDATE（changed_fields と差分の before/after のみ）として記録する。
+ *   - change_reason（t_opelog の担当者メモ）の取り込みは未対応（業務確認後に追加可能）。
+ *   - changed_by は t_dankalog.tancd → `legacy-tancd-${tancd}`。t_famlog は tancd 列が無く null。
+ *
+ * 冪等性: 各ログ行 PK（danka_log_cd / family_log_id）を
+ *   History.legacy_log_cd + legacy_log_table の複合ユニークで一意化し、
+ *   createMany({ skipDuplicates }) と既存キー事前ロードで再実行時の重複を防ぐ。
+ *
+ * 本番投入: `npm run migrate:legacy -- --only=history`（#163 のデプロイに同梱可）。
+ */
+
+type LogRow = RowDataPacket & Record<string, unknown>;
+
+// スナップショット差分の対象外（ログ管理メタ列）
+const DANKALOG_META = new Set([
+  'danka_log_cd',
+  'rireki_cd',
+  'reg_date',
+  'mod_date',
+  'del_date',
+  'del_flg',
+  'tancd',
+]);
+const FAMLOG_META = new Set([
+  'family_log_id',
+  'rireki_cd',
+  'reg_date',
+  'mod_date',
+  'del_date',
+  'del_flg',
+]);
+
+/** メタ列を除いたエンティティ状態のスナップショットを作る。 */
+function buildSnapshot(row: Record<string, unknown>, meta: Set<string>): Record<string, unknown> {
+  const snap: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    if (!meta.has(k)) snap[k] = v ?? null;
+  }
+  return snap;
+}
+
+/** 値の等価判定（mysql の型ゆれを文字列で吸収）。 */
+function normalize(v: unknown): string {
+  return v == null ? '' : String(v);
+}
+
+/** before→after で変化したフィールド名の配列。 */
+function diffFields(before: Record<string, unknown>, after: Record<string, unknown>): string[] {
+  const changed: string[] = [];
+  for (const k of Object.keys(after)) {
+    if (normalize(before[k]) !== normalize(after[k])) changed.push(k);
+  }
+  return changed;
+}
+
+/** 指定キーだけ抜き出した部分レコード。 */
+function pick(record: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of keys) out[k] = record[k] ?? null;
+  return out;
+}
+
+interface BuildEntriesParams {
+  rows: LogRow[];
+  groupKey: string; // 'danka_cd' | 'family_cd'
+  meta: Set<string>;
+  entityType: 'Customer' | 'FamilyContact';
+  table: 't_dankalog' | 't_famlog';
+  existingKeys: Set<string>;
+  /** 1行から entity_id / contract_plot_id / physical_plot_id / changed_by を解決。null entityId なら group ごとスキップ。 */
+  resolve: (row: LogRow) => {
+    entityId: string | null;
+    contractPlotId: string | null;
+    physicalPlotId: string | null;
+    changedBy: string | null;
+  };
+  counters: { skipNoEntity: number; skipExisting: number; skipNoChange: number };
+}
+
+function buildEntries(params: BuildEntriesParams): Prisma.HistoryCreateManyInput[] {
+  const { rows, groupKey, meta, entityType, table, existingKeys, resolve, counters } = params;
+  const entries: Prisma.HistoryCreateManyInput[] = [];
+
+  let i = 0;
+  while (i < rows.length) {
+    const gid: unknown = rows[i][groupKey];
+    // 同一エンティティの連続行を取り出す（rows は groupKey, rireki_cd でソート済み）
+    const group: LogRow[] = [];
+    while (i < rows.length && (rows[i][groupKey] as unknown) === gid) {
+      group.push(rows[i]);
+      i++;
+    }
+
+    const resolved = resolve(group[0]);
+    if (!resolved.entityId) {
+      counters.skipNoEntity += group.length;
+      continue;
+    }
+
+    let prev: Record<string, unknown> | null = null;
+    for (const row of group) {
+      const pk = row[table === 't_dankalog' ? 'danka_log_cd' : 'family_log_id'] as number;
+      const snapshot = buildSnapshot(row, meta);
+      const key = `${table}:${pk}`;
+
+      const isCreate = prev === null;
+      const changed = isCreate ? [] : diffFields(prev as Record<string, unknown>, snapshot);
+
+      // 変化なしの UPDATE 行はノイズなので記録しない（prev は更新する）
+      if (!isCreate && changed.length === 0) {
+        counters.skipNoChange++;
+        prev = snapshot;
+        continue;
+      }
+      if (existingKeys.has(key)) {
+        counters.skipExisting++;
+        prev = snapshot;
+        continue;
+      }
+
+      const perRow = resolve(row);
+      const createdAt = parseLegacyDate(row.reg_date) ?? parseLegacyDate(row.mod_date);
+
+      entries.push({
+        entity_type: entityType,
+        entity_id: resolved.entityId,
+        contract_plot_id: perRow.contractPlotId,
+        physical_plot_id: perRow.physicalPlotId,
+        action_type: isCreate ? 'CREATE' : 'UPDATE',
+        before_record: isCreate ? undefined : (pick(prev!, changed) as Prisma.InputJsonValue),
+        after_record: (isCreate ? snapshot : pick(snapshot, changed)) as Prisma.InputJsonValue,
+        changed_fields: isCreate ? undefined : (changed as unknown as Prisma.InputJsonValue),
+        changed_by: perRow.changedBy,
+        ...(createdAt ? { created_at: createdAt } : {}),
+        legacy_log_cd: pk,
+        legacy_log_table: table,
+      });
+      prev = snapshot;
+    }
+  }
+
+  return entries;
+}
+
+export const stepHistory: MigrationStep = {
+  name: 'history',
+  dependsOn: ['customer', 'contractPlot', 'familyContact'],
+  async run({ prisma, logger, idMaps, dryRun }) {
+    await rebuildIdMap(prisma, idMaps, 'customer', logger);
+    await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
+    await rebuildIdMap(prisma, idMaps, 'physicalPlot', logger);
+    assertIdMapsReady('history', idMaps, ['customer', 'contractPlot', 'physicalPlot']);
+
+    // famlog 用: family_cd → FamilyContact（entity_id + contract_plot_id）
+    const familyContacts = await prisma.familyContact.findMany({
+      where: { legacy_family_cd: { not: null } },
+      select: { id: true, legacy_family_cd: true, contract_plot_id: true },
+    });
+    const familyByCd = new Map<number, { id: string; contractPlotId: string | null }>();
+    for (const fc of familyContacts) {
+      if (fc.legacy_family_cd != null) {
+        familyByCd.set(fc.legacy_family_cd, { id: fc.id, contractPlotId: fc.contract_plot_id });
+      }
+    }
+
+    // 既存の取込済みキー（再実行スキップの集計用。実INSERTは skipDuplicates でも防御）
+    const existing = await prisma.history.findMany({
+      where: { legacy_log_table: { not: null } },
+      select: { legacy_log_table: true, legacy_log_cd: true },
+    });
+    const existingKeys = new Set(existing.map((e) => `${e.legacy_log_table}:${e.legacy_log_cd}`));
+
+    const counters = { skipNoEntity: 0, skipExisting: 0, skipNoChange: 0 };
+
+    // ---- t_dankalog → Customer ----
+    const dankalog = await legacyQuery<LogRow>(
+      `SELECT * FROM t_dankalog ORDER BY danka_cd, rireki_cd, danka_log_cd`
+    );
+    const dankaEntries = buildEntries({
+      rows: dankalog,
+      groupKey: 'danka_cd',
+      meta: DANKALOG_META,
+      entityType: 'Customer',
+      table: 't_dankalog',
+      existingKeys,
+      resolve: (row) => {
+        const dankaCd = row.danka_cd as number | null;
+        const graveCd = row.grave_cd as number | null;
+        return {
+          entityId: dankaCd != null ? (idMaps.customer.get(dankaCd) ?? null) : null,
+          contractPlotId: graveCd != null ? (idMaps.contractPlot.get(graveCd) ?? null) : null,
+          physicalPlotId: graveCd != null ? (idMaps.physicalPlot.get(graveCd) ?? null) : null,
+          changedBy: row.tancd != null ? `legacy-tancd-${row.tancd}` : null,
+        };
+      },
+      counters,
+    });
+
+    // ---- t_famlog → FamilyContact ----
+    const famlog = await legacyQuery<LogRow>(
+      `SELECT * FROM t_famlog ORDER BY family_cd, rireki_cd, family_log_id`
+    );
+    const famEntries = buildEntries({
+      rows: famlog,
+      groupKey: 'family_cd',
+      meta: FAMLOG_META,
+      entityType: 'FamilyContact',
+      table: 't_famlog',
+      existingKeys,
+      resolve: (row) => {
+        const familyCd = row.family_cd as number | null;
+        const fc = familyCd != null ? familyByCd.get(familyCd) : undefined;
+        return {
+          entityId: fc?.id ?? null,
+          contractPlotId: fc?.contractPlotId ?? null,
+          physicalPlotId: null,
+          changedBy: null, // t_famlog に担当者列は無い
+        };
+      },
+      counters,
+    });
+
+    const entries = [...dankaEntries, ...famEntries];
+
+    let inserted = 0;
+    if (!dryRun && entries.length > 0) {
+      const CHUNK = 1000;
+      for (let i = 0; i < entries.length; i += CHUNK) {
+        const chunk = entries.slice(i, i + CHUNK);
+        const r = await prisma.history.createMany({ data: chunk, skipDuplicates: true });
+        inserted += r.count;
+      }
+    } else {
+      inserted = entries.length;
+    }
+
+    logger.info(
+      {
+        dankalog_rows: dankalog.length,
+        famlog_rows: famlog.length,
+        danka_entries: dankaEntries.length,
+        fam_entries: famEntries.length,
+        ...counters,
+      },
+      'History migrated'
+    );
+
+    return {
+      inserted,
+      skipped: counters.skipNoEntity + counters.skipExisting + counters.skipNoChange,
+      notes: {
+        dankalog_rows: dankalog.length,
+        famlog_rows: famlog.length,
+        danka_entries: dankaEntries.length,
+        fam_entries: famEntries.length,
+        skip_no_entity: counters.skipNoEntity,
+        skip_existing: counters.skipExisting,
+        skip_no_change: counters.skipNoChange,
+      },
+    };
+  },
+};

--- a/scripts/migrate-from-legacy.ts
+++ b/scripts/migrate-from-legacy.ts
@@ -46,6 +46,7 @@ import { stepConstructionInfo } from './legacy-migration/steps/09-construction-i
 import { stepBilling } from './legacy-migration/steps/10-billing';
 import { stepPayment } from './legacy-migration/steps/11-payment';
 import { stepPaymentStatus } from './legacy-migration/steps/12-payment-status';
+import { stepHistory } from './legacy-migration/steps/14-history';
 import { stepSummary } from './legacy-migration/steps/13-summary';
 import type {
   MigrationContext,
@@ -66,6 +67,7 @@ const ALL_STEPS: MigrationStep[] = [
   stepBilling,
   stepPayment,
   stepPaymentStatus,
+  stepHistory,
   stepSummary,
 ];
 

--- a/tests/scripts/legacy-migration/steps/history.test.ts
+++ b/tests/scripts/legacy-migration/steps/history.test.ts
@@ -1,0 +1,250 @@
+/**
+ * 回帰テスト: t_dankalog / t_famlog → History 移行（#324）
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepHistory } from '../../../../scripts/legacy-migration/steps/14-history';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+describe('stepHistory: t_dankalog / t_famlog → History (#324)', () => {
+  beforeEach(() => mockedLegacyQuery.mockReset());
+
+  const buildIdMaps = () => {
+    const idMaps = createIdMaps();
+    idMaps.customer.set(100, 'cust-100'); // rebuildIdMap を no-op に
+    idMaps.contractPlot.set(500, 'cp-500');
+    idMaps.physicalPlot.set(500, 'pp-500');
+    return idMaps;
+  };
+
+  const buildPrisma = (created: Array<Record<string, unknown>>, existing: unknown[] = []) =>
+    ({
+      customer: { findMany: jest.fn() },
+      contractPlot: { findMany: jest.fn() },
+      physicalPlot: { findMany: jest.fn() },
+      familyContact: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([{ id: 'fc-1', legacy_family_cd: 9, contract_plot_id: 'cp-500' }]),
+      },
+      history: {
+        findMany: jest.fn().mockResolvedValue(existing),
+        createMany: jest
+          .fn()
+          .mockImplementation(({ data }: { data: Record<string, unknown>[] }) => {
+            created.push(...data);
+            return Promise.resolve({ count: data.length });
+          }),
+      },
+    }) as unknown as PrismaClient;
+
+  it('連続スナップショットを CREATE + 差分 UPDATE として取り込む', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      // t_dankalog: danka_cd=100 の2世代（tel1 が変化）
+      .mockResolvedValueOnce([
+        {
+          danka_log_cd: 1,
+          rireki_cd: 1,
+          danka_cd: 100,
+          grave_cd: 500,
+          tancd: 7,
+          reg_date: 20200101,
+          owner_sei: '山田',
+          tel1: '03-1111',
+        },
+        {
+          danka_log_cd: 2,
+          rireki_cd: 2,
+          danka_cd: 100,
+          grave_cd: 500,
+          tancd: 8,
+          reg_date: 20210101,
+          owner_sei: '山田',
+          tel1: '03-2222',
+        },
+      ])
+      // t_famlog: なし
+      .mockResolvedValueOnce([]);
+
+    await stepHistory.run({ prisma, logger: buildLogger(), idMaps: buildIdMaps(), dryRun: false });
+
+    expect(created).toHaveLength(2);
+
+    const createEntry = created.find((e) => e['action_type'] === 'CREATE')!;
+    expect(createEntry['entity_type']).toBe('Customer');
+    expect(createEntry['entity_id']).toBe('cust-100');
+    expect(createEntry['contract_plot_id']).toBe('cp-500');
+    expect(createEntry['physical_plot_id']).toBe('pp-500');
+    expect(createEntry['changed_by']).toBe('legacy-tancd-7');
+    expect(createEntry['legacy_log_cd']).toBe(1);
+    expect(createEntry['legacy_log_table']).toBe('t_dankalog');
+    expect((createEntry['after_record'] as Record<string, unknown>)['tel1']).toBe('03-1111');
+
+    const updateEntry = created.find((e) => e['action_type'] === 'UPDATE')!;
+    expect(updateEntry['changed_fields']).toEqual(['tel1']);
+    expect((updateEntry['before_record'] as Record<string, unknown>)['tel1']).toBe('03-1111');
+    expect((updateEntry['after_record'] as Record<string, unknown>)['tel1']).toBe('03-2222');
+    expect(updateEntry['changed_by']).toBe('legacy-tancd-8');
+    expect(updateEntry['legacy_log_cd']).toBe(2);
+  });
+
+  it('変化なしの世代は記録せず、Customer 未マップの danka はスキップする', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([
+        // danka_cd=100: 2世代だが内容同一 → CREATE のみ（2件目は no-change skip）
+        {
+          danka_log_cd: 1,
+          rireki_cd: 1,
+          danka_cd: 100,
+          grave_cd: 500,
+          tancd: 7,
+          reg_date: 20200101,
+          owner_sei: '山田',
+        },
+        {
+          danka_log_cd: 2,
+          rireki_cd: 2,
+          danka_cd: 100,
+          grave_cd: 500,
+          tancd: 7,
+          reg_date: 20200201,
+          owner_sei: '山田',
+        },
+        // danka_cd=999: idMap 未登録 → group ごとスキップ
+        {
+          danka_log_cd: 3,
+          rireki_cd: 1,
+          danka_cd: 999,
+          grave_cd: 500,
+          tancd: 7,
+          reg_date: 20200101,
+          owner_sei: '佐藤',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await stepHistory.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: buildIdMaps(),
+      dryRun: false,
+    });
+
+    expect(created).toHaveLength(1); // CREATE のみ
+    expect(created[0]['action_type']).toBe('CREATE');
+    expect(result.notes?.['skip_no_change']).toBe(1);
+    expect(result.notes?.['skip_no_entity']).toBe(1);
+  });
+
+  it('既存の legacy_log_cd は再取込しない（冪等）', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created, [{ legacy_log_table: 't_dankalog', legacy_log_cd: 1 }]);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([
+        {
+          danka_log_cd: 1,
+          rireki_cd: 1,
+          danka_cd: 100,
+          grave_cd: 500,
+          tancd: 7,
+          reg_date: 20200101,
+          owner_sei: '山田',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await stepHistory.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: buildIdMaps(),
+      dryRun: false,
+    });
+
+    expect(created).toHaveLength(0);
+    expect(result.notes?.['skip_existing']).toBe(1);
+  });
+
+  it('t_famlog は FamilyContact エンティティとして取り込む', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([]) // dankalog なし
+      .mockResolvedValueOnce([
+        {
+          family_log_id: 11,
+          rireki_cd: 1,
+          family_cd: 9,
+          danka_cd: 100,
+          reg_date: 20200101,
+          family_sei: '田中',
+          tel1: '090-0000',
+        },
+      ]);
+
+    await stepHistory.run({ prisma, logger: buildLogger(), idMaps: buildIdMaps(), dryRun: false });
+
+    expect(created).toHaveLength(1);
+    expect(created[0]['entity_type']).toBe('FamilyContact');
+    expect(created[0]['entity_id']).toBe('fc-1');
+    expect(created[0]['contract_plot_id']).toBe('cp-500');
+    expect(created[0]['changed_by']).toBeNull(); // famlog に tancd 無し
+    expect(created[0]['legacy_log_table']).toBe('t_famlog');
+  });
+
+  it('dryRun では createMany を呼ばず件数のみ返す', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = buildPrisma(created);
+
+    mockedLegacyQuery
+      .mockResolvedValueOnce([
+        {
+          danka_log_cd: 1,
+          rireki_cd: 1,
+          danka_cd: 100,
+          grave_cd: 500,
+          tancd: 7,
+          reg_date: 20200101,
+          owner_sei: '山田',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await stepHistory.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: buildIdMaps(),
+      dryRun: true,
+    });
+
+    expect(prisma.history.createMany as jest.Mock).not.toHaveBeenCalled();
+    expect(result.inserted).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要

移行区画の「履歴」タブが**全区画で空**だった根本原因（レガシー履歴テーブルの未取込）を解消する。移行設計でマッピング確定済み・未実装・未起票のままだったステップを新設。

## 実装

- **新ステップ `scripts/legacy-migration/steps/14-history.ts`** を `ALL_STEPS` に追加（payment 後・summary 前）
  - スナップショット形式の `t_dankalog`(86列)/`t_famlog`(46列) を**世代順に比較**し `changed_fields`/`before_record`/`after_record`(JSON) を生成
  - `t_dankalog` → `entity_type='Customer'`（`changed_by=legacy-tancd-${tancd}`）
  - `t_famlog` → `entity_type='FamilyContact'`（tancd 列なし→null）
  - 最初の世代を **CREATE**、以降を**差分 UPDATE**。変化なし世代は記録しない
  - `contract_plot_id`/`physical_plot_id` を idMap で解決し、区画詳細の履歴クエリ（getPlotById/getPlotHistory の OR 条件）で拾える形にする
- **冪等キー**: `History.legacy_log_cd` + `legacy_log_table` を追加し複合ユニーク化（migration `20260608140000`）。`createMany({ skipDuplicates })` + 既存キー事前ロードで再実行安全
- dry-run 対応・単体テスト5件

## 前提（business-confirmation 残・本 issue で要確認）

- 世代の並び順は `rireki_cd ASC` を仮定（名義変更世代番号の可能性 → 確定後に並び順を再確認）
- `change_reason`（`t_opelog` の担当者メモ）取込は未対応（業務確認後に追加可能）
- 履歴の保持期間は全件取込（件数は dry-run で突合）

## 残（本番運用）

`prisma migrate deploy` 後に `npm run migrate:legacy -- --only=history`（#163 のデプロイに同梱可）。実投入前に dry-run で件数を突合する。

## 検証

- `npx tsc --noEmit` clean / `npm run lint` clean
- `npm test` → 1208 passed（新規5件）

Closes #324
Refs #163, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)