### PR TITLE
chore: TYPES_REF を types#48 (node_modules 追跡解除済) へ bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /packages/types
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
 # 詳細: zaitsu82/komine-crm-backend#60
-ARG TYPES_REF=7836c67e228a246c70cc3a541db6b93edd286bcf
+ARG TYPES_REF=38f5623d2b0b1f3e49f7f74fca0ed6abe03891c1
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要

types#48 で、誤コミットされていた `node_modules` シンボリックリンクを追跡解除した。本番 Docker ビルド（types ステージ `git clone && npm ci && npm run build`）が汚染のない types を clone するよう、backend Dockerfile の `TYPES_REF` を types#48 (`38f5623`) へ bump する。

型内容は #47 と同一（symlink 除去のみ）。Docker Security Scan で types ステージの `npm ci` が問題なく通ることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)