### PR TITLE
fix(plots): deletePlot で合祀等の子レコードを論理削除しカスケード漏れを解消 (#358)

### DIFF
--- a/src/collective-burials/collectiveBurialController.ts
+++ b/src/collective-burials/collectiveBurialController.ts
@@ -56,8 +56,11 @@ export const getCollectiveBurialList = async (
     const skip = (pageNum - 1) * limitNum;
 
     // 検索条件の構築
+    // 親契約が論理削除済みの「孤児合祀」を常に除外する（#358 layer2・防御的二重担保）。
+    // deletePlot 側のカスケード漏れで active のまま残った合祀が一覧に出ないようにする。
     const where: Record<string, unknown> = {
       deleted_at: null,
+      contractPlot: { is: { deleted_at: null } },
     };
 
     // 請求ステータスフィルター
@@ -77,29 +80,34 @@ export const getCollectiveBurialList = async (
     }
 
     // 検索クエリ（顧客名、区画番号で検索）
+    // contractPlot フィルタは上で deleted_at:null を設定済みのため、検索条件は
+    // その is 配下にマージして親契約の論理削除ガードを保持する。
     if (search) {
       where['contractPlot'] = {
-        OR: [
-          {
-            physicalPlot: {
-              plot_number: { contains: search as string, mode: 'insensitive' },
+        is: {
+          deleted_at: null,
+          OR: [
+            {
+              physicalPlot: {
+                plot_number: { contains: search as string, mode: 'insensitive' },
+              },
             },
-          },
-          {
-            saleContractRoles: {
-              some: {
-                // 論理削除済みの旧役割（解約・差し替えで外れた顧客）を検索対象から除外（#206）
-                deleted_at: null,
-                customer: {
-                  OR: [
-                    { name: { contains: search as string, mode: 'insensitive' } },
-                    { name_kana: { contains: search as string, mode: 'insensitive' } },
-                  ],
+            {
+              saleContractRoles: {
+                some: {
+                  // 論理削除済みの旧役割（解約・差し替えで外れた顧客）を検索対象から除外（#206）
+                  deleted_at: null,
+                  customer: {
+                    OR: [
+                      { name: { contains: search as string, mode: 'insensitive' } },
+                      { name_kana: { contains: search as string, mode: 'insensitive' } },
+                    ],
+                  },
                 },
               },
             },
-          },
-        ],
+          ],
+        },
       };
     }
 
@@ -200,7 +208,8 @@ export const getCollectiveBurialById = async (
     const { id } = req.params as Record<string, string>;
 
     const collectiveBurial = await prisma.collectiveBurial.findFirst({
-      where: { id, deleted_at: null },
+      // 親契約が論理削除済みの孤児合祀は詳細でも参照不能にする（#358 layer2）
+      where: { id, deleted_at: null, contractPlot: { is: { deleted_at: null } } },
       include: {
         contractPlot: {
           include: {

--- a/src/plots/controllers/deletePlot.ts
+++ b/src/plots/controllers/deletePlot.ts
@@ -13,7 +13,7 @@ import { Prisma } from '@prisma/client';
 import { updatePhysicalPlotStatus } from '../utils';
 import prisma from '../../db/prisma';
 import { NotFoundError } from '../../middleware/errorHandler';
-import { recordEntityDeleted } from '../services/historyService';
+import { recordEntityDeleted, HistoryEntityType } from '../services/historyService';
 
 /**
  * ContractPlot削除（論理削除）
@@ -170,7 +170,124 @@ export const deletePlot = async (
           }
         }
 
-        // 7. PhysicalPlotのステータスを更新
+        // 7. ContractPlot 配下の子レコードを論理削除（#358）
+        // いずれも contract_plot_id で直接紐づくため、分割販売（同一物理区画に
+        // 別の有効契約）でも他契約のデータには影響しない。
+        // これらを消し残すと、親契約削除後も合祀管理画面に孤児レコードが残る／
+        // saleContractRole が active のまま残り顧客削除判定（上記）を狂わせる。
+        const childCascades: Array<{
+          entityType: HistoryEntityType;
+          findActive: () => Promise<Array<{ id: string }>>;
+          softDelete: (childId: string) => Promise<unknown>;
+        }> = [
+          {
+            entityType: 'CollectiveBurial',
+            findActive: () =>
+              tx.collectiveBurial.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.collectiveBurial.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'BuriedPerson',
+            findActive: () =>
+              tx.buriedPerson.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.buriedPerson.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'GravestoneInfo',
+            findActive: () =>
+              tx.gravestoneInfo.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.gravestoneInfo.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'ConstructionInfo',
+            findActive: () =>
+              tx.constructionInfo.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.constructionInfo.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'FamilyContact',
+            findActive: () =>
+              tx.familyContact.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.familyContact.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'SaleContractRole',
+            findActive: () =>
+              tx.saleContractRole.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.saleContractRole.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'Document',
+            findActive: () =>
+              tx.document.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.document.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'Billing',
+            findActive: () =>
+              tx.billing.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.billing.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+          {
+            entityType: 'Payment',
+            findActive: () =>
+              tx.payment.findMany({
+                where: { contract_plot_id: id, deleted_at: null },
+                select: { id: true },
+              }),
+            softDelete: (childId) =>
+              tx.payment.update({ where: { id: childId }, data: { deleted_at: now } }),
+          },
+        ];
+
+        for (const cascade of childCascades) {
+          const rows = await cascade.findActive();
+          for (const row of rows) {
+            await cascade.softDelete(row.id);
+            await recordEntityDeleted(tx, {
+              entityType: cascade.entityType,
+              entityId: row.id,
+              physicalPlotId,
+              contractPlotId: id,
+              beforeRecord: { id: row.id },
+              req,
+            });
+          }
+        }
+
+        // 8. PhysicalPlotのステータスを更新
         await updatePhysicalPlotStatus(tx, physicalPlotId);
       },
       // 在庫面積・status再計算を含むため並行更新と直列化する（#278）

--- a/src/plots/services/historyLabels.ts
+++ b/src/plots/services/historyLabels.ts
@@ -237,6 +237,26 @@ export const FIELD_LABELS: Record<HistoryEntityType, Record<string, string>> = {
     type: '書類種別',
     name: '書類名',
   },
+  Billing: {
+    category: '請求区分',
+    use_start_year: '使用開始年',
+    use_end_year: '使用終了年',
+    target_month: '対象月',
+    billing_years: '請求年数',
+    amount: '請求金額',
+    billing_date: '請求日',
+    paid_amount: '入金済額',
+    status: '請求ステータス',
+    notes: '備考',
+  },
+  Payment: {
+    scheduled_date: '入金予定日',
+    scheduled_amount: '入金予定額',
+    payment_date: '入金日',
+    payment_amount: '入金額',
+    fee_type: '料金種別',
+    notes: '備考',
+  },
 };
 
 /**
@@ -257,6 +277,8 @@ export const ENTITY_LABELS: Record<HistoryEntityType, string> = {
   FamilyContact: '家族連絡先',
   SaleContractRole: '契約役割',
   Document: '書類',
+  Billing: '請求',
+  Payment: '入金',
 };
 
 /**

--- a/src/plots/services/historyService.ts
+++ b/src/plots/services/historyService.ts
@@ -37,7 +37,9 @@ export type HistoryEntityType =
   | 'ConstructionInfo'
   | 'CollectiveBurial'
   | 'GravestoneInfo'
-  | 'FamilyContact';
+  | 'FamilyContact'
+  | 'Billing'
+  | 'Payment';
 
 /**
  * 履歴レコード作成のための入力パラメータ

--- a/tests/collective-burials/collectiveBurialFixes.test.ts
+++ b/tests/collective-burials/collectiveBurialFixes.test.ts
@@ -294,20 +294,25 @@ describe('collectiveBurialController — バグ修正回帰', () => {
       mockRequest.query = { search: '山田' };
       await getCollectiveBurialList(mockRequest as Request, mockResponse as Response, mockNext);
 
+      // 検索条件は contractPlot.is 配下にマージされ、親契約の論理削除ガード
+      // （deleted_at: null）と OR 検索条件が共存する（#358 layer2）
       expect(mockPrisma.collectiveBurial.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            contractPlot: expect.objectContaining({
-              OR: expect.arrayContaining([
-                expect.objectContaining({
-                  saleContractRoles: {
-                    some: expect.objectContaining({
-                      deleted_at: null,
-                    }),
-                  },
-                }),
-              ]),
-            }),
+            contractPlot: {
+              is: expect.objectContaining({
+                deleted_at: null,
+                OR: expect.arrayContaining([
+                  expect.objectContaining({
+                    saleContractRoles: {
+                      some: expect.objectContaining({
+                        deleted_at: null,
+                      }),
+                    },
+                  }),
+                ]),
+              }),
+            },
           }),
         })
       );

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -69,9 +69,30 @@ const mockPrisma: any = {
   },
   gravestoneInfo: {
     findUnique: jest.fn(),
+    findMany: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+  },
+  constructionInfo: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  document: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  billing: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  payment: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
   },
   familyContact: {
     findMany: jest.fn(),
@@ -91,6 +112,7 @@ const mockPrisma: any = {
   },
   collectiveBurial: {
     findUnique: jest.fn(),
+    findMany: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
   },
@@ -163,6 +185,7 @@ import {
 import {
   recordEntityUpdated,
   recordContractPlotUpdated,
+  recordEntityDeleted,
 } from '../../src/plots/services/historyService';
 import {
   validateContractArea,
@@ -2374,6 +2397,87 @@ describe('Plot Controller (ContractPlot Model)', () => {
 
       expect(mockNext).toHaveBeenCalledWith(expect.any(NotFoundError));
     });
+
+    it('契約区画削除時に合祀・埋葬者・契約役割など子レコードを論理削除する (#358)', async () => {
+      setupDeleteCascadeMocks();
+      mockRequest.params = { id: 'cp1' };
+
+      await deletePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // 合祀（今回の孤児レコードの主因）が論理削除されること
+      expect(mockPrisma.collectiveBurial.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cb1' },
+          data: expect.objectContaining({ deleted_at: expect.any(Date) }),
+        })
+      );
+      // 契約役割が論理削除されること（顧客削除判定の正確性のため）
+      expect(mockPrisma.saleContractRole.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'scr1' },
+          data: expect.objectContaining({ deleted_at: expect.any(Date) }),
+        })
+      );
+      // 埋葬者・墓石・工事・家族連絡先・書類・請求・入金も論理削除されること
+      expect(mockPrisma.buriedPerson.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'bp1' } })
+      );
+      expect(mockPrisma.billing.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'bl1' } })
+      );
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'pm1' } })
+      );
+      // 各子に DELETE 履歴が記録されること
+      expect(recordEntityDeleted).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ entityType: 'CollectiveBurial', entityId: 'cb1' })
+      );
+      expect(responseStatus).toHaveBeenCalledWith(200);
+    });
+
+    // deletePlot のカスケード対象を網羅したモック準備
+    function setupDeleteCascadeMocks(): void {
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        contract_date: new Date('2024-01-01'),
+        price: 1000000,
+        payment_status: 'paid',
+        physicalPlot: { id: 'pp1' },
+        saleContractRoles: [
+          { id: 'scr1', customer: { id: 'c1', name: '山田太郎', workInfo: null } },
+        ],
+        usageFee: null,
+        managementFee: null,
+      });
+      mockPrisma.contractPlot.update.mockResolvedValue({ id: 'cp1' });
+      // 顧客の他契約参照チェック（contract_plot_id: { not } 付き）は「他に無い」、
+      // カスケードの役割検索（contract_plot_id 等値）は scr1 を返す
+      mockPrisma.saleContractRole.findMany.mockImplementation((args: any) => {
+        if (args?.where?.contract_plot_id?.not) return Promise.resolve([]);
+        return Promise.resolve([{ id: 'scr1' }]);
+      });
+      mockPrisma.customer.update.mockResolvedValue({ id: 'c1' });
+      mockPrisma.collectiveBurial.findMany.mockResolvedValue([{ id: 'cb1' }]);
+      mockPrisma.collectiveBurial.update.mockResolvedValue({ id: 'cb1' });
+      mockPrisma.buriedPerson.findMany.mockResolvedValue([{ id: 'bp1' }]);
+      mockPrisma.buriedPerson.update.mockResolvedValue({ id: 'bp1' });
+      mockPrisma.gravestoneInfo.findMany.mockResolvedValue([{ id: 'gs1' }]);
+      mockPrisma.gravestoneInfo.update.mockResolvedValue({ id: 'gs1' });
+      mockPrisma.constructionInfo.findMany.mockResolvedValue([{ id: 'ci1' }]);
+      mockPrisma.constructionInfo.update.mockResolvedValue({ id: 'ci1' });
+      mockPrisma.familyContact.findMany.mockResolvedValue([{ id: 'fc1' }]);
+      mockPrisma.familyContact.update.mockResolvedValue({ id: 'fc1' });
+      mockPrisma.saleContractRole.update.mockResolvedValue({ id: 'scr1' });
+      mockPrisma.document.findMany.mockResolvedValue([{ id: 'doc1' }]);
+      mockPrisma.document.update.mockResolvedValue({ id: 'doc1' });
+      mockPrisma.billing.findMany.mockResolvedValue([{ id: 'bl1' }]);
+      mockPrisma.billing.update.mockResolvedValue({ id: 'bl1' });
+      mockPrisma.payment.findMany.mockResolvedValue([{ id: 'pm1' }]);
+      mockPrisma.payment.update.mockResolvedValue({ id: 'pm1' });
+    }
   });
 
   describe('getPlotContracts', () => {


### PR DESCRIPTION
## 概要
契約区画削除（`DELETE /api/v1/plots/:id`）で、`collective_burials` 等の子レコードが論理削除されず、親契約が消えても**合祀管理画面に孤児レコードが残る**不具合を修正（本番で実際に発生・2026-06-09 に手動クリーンアップ済み）。本PRはその再発防止。

## 修正（2層）
### 1. `deletePlot` のカスケード追加
トランザクション内で、対象 `contractPlot` 配下の以下9種を論理削除：
`collectiveBurial` / `buriedPerson` / `gravestoneInfo` / `constructionInfo` / `familyContact` / `saleContractRole` / `document` / `billing` / `payment`
- いずれも `contract_plot_id` で直接紐づくため、**分割販売（同一物理区画に別の有効契約）でも他契約のデータには影響しない**
- 各削除に `recordEntityDeleted` で DELETE 履歴を記録（`HistoryEntityType` に `Billing` / `Payment` を追加、`historyLabels` も整備）
- `sale_contract_roles` を消し残さないことで、顧客の「他契約から参照されているか」判定が削除済み役割を active と誤カウントする問題も解消

### 2. 合祀一覧/詳細クエリの防御的ガード
`collectiveBurialController` の一覧・詳細クエリに `contractPlot: { is: { deleted_at: null } }` を常時付与し、親契約が論理削除済みの孤児合祀を二重に除外。検索フィルタは `is` 配下にマージして親契約ガードと共存させる。

## テスト
- 契約区画削除で合祀・埋葬者・契約役割・請求・入金等が論理削除され DELETE 履歴が記録されること
- 検索フィルタが `contractPlot.is` 配下にマージされ親契約ガードと共存すること
- 全 1234 テスト green / tsc・lint clean

## 補足
- `histories` は `deleted_at` を持たない監査ログのため対象外
- `physical_plots` は status 再計算のみ（物理区画は残す＝仕様どおり）

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)