### PR TITLE
fix(migration): shiharai旧int値をpayment_methodコードへ確定remap (#108)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "backfill:area-name": "ts-node --transpile-only scripts/backfill-area-name.ts",
     "backfill:konryu-establishment": "ts-node --transpile-only scripts/backfill-konryu-establishment.ts",
     "backfill:legacy-value-cleanup": "ts-node --transpile-only scripts/backfill-legacy-value-cleanup.ts",
+    "backfill:shiharai-payment-method": "ts-node --transpile-only scripts/backfill-shiharai-payment-method.ts",
     "verify:migration": "ts-node --transpile-only scripts/verify-migration.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/scripts/backfill-shiharai-payment-method.ts
+++ b/scripts/backfill-shiharai-payment-method.ts
@@ -1,0 +1,112 @@
+/// <reference types="node" />
+/**
+ * 使用料・管理料の支払方法(shiharai)レガシー値を正コードへ remap する backfill（#108）
+ *
+ * 移行済みデータに残る生レガシー値を payment_method_master の code に揃える:
+ *   '0' / 'legacy-shiharai-0' → 'BANK_TRANSFER'   （銀行振込）
+ *   '1' / 'legacy-shiharai-1' → 'ACCOUNT_TRANSFER' （口座振替）
+ *   '2' / 'legacy-shiharai-2' → null               （永代＝定期支払なし。管理料のみ出現）
+ *   '口座振替'（新システム手入力の表記揺れ）        → 'ACCOUNT_TRANSFER'
+ *
+ * 旧int値の意味は issue #108 の業務確認（2026-06-08）で確定。
+ * null（未登録）と、既に正コード（CASH/BANK_TRANSFER/ACCOUNT_TRANSFER）のものは対象外。
+ *
+ * 使い方:
+ *   npx ts-node --transpile-only scripts/backfill-shiharai-payment-method.ts          # dry-run（変更計画のみ）
+ *   npx ts-node --transpile-only scripts/backfill-shiharai-payment-method.ts --apply  # 実際に更新
+ *   npm run backfill:shiharai-payment-method            # dry-run
+ *   npm run backfill:shiharai-payment-method -- --apply # 実際に更新
+ *
+ * 冪等: 実行後はレガシー値が消えるため再実行で 0 件。
+ */
+import 'dotenv/config';
+
+import { prisma } from '../src/db/prisma';
+
+const APPLY = process.argv.includes('--apply');
+
+/**
+ * 現在の payment_method 文字列を新コードへ写像する。
+ * - 生int / legacy-shiharai-N / 表記揺れ「口座振替」を対象にする。
+ * - 写像対象外（null・既存の正コード・想定外値）は undefined を返し、触らない。
+ */
+function mapLegacyShiharai(value: string): string | null | undefined {
+  if (value === '口座振替') return 'ACCOUNT_TRANSFER';
+  const m = /^(?:legacy-shiharai-)?(\d+)$/.exec(value);
+  if (!m) return undefined;
+  switch (m[1]) {
+    case '0':
+      return 'BANK_TRANSFER';
+    case '1':
+      return 'ACCOUNT_TRANSFER';
+    case '2':
+      return null; // 永代＝支払なし
+    default:
+      return undefined; // 想定外の int は温存
+  }
+}
+
+type FeeModel = 'usageFee' | 'managementFee';
+
+interface PlanRow {
+  from: string;
+  to: string | null;
+  count: number;
+}
+
+async function backfillFee(model: FeeModel): Promise<{ plan: PlanRow[]; updated: number }> {
+  const delegate = prisma[model] as {
+    groupBy: (args: {
+      by: ['payment_method'];
+      _count: { _all: true };
+    }) => Promise<Array<{ payment_method: string | null; _count: { _all: number } }>>;
+    updateMany: (args: {
+      where: { payment_method: string };
+      data: { payment_method: string | null };
+    }) => Promise<{ count: number }>;
+  };
+
+  const groups = await delegate.groupBy({ by: ['payment_method'], _count: { _all: true } });
+
+  const plan: PlanRow[] = [];
+  for (const g of groups) {
+    if (g.payment_method == null) continue;
+    const to = mapLegacyShiharai(g.payment_method);
+    if (to === undefined) continue; // 触らない
+    plan.push({ from: g.payment_method, to, count: g._count._all });
+  }
+
+  if (!APPLY) return { plan, updated: 0 };
+
+  let updated = 0;
+  for (const p of plan) {
+    const r = await delegate.updateMany({
+      where: { payment_method: p.from },
+      data: { payment_method: p.to },
+    });
+    updated += r.count;
+  }
+  return { plan, updated };
+}
+
+async function main(): Promise<void> {
+  console.log(`[backfill shiharai-payment-method] start (apply=${APPLY})`);
+
+  const usageFee = await backfillFee('usageFee');
+  const managementFee = await backfillFee('managementFee');
+
+  console.log(JSON.stringify({ apply: APPLY, usageFee, managementFee }, null, 2));
+
+  if (!APPLY) {
+    console.log('\n（dry-run。--apply で実際に更新します）');
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error('ERROR', e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/legacy-migration/steps/05-contract-plot.ts
+++ b/scripts/legacy-migration/steps/05-contract-plot.ts
@@ -25,10 +25,21 @@ function mapFeeCode(
   return map[value] ?? `legacy-${prefix}-${value}`;
 }
 
-// 支払方法(shiharai)は旧コードの意味が未特定（対応する sykbnn KBNNO 無し）。
-// 業務確認まで legacy- prefix で温存し、マスタ名への誤変換を防ぐ。
-function mapShiharai(value: number | null | undefined): string | null {
-  return value == null ? null : `legacy-shiharai-${value}`;
+// 支払方法(shiharai)は旧 sykbnn に対応 KBNNO が無く長らく意味未特定だったが、
+// 業務確認（issue #108, 2026-06-08）で旧int値の意味が確定した:
+//   0 = 銀行振込(BANK_TRANSFER) / 1 = 口座振替(ACCOUNT_TRANSFER) / 2 = 永代＝支払なし(null)
+// payment_method_master と一致する code に remap する（seedMasters.ts 参照）。
+const SHIHARAI_MAP: Record<number, string | null> = {
+  0: 'BANK_TRANSFER',
+  1: 'ACCOUNT_TRANSFER',
+  2: null, // 永代（管理料のみ・定期支払なし）→ 支払方法ではないため null
+};
+export function mapShiharai(value: number | null | undefined): string | null {
+  if (value == null) return null;
+  // 対応表に無い想定外値のみ、誤変換を避けて legacy- prefix で温存する。
+  return Object.prototype.hasOwnProperty.call(SHIHARAI_MAP, value)
+    ? SHIHARAI_MAP[value]
+    : `legacy-shiharai-${value}`;
 }
 
 interface BochiContractRow extends RowDataPacket {

--- a/tests/scripts/legacy-migration/steps/shiharai-mapping.test.ts
+++ b/tests/scripts/legacy-migration/steps/shiharai-mapping.test.ts
@@ -1,0 +1,30 @@
+/**
+ * 回帰テスト: 支払方法(shiharai) の旧int値 → 新マスタ code 変換（#108）
+ *
+ * 業務確認（2026-06-08）で確定した対応:
+ *   0 = 銀行振込(BANK_TRANSFER) / 1 = 口座振替(ACCOUNT_TRANSFER) / 2 = 永代＝支払なし(null)
+ */
+import { mapShiharai } from '../../../../scripts/legacy-migration/steps/05-contract-plot';
+
+describe('mapShiharai: 旧shiharai値 → payment_method code (#108)', () => {
+  it('0 は銀行振込(BANK_TRANSFER)', () => {
+    expect(mapShiharai(0)).toBe('BANK_TRANSFER');
+  });
+
+  it('1 は口座振替(ACCOUNT_TRANSFER)', () => {
+    expect(mapShiharai(1)).toBe('ACCOUNT_TRANSFER');
+  });
+
+  it('2 は永代＝支払なしのため null', () => {
+    expect(mapShiharai(2)).toBeNull();
+  });
+
+  it('null / undefined はそのまま null', () => {
+    expect(mapShiharai(null)).toBeNull();
+    expect(mapShiharai(undefined)).toBeNull();
+  });
+
+  it('対応表に無い想定外値は legacy- prefix で温存する', () => {
+    expect(mapShiharai(9)).toBe('legacy-shiharai-9');
+  });
+});


### PR DESCRIPTION
## 概要

支払方法(shiharai)の旧int値の意味が **業務確認（#108, 2026-06-08）で確定** したため、これまで誤変換回避のため `legacy-shiharai-{n}` で温存していた値を `payment_method_master` の正コードへ remap する。これにより #108 の最後の未決着項目を解消する。

## 確定マッピング

| 旧int値 | 意味 | → 新コード |
|---|---|---|
| `0` | 銀行振込 | `BANK_TRANSFER` |
| `1` | 口座振替 | `ACCOUNT_TRANSFER` |
| `2` | 永代（支払なし・管理料のみ） | `null` |
| `口座振替`（新システム手入力の表記揺れ） | 口座振替 | `ACCOUNT_TRANSFER` |
| `null` | 未登録 | （変更なし） |

旧 `sykbnn` に shiharai 対応の KBNNO が存在せず長らく意味未特定だったが、業務担当の回答で確定。`BANK_TRANSFER`/`ACCOUNT_TRANSFER` は既存マスタにあるため新規マスタ値追加は不要。

## 変更内容

- `scripts/legacy-migration/steps/05-contract-plot.ts`: `mapShiharai` を `SHIHARAI_MAP` ベースに変更（今後の再移行で正コードを生成）・テスト用に export
- `scripts/backfill-shiharai-payment-method.ts`（新規）: 移行済み本番データの生int / `口座振替` リテラルを正コードへ remap する冪等 backfill（`--apply` で適用、無印は dry-run）
- `tests/scripts/legacy-migration/steps/shiharai-mapping.test.ts`（新規）: 確定マッピングの回帰テスト
- `package.json`: `backfill:shiharai-payment-method` スクリプト追加

## 本番DB 適用状況

backfill 適用済み（このPRマージ前に実施済み）:

| | 使用料 | 管理料 |
|---|---|---|
| 更新件数 | 3,529 | 3,529 |
| ACCOUNT_TRANSFER | 3,259 | 2,913 |
| BANK_TRANSFER | 270 | 269 |
| null（未登録＋永代） | 2,617 | 2,963 |

再実行で 0 件 = 冪等を確認済み。UI に出ていた「旧コード:0/1/2」表示は解消。

## 検証

- `npx tsc --noEmit` clean
- `npm run lint` clean
- 移行ステップテスト 30件 green（新規 shiharai-mapping 5件含む）

Closes #108