### PR TITLE
fix(payments/migration): 入金料金種別のラベル化と工事業者0の未設定化 (#334)

### DIFF
--- a/scripts/backfill-legacy-value-cleanup.ts
+++ b/scripts/backfill-legacy-value-cleanup.ts
@@ -6,6 +6,7 @@
  *  1. gravestone_infos.direction_id / position_id = 0 → null（方位/位置の「旧コード:0」）
  *  2. family_contacts.relationship の生int → 続柄マスタ名（'0'/未解決は 'unknown'）
  *  3. buried_persons.religion = 'legacy-shuuha-*' → null（宗派マスタ不要確定）
+ *  4. construction_infos.contractor = 'legacy-gyousha-0'（=未設定）→ null + 業者マスタ無効化（#334）
  *
  * いずれもアプリ作成データには影響しない（0/センチネル/生int は移行由来のみ）。
  *
@@ -82,14 +83,44 @@ async function backfillReligion(): Promise<Record<string, number>> {
   return { religion_nulled: r.count };
 }
 
+async function backfillGyousha(): Promise<Record<string, number>> {
+  // gyousha_cd=0（=未設定）由来の contractor='legacy-gyousha-0' を null にし、
+  // 「業者ID:0」業者マスタを無効化する（#334）。実在業者（legacy-gyousha-1 等）は対象外。
+  const GYOUSHA_ZERO = 'legacy-gyousha-0';
+  if (!APPLY) {
+    const constructions = await prisma.constructionInfo.count({
+      where: { contractor: GYOUSHA_ZERO },
+    });
+    const master = await prisma.contractorMaster.count({
+      where: { code: GYOUSHA_ZERO, is_active: true },
+    });
+    return { construction_gyousha_zero: constructions, active_gyousha_zero_master: master };
+  }
+  const constructions = await prisma.constructionInfo.updateMany({
+    where: { contractor: GYOUSHA_ZERO },
+    data: { contractor: null },
+  });
+  const master = await prisma.contractorMaster.updateMany({
+    where: { code: GYOUSHA_ZERO },
+    data: { is_active: false },
+  });
+  return {
+    construction_contractor_nulled: constructions.count,
+    gyousha_zero_master_deactivated: master.count,
+  };
+}
+
 async function main(): Promise<void> {
   console.log(`[backfill legacy-value-cleanup] start (apply=${APPLY})`);
 
   const directionPosition = await backfillDirectionPosition();
   const relationship = await backfillRelationship();
   const religion = await backfillReligion();
+  const gyousha = await backfillGyousha();
 
-  console.log(JSON.stringify({ apply: APPLY, directionPosition, relationship, religion }, null, 2));
+  console.log(
+    JSON.stringify({ apply: APPLY, directionPosition, relationship, religion, gyousha }, null, 2)
+  );
 }
 
 main()

--- a/scripts/legacy-migration/steps/09-construction-info.ts
+++ b/scripts/legacy-migration/steps/09-construction-info.ts
@@ -43,9 +43,10 @@ export const stepConstructionInfo: MigrationStep = {
     );
 
     // 出現する legacy gyousha_cd の一意集合を ContractorMaster に upsert
+    // gyousha_cd = 0 は「未設定」を意味するため業者マスタを作らず、contractor も null にする（#334）。
     const distinctGyousha = new Set<number>();
     for (const row of rows) {
-      if (row.gyousha_cd != null) distinctGyousha.add(row.gyousha_cd);
+      if (row.gyousha_cd != null && row.gyousha_cd !== 0) distinctGyousha.add(row.gyousha_cd);
     }
     let mastersUpserted = 0;
     if (!dryRun) {
@@ -101,7 +102,10 @@ export const stepConstructionInfo: MigrationStep = {
           start_date: parseLegacyDate(row.construction_start),
           completion_date: parseLegacyDate(row.construction_end),
           scheduled_end_date: parseLegacyDate(row.construction_sch),
-          contractor: row.gyousha_cd != null ? `legacy-gyousha-${row.gyousha_cd}` : null,
+          contractor:
+            row.gyousha_cd != null && row.gyousha_cd !== 0
+              ? `legacy-gyousha-${row.gyousha_cd}`
+              : null, // gyousha_cd=0 は未設定（#334）
           work_amount_1: row.price ?? null,
           payment_amount_1: row.payment ?? null,
           construction_content: cleanStr(row.construction_content),

--- a/src/billings/billingController.ts
+++ b/src/billings/billingController.ts
@@ -6,6 +6,7 @@ import prisma from '../db/prisma';
 import { NotFoundError, ValidationError } from '../middleware/errorHandler';
 import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentStatusService';
 import { recalculateBillingPayments } from './billingService';
+import { resolvePaymentFeeTypeLabel } from '../payments/feeTypeLabels';
 import {
   createBillingSchema,
   updateBillingSchema,
@@ -243,7 +244,8 @@ export const getBillingById = async (
           scheduledDate: p.scheduled_date?.toISOString().split('T')[0] ?? null,
           paymentAmount: p.payment_amount,
           scheduledAmount: p.scheduled_amount,
-          feeType: p.fee_type,
+          // レガシーセンチネル（legacy-fee-2023000X）を使用料/管理料へ解決して返す（#334）
+          feeType: resolvePaymentFeeTypeLabel(p.fee_type),
           staffInCharge: p.staff_in_charge,
           notes: p.notes,
         })),

--- a/src/payments/feeTypeLabels.ts
+++ b/src/payments/feeTypeLabels.ts
@@ -1,0 +1,26 @@
+/**
+ * 入金(payments)の料金種別ラベル解決（#334）
+ *
+ * レガシー移行（scripts/legacy-migration/steps/11-payment.ts）で payments.fee_type には
+ * `legacy-fee-20230001` / `legacy-fee-20230002` というセンチネル文字列が入っている。
+ * 業務確認（komine-docs#10）で以下と確定したため、表示時に日本語ラベルへ変換する:
+ *   - 20230001 = 使用料
+ *   - 20230002 = 管理料
+ *
+ * fee_type はマスタFKではなく自由文字列カラムのため、生データ（センチネル）は保持したまま
+ * 読み取り時（DTO化）にのみラベル解決する。新規入金で入った非レガシー値はそのまま返す。
+ */
+export const LEGACY_PAYMENT_FEE_TYPE_LABELS: Record<string, string> = {
+  'legacy-fee-20230001': '使用料',
+  'legacy-fee-20230002': '管理料',
+};
+
+/**
+ * payments.fee_type を表示用ラベルへ解決する。
+ * - 既知のレガシーセンチネル → 日本語ラベル
+ * - それ以外（新規入金値・null）→ そのまま
+ */
+export function resolvePaymentFeeTypeLabel(feeType: string | null | undefined): string | null {
+  if (feeType == null) return null;
+  return LEGACY_PAYMENT_FEE_TYPE_LABELS[feeType] ?? feeType;
+}

--- a/src/payments/paymentController.ts
+++ b/src/payments/paymentController.ts
@@ -9,6 +9,7 @@ import {
   listPaymentsQuerySchema,
 } from '../validations/paymentValidation';
 import { recalculateBillingPayments } from '../billings/billingService';
+import { resolvePaymentFeeTypeLabel } from './feeTypeLabels';
 
 type PaymentWithRelations = Prisma.PaymentGetPayload<{
   include: {
@@ -44,7 +45,8 @@ const formatPayment = (p: PaymentWithRelations) => ({
   scheduledAmount: p.scheduled_amount,
   paymentDate: p.payment_date?.toISOString().split('T')[0] ?? null,
   paymentAmount: p.payment_amount,
-  feeType: p.fee_type,
+  // レガシーセンチネル（legacy-fee-2023000X）を使用料/管理料へ解決して返す（#334）
+  feeType: resolvePaymentFeeTypeLabel(p.fee_type),
   applicationType: p.application_type,
   billingType: p.billing_type,
   staffInCharge: p.staff_in_charge,

--- a/tests/payments/feeTypeLabels.test.ts
+++ b/tests/payments/feeTypeLabels.test.ts
@@ -1,0 +1,22 @@
+import { resolvePaymentFeeTypeLabel } from '../../src/payments/feeTypeLabels';
+
+describe('resolvePaymentFeeTypeLabel (#334)', () => {
+  it('legacy-fee-20230001 を「使用料」に解決する', () => {
+    expect(resolvePaymentFeeTypeLabel('legacy-fee-20230001')).toBe('使用料');
+  });
+
+  it('legacy-fee-20230002 を「管理料」に解決する', () => {
+    expect(resolvePaymentFeeTypeLabel('legacy-fee-20230002')).toBe('管理料');
+  });
+
+  it('既知センチネル以外（新規入金値）はそのまま返す', () => {
+    expect(resolvePaymentFeeTypeLabel('管理料')).toBe('管理料');
+    expect(resolvePaymentFeeTypeLabel('使用料')).toBe('使用料');
+    expect(resolvePaymentFeeTypeLabel('その他')).toBe('その他');
+  });
+
+  it('null / undefined は null を返す', () => {
+    expect(resolvePaymentFeeTypeLabel(null)).toBeNull();
+    expect(resolvePaymentFeeTypeLabel(undefined)).toBeNull();
+  });
+});

--- a/tests/payments/paymentController.test.ts
+++ b/tests/payments/paymentController.test.ts
@@ -181,6 +181,18 @@ describe('paymentController', () => {
 
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'NotFoundError' }));
     });
+
+    it('レガシーセンチネル fee_type を使用料/管理料に解決して返す (#334)', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue(
+        buildPaymentRow({ fee_type: 'legacy-fee-20230001' })
+      );
+
+      const req = buildRequest({ params: { id: PAYMENT_UUID } });
+      await getPaymentById(req as Request, res as Response, next);
+
+      const payload = (res.json as jest.Mock).mock.calls[0][0];
+      expect(payload.data.feeType).toBe('使用料');
+    });
   });
 
   describe('createPayment', () => {


### PR DESCRIPTION
## 概要
#334 のうち**業務確認で確定した分**と**既知のデータ品質分**を対応する。

### 1. 入金の料金種別ラベル化（業務確認で確定）
入金明細で全件 `legacy-fee-20230001` / `legacy-fee-20230002` の生センチネル表示になっていた問題。業務確認で **20230001=使用料 / 20230002=管理料** と確定したため、DTO 層でラベル解決する。
- 共有ヘルパー `resolvePaymentFeeTypeLabel`（`src/payments/feeTypeLabels.ts`）を追加
- `paymentController` / `billingController` の入金明細 `feeType` に適用
- 生データ（センチネル）は保持し**読み取り時のみ解決**。新規入金値・null はそのまま透過

### 2. 工事業者 `gyousha_cd=0`（=未設定）の未設定化
工事記録の大半（233件）が「業者ID:0」表示になっていた問題。`gyousha_cd=0` は未設定を意味するため未登録扱いにする。
- 移行 `09-construction-info`: `gyousha_cd=0` は業者マスタを作らず `contractor` を null にする
- `backfill-legacy-value-cleanup` に #4 を追加: 既存の `contractor='legacy-gyousha-0'` を null 化＋当該業者マスタを `is_active=false`。**本番反映は #355 のバッチ実行時に同梱**（実在業者 legacy-gyousha-1 等は対象外）

## テスト
- `resolvePaymentFeeTypeLabel` 単体（センチネル→ラベル / 未知値透過 / null）
- paymentController で legacy センチネルがDTOで解決されること
- 全 1239 テスト green / tsc・lint clean

## 残（業務確認継続）
- `grave_kind` / `grave_kubun` / `grave_type` の各レガシーintの意味は**事務所確認が必要**なため本PRでは未対応。確定後にマスタ化/表示判断（issueに残課題としてコメント）。

Refs #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)