### PR TITLE
feat(masters): 合祀年数マスタ・変更理由マスタを追加（業務確認 Q16/Q17） (#343, #344)

### DIFF
--- a/prisma/migrations/20260608150000_add_validity_period_and_change_reason_master/migration.sql
+++ b/prisma/migrations/20260608150000_add_validity_period_and_change_reason_master/migration.sql
@@ -1,0 +1,52 @@
+-- #343/#344: 合祀年数マスタ・変更履歴理由マスタを追加（業務確認シート Q17/Q16）
+
+-- CreateTable
+CREATE TABLE "validity_period_master" (
+    "id" SERIAL NOT NULL,
+    "code" VARCHAR(10) NOT NULL,
+    "name" VARCHAR(50) NOT NULL,
+    "description" VARCHAR(200),
+    "sort_order" INTEGER,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "validity_period_master_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "change_reason_master" (
+    "id" SERIAL NOT NULL,
+    "code" VARCHAR(10) NOT NULL,
+    "name" VARCHAR(50) NOT NULL,
+    "description" VARCHAR(200),
+    "sort_order" INTEGER,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "change_reason_master_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "validity_period_master_code_key" ON "validity_period_master"("code");
+CREATE UNIQUE INDEX "change_reason_master_code_key" ON "change_reason_master"("code");
+
+-- Seed: 合祀年数（13/15/24/33）
+INSERT INTO "validity_period_master" ("code", "name", "sort_order", "updated_at") VALUES
+  ('13', '13年', 13, CURRENT_TIMESTAMP),
+  ('15', '15年', 15, CURRENT_TIMESTAMP),
+  ('24', '24年', 24, CURRENT_TIMESTAMP),
+  ('33', '33年', 33, CURRENT_TIMESTAMP);
+
+-- Seed: 変更理由（名義変更/住所変更/電話番号変更/解約/合祀/修理/字彫/備品購入/その他）
+INSERT INTO "change_reason_master" ("code", "name", "sort_order", "updated_at") VALUES
+  ('meigi', '名義変更', 1, CURRENT_TIMESTAMP),
+  ('jusho', '住所変更', 2, CURRENT_TIMESTAMP),
+  ('tel', '電話番号変更', 3, CURRENT_TIMESTAMP),
+  ('kaiyaku', '解約', 4, CURRENT_TIMESTAMP),
+  ('goushi', '合祀', 5, CURRENT_TIMESTAMP),
+  ('shuri', '修理', 6, CURRENT_TIMESTAMP),
+  ('jibori', '字彫', 7, CURRENT_TIMESTAMP),
+  ('bihin', '備品購入', 8, CURRENT_TIMESTAMP),
+  ('other', 'その他', 9, CURRENT_TIMESTAMP);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -788,6 +788,36 @@ model PositionMaster {
   @@map("position_master")
 }
 
+// 合祀年数マスタ（#343, komine-docs#10 Q17）。選択肢提示用（13/15/24/33）。
+// 保存は ContractPlot.validity_period_years(int) のまま、例外は BuriedPerson.validity_period_years_override(#329)。
+model ValidityPeriodMaster {
+  id          Int      @id @default(autoincrement()) // ID
+  code        String   @unique @db.VarChar(10) // 年数コード（"13".."33"）
+  name        String   @db.VarChar(50) // 表示名（13年 など）
+  description String?  @db.VarChar(200) // 説明
+  sort_order  Int? // 表示順序
+  is_active   Boolean  @default(true) // 有効フラグ
+  created_at  DateTime @default(now()) // 作成日時
+  updated_at  DateTime @updatedAt // 更新日時
+
+  @@map("validity_period_master")
+}
+
+// 変更履歴の理由マスタ（#344, komine-docs#10 項目4）。変更履歴の change_reason 選択肢。
+// History.change_reason は自由記入のままで、本マスタは選択肢提示のみ。
+model ChangeReasonMaster {
+  id          Int      @id @default(autoincrement()) // ID
+  code        String   @unique @db.VarChar(10) // 理由コード
+  name        String   @db.VarChar(50) // 表示名（名義変更 など）
+  description String?  @db.VarChar(200) // 説明
+  sort_order  Int? // 表示順序
+  is_active   Boolean  @default(true) // 有効フラグ
+  created_at  DateTime @default(now()) // 作成日時
+  updated_at  DateTime @updatedAt // 更新日時
+
+  @@map("change_reason_master")
+}
+
 // =============================================================================
 // 請求・入金管理
 // =============================================================================

--- a/prisma/seedMasters.ts
+++ b/prisma/seedMasters.ts
@@ -115,6 +115,27 @@ const position: MasterSeedRow[] = [
   { code: '3', name: '中', sort_order: 3 },
 ];
 
+// 合祀年数（#343, komine-docs#10 Q17）: 13/15/24/33。
+const validityPeriod: MasterSeedRow[] = [
+  { code: '13', name: '13年', sort_order: 13 },
+  { code: '15', name: '15年', sort_order: 15 },
+  { code: '24', name: '24年', sort_order: 24 },
+  { code: '33', name: '33年', sort_order: 33 },
+];
+
+// 変更理由（#344, komine-docs#10 項目4）: 変更履歴の change_reason 選択肢。
+const changeReason: MasterSeedRow[] = [
+  { code: 'meigi', name: '名義変更', sort_order: 1 },
+  { code: 'jusho', name: '住所変更', sort_order: 2 },
+  { code: 'tel', name: '電話番号変更', sort_order: 3 },
+  { code: 'kaiyaku', name: '解約', sort_order: 4 },
+  { code: 'goushi', name: '合祀', sort_order: 5 },
+  { code: 'shuri', name: '修理', sort_order: 6 },
+  { code: 'jibori', name: '字彫', sort_order: 7 },
+  { code: 'bihin', name: '備品購入', sort_order: 8 },
+  { code: 'other', name: 'その他', sort_order: 9 },
+];
+
 export interface MasterSeedSummary {
   master: string;
   inserted: number;
@@ -180,6 +201,18 @@ export async function seedMasters(prisma: PrismaClient): Promise<MasterSeedSumma
     skipDuplicates: true,
   });
   summary.push({ master: 'position_master', inserted: pos.count });
+
+  const validity = await prisma.validityPeriodMaster.createMany({
+    data: validityPeriod,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'validity_period_master', inserted: validity.count });
+
+  const change = await prisma.changeReasonMaster.createMany({
+    data: changeReason,
+    skipDuplicates: true,
+  });
+  summary.push({ master: 'change_reason_master', inserted: change.count });
 
   return summary;
 }

--- a/src/masters/masterController.ts
+++ b/src/masters/masterController.ts
@@ -511,6 +511,64 @@ export const getPositionMaster = async (req: Request, res: Response) => {
 };
 
 /**
+ * 合祀年数マスタ取得（#343）
+ */
+export const getValidityPeriodMaster = async (req: Request, res: Response) => {
+  try {
+    const data = await prisma.validityPeriodMaster.findMany({
+      where: buildMasterWhere(req),
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    const formatted: MasterData[] = data.map((item) => ({
+      id: item.id,
+      code: item.code,
+      name: item.name,
+      description: item.description,
+      sortOrder: item.sort_order,
+      isActive: item.is_active,
+    }));
+
+    res.status(200).json({ success: true, data: formatted });
+  } catch (error) {
+    getRequestLogger().error({ err: error }, 'Error fetching validity period master');
+    res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_SERVER_ERROR', message: '合祀年数マスタの取得に失敗しました' },
+    });
+  }
+};
+
+/**
+ * 変更理由マスタ取得（#344）
+ */
+export const getChangeReasonMaster = async (req: Request, res: Response) => {
+  try {
+    const data = await prisma.changeReasonMaster.findMany({
+      where: buildMasterWhere(req),
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    const formatted: MasterData[] = data.map((item) => ({
+      id: item.id,
+      code: item.code,
+      name: item.name,
+      description: item.description,
+      sortOrder: item.sort_order,
+      isActive: item.is_active,
+    }));
+
+    res.status(200).json({ success: true, data: formatted });
+  } catch (error) {
+    getRequestLogger().error({ err: error }, 'Error fetching change reason master');
+    res.status(500).json({
+      success: false,
+      error: { code: 'INTERNAL_SERVER_ERROR', message: '変更理由マスタの取得に失敗しました' },
+    });
+  }
+};
+
+/**
  * マスタ CRUD で使う DB クライアント。トランザクション内では tx を渡す（#278）。
  */
 type MasterDbClient = typeof prisma | Prisma.TransactionClient;
@@ -532,6 +590,8 @@ const getMasterDelegate = (masterType: MasterType, db: MasterDbClient = prisma):
     contractor: db.contractorMaster,
     direction: db.directionMaster,
     position: db.positionMaster,
+    'validity-period': db.validityPeriodMaster,
+    'change-reason': db.changeReasonMaster,
   };
   return delegateMap[masterType] as MasterDelegate;
 };
@@ -549,6 +609,8 @@ const masterTypeLabels: Record<MasterType, string> = {
   contractor: '工事業者',
   direction: '方角',
   position: '位置',
+  'validity-period': '合祀年数',
+  'change-reason': '変更理由',
 };
 
 /**
@@ -568,6 +630,8 @@ const MASTER_CODE_MAX_LENGTH: Record<MasterType, number> = {
   contractor: 20,
   direction: 10,
   position: 10,
+  'validity-period': 10,
+  'change-reason': 10,
 };
 
 /**
@@ -1099,6 +1163,8 @@ export const getAllMasters = async (req: Request, res: Response) => {
       contractor,
       direction,
       position,
+      validityPeriod,
+      changeReason,
     ] = await Promise.all([
       prisma.cemeteryTypeMaster.findMany({
         where: buildMasterWhere(req),
@@ -1145,6 +1211,14 @@ export const getAllMasters = async (req: Request, res: Response) => {
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
       prisma.positionMaster.findMany({
+        where: buildMasterWhere(req),
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.validityPeriodMaster.findMany({
+        where: buildMasterWhere(req),
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      }),
+      prisma.changeReasonMaster.findMany({
         where: buildMasterWhere(req),
         orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
       }),
@@ -1244,6 +1318,22 @@ export const getAllMasters = async (req: Request, res: Response) => {
           isActive: item.is_active,
         })),
         position: position.map((item) => ({
+          id: item.id,
+          code: item.code,
+          name: item.name,
+          description: item.description,
+          sortOrder: item.sort_order,
+          isActive: item.is_active,
+        })),
+        validityPeriod: validityPeriod.map((item) => ({
+          id: item.id,
+          code: item.code,
+          name: item.name,
+          description: item.description,
+          sortOrder: item.sort_order,
+          isActive: item.is_active,
+        })),
+        changeReason: changeReason.map((item) => ({
           id: item.id,
           code: item.code,
           name: item.name,

--- a/src/masters/masterRoutes.ts
+++ b/src/masters/masterRoutes.ts
@@ -12,6 +12,8 @@ import {
   getContractorMaster,
   getDirectionMaster,
   getPositionMaster,
+  getValidityPeriodMaster,
+  getChangeReasonMaster,
   getAllMasters,
   createMaster,
   updateMaster,
@@ -125,6 +127,22 @@ router.get(
   authenticate,
   checkApiPermission(),
   withLogging('Masters', 'getPositionMaster', getPositionMaster)
+);
+
+// 合祀年数マスタ（#343）
+router.get(
+  '/validity-period',
+  authenticate,
+  checkApiPermission(),
+  withLogging('Masters', 'getValidityPeriodMaster', getValidityPeriodMaster)
+);
+
+// 変更理由マスタ（#344）
+router.get(
+  '/change-reason',
+  authenticate,
+  checkApiPermission(),
+  withLogging('Masters', 'getChangeReasonMaster', getChangeReasonMaster)
 );
 
 // マスタデータ CRUD（汎用）

--- a/src/validations/masterValidation.ts
+++ b/src/validations/masterValidation.ts
@@ -55,6 +55,8 @@ export const VALID_MASTER_TYPES = [
   'contractor',
   'direction',
   'position',
+  'validity-period',
+  'change-reason',
 ] as const;
 
 export type MasterType = (typeof VALID_MASTER_TYPES)[number];

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2006,6 +2006,58 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v1/masters/validity-period:
+    get:
+      tags:
+        - Masters
+      summary: 合祀年数マスタ一覧取得
+      description: 合祀までの年数（13/15/24/33）の選択肢を表示順で取得（#343, komine-docs#10 Q17）。
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 合祀年数マスタ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MasterItem"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v1/masters/change-reason:
+    get:
+      tags:
+        - Masters
+      summary: 変更理由マスタ一覧取得
+      description: 変更履歴の理由（名義変更/住所変更/解約/合祀 等）の選択肢を表示順で取得（#344, komine-docs#10 項目4）。
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: 変更理由マスタ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MasterItem"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v1/masters/all:
     get:
       tags:
@@ -2399,6 +2451,30 @@ components:
           type: integer
           nullable: true
           example: 1
+        isActive:
+          type: boolean
+          example: true
+
+    MasterItem:
+      type: object
+      description: 標準マスタ項目（合祀年数・変更理由 等の共通形）。
+      properties:
+        id:
+          type: integer
+          example: 1
+        code:
+          type: string
+          example: "13"
+        name:
+          type: string
+          example: "13年"
+        description:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+          nullable: true
+          example: 13
         isActive:
           type: boolean
           example: true

--- a/tests/masters/masterController.test.ts
+++ b/tests/masters/masterController.test.ts
@@ -176,6 +176,12 @@ const mockPrisma: any = {
   positionMaster: {
     findMany: jest.fn(),
   },
+  validityPeriodMaster: {
+    findMany: jest.fn(),
+  },
+  changeReasonMaster: {
+    findMany: jest.fn(),
+  },
 };
 
 // PrismaClientをモック化
@@ -197,6 +203,8 @@ import {
   getContractorMaster,
   getDirectionMaster,
   getPositionMaster,
+  getValidityPeriodMaster,
+  getChangeReasonMaster,
   getAllMasters,
 } from '../../src/masters/masterController';
 
@@ -698,6 +706,8 @@ describe('Master Controller', () => {
       mockPrisma.contractorMaster.findMany.mockResolvedValue(mockContractorData);
       mockPrisma.directionMaster.findMany.mockResolvedValue(mockDirectionData);
       mockPrisma.positionMaster.findMany.mockResolvedValue(mockPositionData);
+      mockPrisma.validityPeriodMaster.findMany.mockResolvedValue([]);
+      mockPrisma.changeReasonMaster.findMany.mockResolvedValue([]);
 
       await getAllMasters(mockRequest as Request, mockResponse as Response);
 
@@ -884,6 +894,80 @@ describe('Master Controller', () => {
           message: '位置マスタの取得に失敗しました',
         },
       });
+    });
+  });
+
+  describe('getValidityPeriodMaster (#343)', () => {
+    it('合祀年数マスタを取得できること', async () => {
+      mockPrisma.validityPeriodMaster.findMany.mockResolvedValue([
+        { id: 1, code: '13', name: '13年', description: null, sort_order: 13, is_active: true },
+      ]);
+
+      await getValidityPeriodMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.validityPeriodMaster.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          { id: 1, code: '13', name: '13年', description: null, sortOrder: 13, isActive: true },
+        ],
+      });
+    });
+
+    it('エラー時は500を返すこと', async () => {
+      mockPrisma.validityPeriodMaster.findMany.mockRejectedValue(new Error('Database error'));
+
+      await getValidityPeriodMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('getChangeReasonMaster (#344)', () => {
+    it('変更理由マスタを取得できること', async () => {
+      mockPrisma.changeReasonMaster.findMany.mockResolvedValue([
+        {
+          id: 1,
+          code: 'meigi',
+          name: '名義変更',
+          description: null,
+          sort_order: 1,
+          is_active: true,
+        },
+      ]);
+
+      await getChangeReasonMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockPrisma.changeReasonMaster.findMany).toHaveBeenCalledWith({
+        where: { is_active: true },
+        orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          {
+            id: 1,
+            code: 'meigi',
+            name: '名義変更',
+            description: null,
+            sortOrder: 1,
+            isActive: true,
+          },
+        ],
+      });
+    });
+
+    it('エラー時は500を返すこと', async () => {
+      mockPrisma.changeReasonMaster.findMany.mockRejectedValue(new Error('Database error'));
+
+      await getChangeReasonMaster(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
     });
   });
 });

--- a/tests/masters/seedMasters.test.ts
+++ b/tests/masters/seedMasters.test.ts
@@ -18,11 +18,13 @@ function createFakePrisma() {
     constructionTypeMaster: { createMany: makeCreateMany(4) },
     directionMaster: { createMany: makeCreateMany(8) },
     positionMaster: { createMany: makeCreateMany(3) },
+    validityPeriodMaster: { createMany: makeCreateMany(4) },
+    changeReasonMaster: { createMany: makeCreateMany(9) },
   };
 }
 
 describe('seedMasters', () => {
-  it('標準マスタ9種すべてに対して createMany を呼ぶ', async () => {
+  it('標準マスタ11種すべてに対して createMany を呼ぶ', async () => {
     const prisma = createFakePrisma();
 
     const summary = await seedMasters(prisma as unknown as PrismaClient);
@@ -36,8 +38,10 @@ describe('seedMasters', () => {
     expect(prisma.constructionTypeMaster.createMany).toHaveBeenCalledTimes(1);
     expect(prisma.directionMaster.createMany).toHaveBeenCalledTimes(1);
     expect(prisma.positionMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.validityPeriodMaster.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.changeReasonMaster.createMany).toHaveBeenCalledTimes(1);
 
-    expect(summary).toHaveLength(9);
+    expect(summary).toHaveLength(11);
   });
 
   it('冪等性のため skipDuplicates: true で投入する', async () => {
@@ -59,7 +63,7 @@ describe('seedMasters', () => {
     const summary = await seedMasters(prisma as unknown as PrismaClient);
 
     const total = summary.reduce((sum, s) => sum + s.inserted, 0);
-    expect(total).toBe(3 + 3 + 2 + 2 + 3 + 3 + 4 + 8 + 3);
+    expect(total).toBe(3 + 3 + 2 + 2 + 3 + 3 + 4 + 8 + 3 + 4 + 9);
     expect(summary.map((s) => s.master)).toEqual([
       'cemetery_type_master',
       'payment_method_master',
@@ -70,6 +74,8 @@ describe('seedMasters', () => {
       'construction_type_master',
       'direction_master',
       'position_master',
+      'validity_period_master',
+      'change_reason_master',
     ]);
   });
 


### PR DESCRIPTION
## 概要

業務確認シート（第2版）の確定を受け、選択肢提示用の2マスタを追加。

| マスタ | 値 | issue / 出典 |
|---|---|---|
| 合祀年数 `validity_period_master` | 13 / 15 / 24 / 33 | #343 / Q17・R43 |
| 変更理由 `change_reason_master` | 名義変更 / 住所変更 / 電話番号変更 / 解約 / 合祀 / 修理 / 字彫 / 備品購入 / その他 | #344 / Q16・komine-docs#10 項目4 |

## 変更（既存マスタ基盤に準拠）

- `prisma/schema.prisma`: 2モデル追加（標準マスタ構造 code/name/sort_order/is_active）
- migration `20260608150000`（CREATE TABLE + UNIQUE index + seed INSERT）
- `seedMasters.ts`: 2配列 + createMany（冪等）
- 汎用 CRUD 登録: `VALID_MASTER_TYPES` / `getMasterDelegate` / `masterTypeLabels` / `MASTER_CODE_MAX_LENGTH`
- 個別 GET 2本（`/masters/validity-period`・`/masters/change-reason`）+ `getAllMasters` 同梱
- swagger（`MasterItem` schema 追加）+ テスト（getter 単体 + getAllMasters + seed 件数）

## 保存形式は不変

`ContractPlot.validity_period_years`(int) と `History.change_reason`(自由記入) はそのまま。マスタは frontend ドロップダウンの選択肢提示のみ。合祀年数の例外は #329 の人別 override で対応。

## 残（本番運用 / 別repo）

- 本番: `prisma migrate deploy` + `npm run seed:masters`（冪等）
- frontend: ドロップダウンを本マスタ接続（`change-reasons.ts` のプリセットを API 取得に置換）。別repo

## 検証

- `npx tsc --noEmit` clean / `npm run lint` clean / `npm run swagger:validate` ✅ / `npm test` → 1218 passed

Closes #343
Closes #344
Refs komine-docs#10 Q16/Q17

🤖 Generated with [Claude Code](https://claude.com/claude-code)