### PR TITLE
chore: FRONTEND_URL を Render Blueprint と .env.example に追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,14 @@ SUPABASE_URL="https://your-project-id.supabase.co"
 # Settings > API > Project API keys > service_role からコピー
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key-here"
 
+# 招待 / パスワードリセットメールの遷移先ベースURL（末尾スラッシュ不可）
+# コード側で `${FRONTEND_URL}/set-password` `${FRONTEND_URL}/reset-password` と連結するため、
+# 末尾に "/" を付けると `//set-password` になり Supabase の Redirect URL 許可リストに
+# マッチせず Site URL にフォールバックする（招待リンクが localhost 等に飛ぶ原因）。
+# 未設定だとリセットは localhost、招待は Supabase Site URL にフォールバックする。
+# この値は Supabase Dashboard の Site URL / Redirect URLs 許可リストと一致させること。
+FRONTEND_URL="http://localhost:3000"
+
 # 初期管理者ブートストラップ (npm run bootstrap:admin / npx prisma db seed)
 # 顧客環境への初回デプロイ時に1度だけ実行して admin ユーザーを作成します
 # 既に admin が存在する場合は何もしません（冪等）

--- a/render.yaml
+++ b/render.yaml
@@ -23,6 +23,13 @@ services:
         sync: false
       - key: ALLOWED_ORIGINS
         sync: false
+      # 招待/パスワードリセットメールの遷移先ベースURL。
+      # 末尾スラッシュ不可（コード側で `${FRONTEND_URL}/set-password` と連結するため、
+      # スラッシュ付きだと `//set-password` になり Supabase の Redirect URL 許可リストに
+      # マッチせず Site URL にフォールバックする）。値は Dashboard で入力。
+      # 例: https://komine-cemetery-crm.vercel.app
+      - key: FRONTEND_URL
+        sync: false
       - key: PUPPETEER_EXECUTABLE_PATH
         value: /usr/bin/chromium
       - key: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD


### PR DESCRIPTION
## 背景

ログイン画面の「パスワードをお忘れの方」/ スタッフ招待メールのリンクが **localhost に飛んでエラー**になる事象を調査。原因は遷移先 `redirectTo` のベースURLである `FRONTEND_URL` が **どの設定ファイルにも明示されていない**こと（`render.yaml` / `.env.example` 双方に欠落、`リリース手順書.md` でも未記載と指摘済み）。

- 招待: `staffController.ts` → `FRONTEND_URL ? ${FRONTEND_URL}/set-password : undefined` → 未設定だと `undefined` → Supabase **Site URL（=localhost）にフォールバック**
- リセット: `authController.ts` → `${FRONTEND_URL || 'http://localhost:3000'}/reset-password` → 未設定だと localhost 直行

## 変更内容

- **render.yaml**: `envVars` に `FRONTEND_URL`（`sync: false` / Dashboard 管理）を追加
- **.env.example**: `FRONTEND_URL` を追記
- いずれも **「末尾スラッシュ不可」** を明記
  - コード側で `${FRONTEND_URL}/set-password` と連結するため、末尾 `/` 付きだと `//set-password` になり、Supabase の **Redirect URLs 許可リストにマッチせず Site URL にフォールバック**してしまう

## デプロイ時の運用メモ（コード変更ではない手動作業）

- [ ] Render Dashboard の `FRONTEND_URL` を本番フロントURL（**末尾スラッシュ無し**）に設定 → 再デプロイ
- [ ] Supabase Dashboard: **Site URL** = `https://komine-cemetery-crm.vercel.app`（オリジンのみ）
- [ ] Supabase Dashboard: **Redirect URLs** に `https://komine-cemetery-crm.vercel.app/set-password` と `/reset-password` を登録
- [ ] 組み込みメールのレート制限解除後に招待を再送し、リンクの `redirect_to=` が本番URL（スラッシュ1個）になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)