### PR TITLE
chore(schema): zod⇔VarChar 不整合9件を解消（KNOWN_VIOLATIONS空・TYPES_REF bump） (#338)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=200f417262f6bc4371b900af8d2a0e9772621eda
+ARG TYPES_REF=df9802a74bd519b75768209d7a94f0730a09ee9b
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/tests/schema-consistency/zodVarcharConsistency.test.ts
+++ b/tests/schema-consistency/zodVarcharConsistency.test.ts
@@ -140,26 +140,11 @@ const EXCEPTIONS: Record<string, Record<string, string>> = {
 
 /**
  * 既知の不整合ベースライン（key=`${schemaName}.${zodField}`、value=対応 VarChar 長）。
- * これらは本テスト導入時点で既に存在していた zod max > VarChar。正式対応（拡幅 vs zod 縮小）は
- * backend #338 で追跡する。解消したら必ずこのテーブルから削除すること（stale 検出で落ちる）。
- *
- * 内訳:
- *  - 電話/郵便番号(6件): DB は全モデル一律 VarChar(7=郵便, 11/15=電話) の digits-only 想定。
- *    zod はハイフン込みの緩い max。保存規約（数字のみ vs 書式込み）の確定が必要。
- *  - paymentMethod(2件)/gravestoneType(1件): zod が兄弟フィールドと不揃い（コピペ）。
- *    zod を VarChar に合わせる（types 変更）べきもの。
+ * 本テスト導入時点の不整合9件は #338 / types#46 で全て解消（電話/郵便は「数字のみ保存」確定で
+ * zod を VarChar に縮小、paymentMethod/gravestoneType も zod を縮小）。ベースラインは空に戻した。
+ * 今後 zod max > VarChar が新たに出たらテストが落ちる。正当な例外を許容する場合のみここへ追記する。
  */
-const KNOWN_VIOLATIONS: Record<string, number> = {
-  'workInfoSchema.workPostalCode': 7,
-  'familyContactSchema.postalCode': 7,
-  'familyContactSchema.phoneNumber': 11,
-  'familyContactSchema.phoneNumber2': 15,
-  'familyContactSchema.faxNumber': 11,
-  'familyContactSchema.workPhoneNumber': 15,
-  'usageFeeSchema.paymentMethod': 20,
-  'managementFeeSchema.paymentMethod': 20,
-  'gravestoneInfoSchema.gravestoneType': 50,
-};
+const KNOWN_VIOLATIONS: Record<string, number> = {};
 
 interface Violation {
   key: string;


### PR DESCRIPTION
## 概要

types#46（zod max を VarChar 長以下に縮小）のマージを受け、#321 の突き合わせテストの `KNOWN_VIOLATIONS` ベースラインを**空に戻す**。導入時に存在した9件を全消化。

電話/郵便番号は **「数字のみ保存」**（業務確認 2026-06-08。`cleanPhone` も全非数字除去で既存データは数字のみ）に基づき zod を VarChar 幅へ縮小。paymentMethod/gravestoneType も兄弟フィールドに合わせて縮小。

## 変更

- `KNOWN_VIOLATIONS = {}`（9件全消化）。今後の新規 `zod max > VarChar` はテストが検出
- `Dockerfile` の `TYPES_REF` を types#46 マージコミット `df9802a` に bump

## 残（別repo・UX）

frontend で電話/郵便入力をハイフン除去で正規化（数字のみ保存に揃える）。

## 検証

- `npm test` → 1219 passed（zod⇔VarChar: known violations 0）
- `npx tsc --noEmit` clean / `npm run lint` clean

Closes #338
Refs zaitsu82/komine-types#46, #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)