### PR TITLE
fix(migration): area_name を m_area.area_name（実区画名）から取る (#151)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "seed:masters": "ts-node --transpile-only prisma/seedMasters.ts",
     "migrate:legacy": "ts-node --transpile-only scripts/migrate-from-legacy.ts",
     "backfill:display-number": "ts-node --transpile-only scripts/backfill-display-number.ts",
+    "backfill:area-name": "ts-node --transpile-only scripts/backfill-area-name.ts",
     "backfill:konryu-establishment": "ts-node --transpile-only scripts/backfill-konryu-establishment.ts",
     "backfill:legacy-value-cleanup": "ts-node --transpile-only scripts/backfill-legacy-value-cleanup.ts",
     "verify:migration": "ts-node --transpile-only scripts/verify-migration.ts",

--- a/scripts/backfill-area-name.ts
+++ b/scripts/backfill-area-name.ts
@@ -1,0 +1,125 @@
+/// <reference types="node" />
+/**
+ * 既存 physical_plots の area_name backfill スクリプト（#151）
+ *
+ * 移行が area_name を `chiku_cd-area_cd`（例 `1-364`）の中間コードで生成していたのを、
+ * レガシー `m_bochi.area_cd → m_area.area_name`（実区画名: 凛A/つながり/樹林/A〜V/数字 等）に
+ * 置き換える。全角英数は半角化（normalizeGraveName）。
+ *
+ * 対象は旧形式の area_name（`\d+-\d+` または `unknown-` 始まり）の移行区画のみ。
+ * アプリ作成区画や既に正規名が入っている区画は対象外（冪等・再実行安全）。
+ *
+ * 使い方:
+ *   npm run backfill:area-name -- --dry-run   # 更新せず件数だけ確認
+ *   npm run backfill:area-name                # 実投入
+ *
+ * 環境変数: LEGACY_MYSQL_* / DATABASE_URL（migrate:legacy と同じ）
+ */
+import 'dotenv/config';
+
+import { prisma } from '../src/db/prisma';
+import { closeLegacyPool, legacyQuery } from './legacy-migration/legacyDb';
+import { normalizeGraveName } from './legacy-migration/transforms';
+
+interface AreaNameRow {
+  grave_cd: number;
+  m_area_name: string | null;
+}
+
+const BATCH = 500;
+const OLD_FORMAT = /^(\d+-\d+|unknown-)/; // 移行が生成した旧 area_name 形式
+
+async function main(): Promise<void> {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+  console.log(`[backfill area_name] start (dryRun=${dryRun})`);
+
+  // 対象: legacy-{grave_cd} 形式で area_name が旧形式の物理区画
+  const targets = await prisma.physicalPlot.findMany({
+    where: { plot_number: { startsWith: 'legacy-' } },
+    select: { id: true, plot_number: true, area_name: true },
+  });
+  const oldFormat = targets.filter((t) => OLD_FORMAT.test(t.area_name));
+  console.log(`legacy 物理区画 ${targets.length} 件 / 旧形式 area_name ${oldFormat.length} 件`);
+
+  // plot_number から grave_cd を抽出
+  const graveCdById = new Map<string, number>();
+  for (const t of oldFormat) {
+    const cd = Number(t.plot_number.slice('legacy-'.length));
+    if (Number.isInteger(cd)) graveCdById.set(t.id, cd);
+  }
+
+  // レガシーから grave_cd → m_area.area_name を一括取得
+  const allCds = [...new Set(graveCdById.values())];
+  const nameByCd = new Map<number, string | null>();
+  for (let i = 0; i < allCds.length; i += BATCH) {
+    const chunk = allCds.slice(i, i + BATCH);
+    const rows = await legacyQuery<AreaNameRow & { constructor: { name: 'RowDataPacket' } }>(
+      `SELECT b.grave_cd, a.area_name AS m_area_name
+         FROM m_bochi b LEFT JOIN m_area a ON a.area_cd = b.area_cd
+        WHERE b.grave_cd IN (${chunk.map(() => '?').join(',')})`,
+      chunk
+    );
+    for (const r of rows) nameByCd.set(r.grave_cd, r.m_area_name);
+  }
+
+  let skippedNoName = 0;
+  let skippedNoCd = 0;
+  const updates: Array<{ id: string; areaName: string }> = [];
+  for (const t of oldFormat) {
+    const cd = graveCdById.get(t.id);
+    if (cd === undefined) {
+      skippedNoCd++;
+      continue;
+    }
+    const areaName = normalizeGraveName(nameByCd.get(cd));
+    if (areaName === null) {
+      skippedNoName++; // m_area に対応無し（実測3件）→ 旧形式のまま残す
+      continue;
+    }
+    updates.push({ id: t.id, areaName });
+  }
+
+  let updated = 0;
+  if (!dryRun) {
+    const CONCURRENCY = 25;
+    for (let i = 0; i < updates.length; i += CONCURRENCY) {
+      const chunk = updates.slice(i, i + CONCURRENCY);
+      await Promise.all(
+        chunk.map((u) =>
+          prisma.physicalPlot.update({ where: { id: u.id }, data: { area_name: u.areaName } })
+        )
+      );
+      updated += chunk.length;
+      if (updated % 500 === 0 || updated === updates.length) {
+        console.log(`  updated ${updated}/${updates.length}`);
+      }
+    }
+  } else {
+    updated = updates.length;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        legacy_plots: targets.length,
+        old_format: oldFormat.length,
+        updated,
+        skip_no_m_area_name: skippedNoName,
+        skip_no_grave_cd: skippedNoCd,
+        sample: updates.slice(0, 10).map((u) => u.areaName),
+      },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR', e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeLegacyPool();
+    await prisma.$disconnect();
+  });

--- a/scripts/legacy-migration/steps/03-physical-plot.ts
+++ b/scripts/legacy-migration/steps/03-physical-plot.ts
@@ -12,6 +12,7 @@ interface BochiPhysicalRow extends RowDataPacket {
   grave_mei: string | null;
   map_id: number | null;
   note: string | null;
+  m_area_name: string | null; // m_area.area_name（area_cd 経由の実区画名。#151）
 }
 
 /**
@@ -20,7 +21,8 @@ interface BochiPhysicalRow extends RowDataPacket {
  * 1 m_bochi 行 = 1 PhysicalPlot + 1 ContractPlot に分解する設計のため、
  * ここでは物理側のみ作成。grave_cd を一意の plot_number とする。
  *
- * area_name は chiku_cd + area_cd の組合せから簡易生成（後でマスタ参照に差し替え可）
+ * area_name は m_bochi.area_cd → m_area.area_name（実区画名: 凛A/つながり/樹林/A〜V/数字 等）。
+ * m_area に対応が無い区画（実測3件のみ）は旧形式 `chiku_cd-area_cd` にフォールバック。#151
  *
  * 異常値除外:
  *   - chiku_cd=0, area_cd=99999999 等は B-3 で発見済のテストデータ
@@ -30,9 +32,11 @@ export const stepPhysicalPlot: MigrationStep = {
   name: 'physicalPlot',
   async run({ prisma, logger, idMaps, dryRun }) {
     const rows = await legacyQuery<BochiPhysicalRow>(
-      `SELECT grave_cd, chiku_cd, area_cd, grave_name_cd, grave_mei, map_id, note
-         FROM m_bochi
-        WHERE del_flg = 0 OR del_flg IS NULL`
+      `SELECT b.grave_cd, b.chiku_cd, b.area_cd, b.grave_name_cd, b.grave_mei, b.map_id, b.note,
+              a.area_name AS m_area_name
+         FROM m_bochi b
+         LEFT JOIN m_area a ON a.area_cd = b.area_cd
+        WHERE b.del_flg = 0 OR b.del_flg IS NULL`
     );
 
     let inserted = 0;
@@ -47,10 +51,13 @@ export const stepPhysicalPlot: MigrationStep = {
       }
       seenPlotNumbers.add(plotNumber);
 
+      // 区画名は m_area.area_name（実区画名）を優先。全角英数は半角化。
+      // m_area に対応が無い区画は旧形式 chiku_cd-area_cd にフォールバック（実測3件のみ）。#151
       const areaName =
-        row.chiku_cd != null && row.area_cd != null
+        normalizeGraveName(row.m_area_name) ??
+        (row.chiku_cd != null && row.area_cd != null
           ? `${row.chiku_cd}-${row.area_cd}`
-          : `unknown-${row.grave_cd}`;
+          : `unknown-${row.grave_cd}`);
 
       // 表示用区画番号（grave_name_cd 由来、例: "A-100"）。plot_number は
       // ユニーク制約・一括取込キーのため legacy-{grave_cd} を維持し、表示はこちら。#158

--- a/tests/scripts/legacy-migration/steps/area-name-mapping.test.ts
+++ b/tests/scripts/legacy-migration/steps/area-name-mapping.test.ts
@@ -1,0 +1,65 @@
+/**
+ * 回帰テスト: PhysicalPlot.area_name を m_area.area_name（実区画名）から取る（#151）
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import { createIdMaps } from '../../../../scripts/legacy-migration/idMap';
+
+jest.mock('../../../../scripts/legacy-migration/legacyDb', () => ({
+  legacyQuery: jest.fn(),
+}));
+
+import { legacyQuery } from '../../../../scripts/legacy-migration/legacyDb';
+import { stepPhysicalPlot } from '../../../../scripts/legacy-migration/steps/03-physical-plot';
+import type { MigrationContext } from '../../../../scripts/legacy-migration/types';
+
+const mockedLegacyQuery = legacyQuery as jest.Mock;
+
+function buildLogger(): MigrationContext['logger'] {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as MigrationContext['logger'];
+}
+
+describe('stepPhysicalPlot: area_name を m_area.area_name から取る (#151)', () => {
+  beforeEach(() => mockedLegacyQuery.mockReset());
+
+  it('m_area.area_name を区画名に使い、全角英数は半角化。対応無しは旧形式にフォールバック', async () => {
+    const created: Array<Record<string, unknown>> = [];
+    const prisma = {
+      physicalPlot: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) => {
+          created.push(data);
+          return Promise.resolve({ id: `pp-${created.length}` });
+        }),
+      },
+    } as unknown as PrismaClient;
+
+    mockedLegacyQuery.mockResolvedValueOnce([
+      // m_area.area_name あり（凛A）
+      { grave_cd: 1, chiku_cd: 1, area_cd: 10, m_area_name: '凛A' },
+      // 全角英数 → 半角化（Ａ → A）
+      { grave_cd: 2, chiku_cd: 1, area_cd: 11, m_area_name: 'Ａ' },
+      // m_area 対応無し → 旧形式 chiku-area にフォールバック
+      { grave_cd: 3, chiku_cd: 1, area_cd: 364, m_area_name: null },
+    ]);
+
+    await stepPhysicalPlot.run({
+      prisma,
+      logger: buildLogger(),
+      idMaps: createIdMaps(),
+      dryRun: false,
+    });
+
+    expect(created).toHaveLength(3);
+    expect(created[0].area_name).toBe('凛A');
+    expect(created[1].area_name).toBe('A'); // 全角Ａ→半角A
+    expect(created[2].area_name).toBe('1-364'); // フォールバック
+  });
+});


### PR DESCRIPTION
## 概要

区画名（`PhysicalPlot.area_name`）が `1-364` のレガシー中間コードのままだった根本を解消。

**レガシーDB実査（業務側でクエリ実行・2026-06-08）で新事実が判明**: `m_bochi.area_cd → m_area.area_name` に**きれいな実区画名**が入っている（前回 #151 調査が見落としていた）。

```
-- 生存区画が JOIN で受け取る area_name の分布（上位）
凛B 647 / 凛A 503 / 凛C 492 / つながり 467 / 凛D 420 / 樹林 281 / 樹木葬 250 /
Ａ 134 / １０ 133 / るり庵テラス 124 / 納骨堂-天空 103 / 納骨堂-阿弥陀 75 / 憩 66 / ...
-- area_cd が m_area に無い（JOIN漏れ）= わずか 3件/6250
```

## 変更

- **step03**: `m_bochi` に `m_area` を LEFT JOIN し、`area_name` を `m_area.area_name` 優先で生成（全角英数は半角化）。対応無しは旧形式 `chiku-area` にフォールバック
- **backfill** `scripts/backfill-area-name.ts`（`npm run backfill:area-name`）: レガシー JOIN で旧形式 area_name（`\d+-\d+`/`unknown-`）の移行区画のみ更新。冪等・dry-run対応
- 回帰テスト追加

## スコープ（三重矛盾への対応）

`m_area.area_name` は **section（区画名）**。schema/inventoryService は `area_name` を「期(第1期…)」想定だが、section→期 のマッピングはレガシーに無く業務確認が必要。本PRは**区画一覧の表示修正を優先**（`1-364` → `凛A`）。期での在庫集計は section→期 マスタ確定後に別途。

## 残（本番運用）

コードマージ後に `npm run backfill:area-name`（#163 同梱可）。

## 検証

- `npx tsc --noEmit` clean / `npm run lint` clean / `npm test` → 1219 passed

Closes #151
Refs komine-docs#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)