### PR TITLE
fix(auth): forgot-password がレート制限時に専用メッセージを返す (#350)

### DIFF
--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -745,6 +745,21 @@ export const forgotPassword = async (req: Request, res: Response) => {
     if (error) {
       // エラーが発生してもセキュリティ上同一レスポンスを返す
       log.warn({ email, error: error.message }, 'Auth: password reset email failed');
+
+      // レート制限だけは専用メッセージを返す（#350）。
+      // レート制限は「送信元の送信枠」の話でメアドの存在に依存しないため、
+      // 専用メッセージを返しても登録済みかどうかの列挙情報は漏れない＝安全。
+      // それ以外のエラー（user無し含む）は従来どおり一律成功で返し列挙対策を維持する。
+      if (error.message.includes('rate limit')) {
+        return res.status(429).json({
+          success: false,
+          error: {
+            code: 'RATE_LIMIT_EXCEEDED',
+            message: 'メールの送信制限に達しました。しばらく待ってから再試行してください。',
+            details: [],
+          },
+        });
+      }
     } else {
       log.info({ email }, 'Auth: password reset email sent');
     }

--- a/tests/auth/authController.test.ts
+++ b/tests/auth/authController.test.ts
@@ -916,6 +916,37 @@ describe('Auth Controller', () => {
         );
         expect(mockResponse.status).toHaveBeenCalledWith(200);
       });
+
+      it('レート制限エラー時は専用メッセージを429で返すこと（#350）', async () => {
+        mockRequest.body = { email: 'active@example.com' };
+        mockPrisma.staff.findFirst.mockResolvedValue(null);
+        mockSupabaseAuth.resetPasswordForEmail.mockResolvedValue({
+          error: { message: 'email rate limit exceeded' },
+        });
+
+        await forgotPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(429);
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: expect.objectContaining({ code: 'RATE_LIMIT_EXCEEDED' }),
+          })
+        );
+      });
+
+      it('レート制限以外の送信エラーは一律成功を維持すること（列挙対策）', async () => {
+        mockRequest.body = { email: 'active@example.com' };
+        mockPrisma.staff.findFirst.mockResolvedValue(null);
+        mockSupabaseAuth.resetPasswordForEmail.mockResolvedValue({
+          error: { message: 'some other transient error' },
+        });
+
+        await forgotPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(200);
+        expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+      });
     });
 
     describe('COOKIE_SECURE によるCookie属性制御（#299）', () => {


### PR DESCRIPTION
## 概要
`POST /api/v1/auth/forgot-password` が Supabase 組み込みメールの**送信レート制限**に当たった場合、従来は全エラーを握りつぶして一律「送信しました」を返していたため、メールが届かない理由がユーザーに伝わらなかった（サポート問い合わせ増の原因）。

## 変更
- `resetPasswordForEmail` が **rate limit** エラーを返したときだけ `429` + `RATE_LIMIT_EXCEEDED` の専用メッセージを返す
- それ以外のエラー（user 無し含む）は**従来どおり一律成功**を維持 → メール列挙攻撃対策は崩さない
  - レート制限は「送信元の送信枠」の話でメアドの存在に依存しないため、専用メッセージを返しても登録済みかどうかの列挙情報は漏れない＝安全
- `staffController` 経由の招待再送（`rate_limit` 分類済み）との**挙動の非対称を解消**

## テスト
- レート制限エラー時に 429 + `RATE_LIMIT_EXCEEDED` を返すこと
- レート制限以外のエラーは一律成功（200）を維持すること
- 既存の招待未完了検知・列挙対策テストは全て green（auth スイート 39 件 pass）

## 関連
- 送信枠そのものの対策（独自SMTP化）は #351
- 遷移先URL設定（`FRONTEND_URL`）は #349（マージ済）

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)