### PR TITLE
fix(migration): 許可日/開始日を契約日起点で投入（komine-docs#10 Q4/Q5） (#326)

### DIFF
--- a/scripts/backfill-konryu-establishment.ts
+++ b/scripts/backfill-konryu-establishment.ts
@@ -7,17 +7,21 @@
  * 正しい器は GravestoneInfo.establishment_deadline/establishment_date。
  *
  * 本スクリプトはレガシーDB不要で、移行済み行（legacy_grave_cd IS NOT NULL）の
- * permit_date → establishment_deadline / start_date → establishment_date へ
- * DB 内で移送し、ContractPlot.permit_date/start_date を null に戻す。
+ * permit_date → establishment_deadline / start_date → establishment_date へ DB 内で移送し、
+ * その後 permit_date/start_date には契約日(contract_date)を代理投入する
+ * （業務確認 komine-docs#10 Q4/Q5: 許可日＝開始日＝契約日相当）。
  *
  * アプリ作成行（legacy_grave_cd IS NULL）は正規の許可日/開始日が入りうるため対象外。
+ *
+ * ⚠️ 安全ガード: establishment_deadline/establishment_date が**未投入**の行だけ処理する。
+ *   これにより、新移行コード（permit=contract_date を投入する版）適用済みの行や、
+ *   既に本スクリプトで処理済みの行を再処理して establishment を壊すことを防ぐ。
  *
  * 使い方:
  *   npx ts-node scripts/backfill-konryu-establishment.ts          # dry-run（件数のみ）
  *   npx ts-node scripts/backfill-konryu-establishment.ts --apply  # 実際に更新
  *
- * 冪等: 実行後は対象行の permit_date/start_date が null になるため再実行で 0 件。
- *       establishment 側に既存値があれば上書きしない（?? で温存）。
+ * 冪等: 実行後は establishment が埋まるため、同じ行は次回ガードで除外され再処理されない。
  */
 import 'dotenv/config';
 
@@ -29,8 +33,8 @@ const CONCURRENCY = 25;
 async function main(): Promise<void> {
   console.log(`[backfill konryu→establishment] start (apply=${APPLY})`);
 
-  // 対象: 移行行で permit_date か start_date が入っているもの（= 誤投入された建立期限/建立日）
-  const targets = await prisma.contractPlot.findMany({
+  // 候補: 移行行で permit_date か start_date が入っているもの（= 誤投入された建立期限/建立日の疑い）
+  const candidates = await prisma.contractPlot.findMany({
     where: {
       legacy_grave_cd: { not: null },
       deleted_at: null,
@@ -40,12 +44,22 @@ async function main(): Promise<void> {
       id: true,
       permit_date: true,
       start_date: true,
+      contract_date: true,
       gravestoneInfo: {
         select: { id: true, establishment_deadline: true, establishment_date: true },
       },
     },
   });
-  console.log(`対象 contract_plots: ${targets.length} 件`);
+
+  // 安全ガード: establishment が未投入の行だけが「旧マッピングの未処理行」。
+  // どちらか埋まっていれば（新移行コード適用済み or 本スクリプト処理済み）除外する。
+  const targets = candidates.filter(
+    (t) =>
+      t.gravestoneInfo == null ||
+      (t.gravestoneInfo.establishment_deadline == null &&
+        t.gravestoneInfo.establishment_date == null)
+  );
+  console.log(`候補 ${candidates.length} 件 / 対象（establishment 未投入）${targets.length} 件`);
 
   let updated = 0;
   let createdGravestone = 0;
@@ -96,10 +110,11 @@ async function main(): Promise<void> {
           createdGravestone++;
         }
 
-        // 誤投入された permit_date/start_date を null に戻す
+        // 誤投入されていた建立期限/建立日は上で establishment へ移送済み。
+        // 許可日/開始日は契約日を代理値にする（komine-docs#10 Q4/Q5）。
         await prisma.contractPlot.update({
           where: { id: t.id },
-          data: { permit_date: null, start_date: null },
+          data: { permit_date: t.contract_date, start_date: t.contract_date },
         });
       })
     );

--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -166,6 +166,11 @@ export const stepContractPlot: MigrationStep = {
         continue;
       }
 
+      // 業務確認（komine-docs#10 Q4/Q5）: 許可日＝開始年月日＝「入金完了しシステム入力した日」で
+      // 三者は同義。レガシーに専用列は無く、契約日(contract_start)を代理値とする（建立期限/建立日は
+      // GravestoneInfo へ別途格納済み #326）。新規入力分はスタッフが必要に応じ調整する。
+      const contractDate = parseLegacyDate(row.contract_start);
+
       const data: Prisma.ContractPlotCreateInput = {
         physicalPlot: { connect: { id: physicalPlotId } },
         contract_area_sqm: 3.6,
@@ -175,18 +180,15 @@ export const stepContractPlot: MigrationStep = {
         grave_kubun: row.grave_kubun,
         grave_type: row.grave_type,
         legacy_grave_cd: row.grave_cd,
-        contract_date: parseLegacyDate(row.contract_start),
+        contract_date: contractDate,
         price: row.shiyouryou ?? null,
         request_date: parseLegacyDate(row.request_date),
         reservation_date: parseLegacyDate(row.reserve_date),
         acceptance_number: row.auth_no != null ? String(row.auth_no) : null,
         acceptance_date: parseLegacyDate(row.auth_date),
-        // 許可日(permit_date)/開始日(start_date) はレガシーの真の対応列が未確定（komine-docs#10 項目5）。
-        // 以前は konryu_kigen(建立期限)/konryu_date(建立日) を誤って入れていた（#326）。
-        // 建立期限/建立日は GravestoneInfo.establishment_deadline/establishment_date へ移す（下記）。
-        // 真の許可日列が確定するまで null。
-        permit_date: null,
-        start_date: null,
+        // 許可日/開始日＝契約日（上記コメント参照、komine-docs#10 Q4/Q5）
+        permit_date: contractDate,
+        start_date: contractDate,
         notes: cleanStr(row.note),
       };
 

--- a/tests/scripts/legacy-migration/steps/konryu-establishment-mapping.test.ts
+++ b/tests/scripts/legacy-migration/steps/konryu-establishment-mapping.test.ts
@@ -4,7 +4,7 @@
  * step05 は以前 konryu_kigen(建立期限)/konryu_date(建立日) を
  * ContractPlot.permit_date(許可日)/start_date(開始日) に誤投入していた。
  * 正しい器は GravestoneInfo.establishment_deadline/establishment_date。
- * permit_date/start_date は真の許可日列が未確定（komine-docs#10 項目5）のため null。
+ * 許可日/開始日は契約日(contract_start)を代理投入する（komine-docs#10 Q4/Q5: 三者同義）。
  */
 import type { PrismaClient } from '@prisma/client';
 
@@ -36,7 +36,7 @@ describe('step05 konryu → establishment マッピング (#326)', () => {
     mockedLegacyQuery.mockReset();
   });
 
-  it('konryu_kigen/konryu_date を GravestoneInfo へ入れ、permit_date/start_date は null にする', async () => {
+  it('konryu_kigen/konryu_date を GravestoneInfo へ入れ、permit_date/start_date には契約日を代理投入する', async () => {
     const contractPlotCreate = jest.fn().mockResolvedValue({ id: 'cp-1' });
     const gravestoneInfoCreate = jest.fn().mockResolvedValue({ id: 'gi-1' });
 
@@ -57,6 +57,7 @@ describe('step05 konryu → establishment マッピング (#326)', () => {
         grave_cd: 500,
         danka_cd: 100,
         status: 1, // active
+        contract_start: 20190401, // 契約日＝許可日＝開始日
         konryu_kigen: 20200101,
         konryu_date: 20200201,
         note: null,
@@ -68,11 +69,14 @@ describe('step05 konryu → establishment マッピング (#326)', () => {
 
     await stepContractPlot.run({ prisma, logger: buildLogger(), idMaps, dryRun: false });
 
-    // permit_date/start_date は null（誤投入しない）
+    // 許可日/開始日＝契約日(contract_start) を代理投入（konryu は入れない）。komine-docs#10 Q4/Q5
     expect(contractPlotCreate).toHaveBeenCalledTimes(1);
     const cpData = contractPlotCreate.mock.calls[0][0].data;
-    expect(cpData.permit_date).toBeNull();
-    expect(cpData.start_date).toBeNull();
+    expect(cpData.contract_date).toEqual(cpData.permit_date);
+    expect(cpData.contract_date).toEqual(cpData.start_date);
+    expect(cpData.permit_date).toBeInstanceOf(Date);
+    // konryu 値（建立期限 20200101）が permit に入っていないこと
+    expect((cpData.permit_date as Date).getUTCFullYear()).toBe(2019);
 
     // GravestoneInfo に建立期限/建立日が入る
     expect(gravestoneInfoCreate).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 概要

業務確認シート（第2版 Q4/Q5）で **「許可日＝開始年月日＝入金完了しシステム入力した日」で三者が同義**と確定。レガシーDBに専用列が無いため、契約日(`contract_start`)を許可日/開始日の代理値とする（#326 で建立期限/建立日は GravestoneInfo へ移済み）。

## 変更

- **step05**: `permit_date`/`start_date` を `null` → 契約日(`contractDate`) に変更（`contract_date` と同値）
- **backfill-konryu-establishment**: konryu を establishment へ移送後、`permit_date`/`start_date` を契約日で埋めるよう変更。**安全ガード追加** — `establishment` が未投入の行だけ処理し、新移行コード適用済み/処理済みの行を再処理して establishment を壊さない（冪等化）
- 回帰テスト更新

## 残（本番運用）

コードマージ後に `npm run backfill:konryu-establishment -- --apply`（#163 同梱可）。

## 検証

- `npx tsc --noEmit` clean / `npm run lint` clean / `npm test` → 1214 passed

Refs #326, komine-docs#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)