### PR TITLE
feat(billing): 管理料の年度請求(Billing)自動生成バッチを追加 (#196)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "swagger:json": "node scripts/swagger.js json",
     "swagger:build": "node scripts/swagger.js build",
     "billing:generate": "ts-node scripts/generate-collective-burial-invoices.ts",
+    "billing:generate-management": "ts-node --transpile-only scripts/generate-management-fee-billings.ts",
     "bootstrap:admin": "ts-node --transpile-only prisma/seed.ts",
     "seed:masters": "ts-node --transpile-only prisma/seedMasters.ts",
     "migrate:legacy": "ts-node --transpile-only scripts/migrate-from-legacy.ts",

--- a/scripts/generate-management-fee-billings.ts
+++ b/scripts/generate-management-fee-billings.ts
@@ -1,0 +1,77 @@
+/// <reference types="node" />
+/**
+ * 管理料の年度請求(Billing)自動生成バッチ（#196）
+ *
+ * 管理料設定(ManagementFee)から対象年度の管理料 Billing を冪等に生成する。
+ * 詳細ロジックは src/billings/managementFeeBillingService.ts を参照。
+ *
+ * 使い方:
+ *   npm run billing:generate-management -- --year=2026             # dry-run（件数のみ）
+ *   npm run billing:generate-management -- --year=2026 --apply     # 実際に生成
+ *   npm run billing:generate-management -- --year=2026 --apply --include-prepaid
+ *     （複数年一括前納の契約も含める。既定は二重請求回避でスキップ）
+ *
+ * 冪等: 同一区画・management_fee・同一 use_start_year の請求が既にあれば再実行でも作らない。
+ */
+import 'dotenv/config';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { generateManagementFeeBillings } from '../src/billings/managementFeeBillingService';
+
+const APPLY = process.argv.includes('--apply');
+const INCLUDE_PREPAID = process.argv.includes('--include-prepaid');
+
+function parseYearArg(): number {
+  const arg = process.argv.find((a) => a.startsWith('--year='));
+  const year = arg ? parseInt(arg.slice('--year='.length), 10) : NaN;
+  if (!Number.isFinite(year) || year < 1990 || year > 2100) {
+    throw new Error('--year=YYYY を 1990〜2100 で指定してください（例: --year=2026）');
+  }
+  return year;
+}
+
+async function main(): Promise<void> {
+  const targetYear = parseYearArg();
+  const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL'] });
+  const prisma = new PrismaClient({ adapter });
+
+  console.log(
+    `[billing:generate-management] year=${targetYear} apply=${APPLY} includePrepaid=${INCLUDE_PREPAID}`
+  );
+
+  try {
+    const result = await generateManagementFeeBillings(prisma, {
+      targetYear,
+      apply: APPLY,
+      includePrepaid: INCLUDE_PREPAID,
+    });
+
+    console.log(
+      JSON.stringify(
+        {
+          ...result,
+          createdPlotIds: `${result.createdPlotIds.length} 件（省略）`,
+        },
+        null,
+        2
+      )
+    );
+
+    if (!APPLY) {
+      console.log('\n（dry-run。--apply で実際に Billing を生成します）');
+    }
+    if (result.skippedPrepaid > 0 && !INCLUDE_PREPAID) {
+      console.log(
+        `\n⚠️ 複数年一括前納の契約 ${result.skippedPrepaid} 件をスキップしました（二重請求回避）。` +
+          ' 前納の次回請求年を確認のうえ、必要なら --include-prepaid で対象化してください。'
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((e) => {
+  console.error('ERROR', e);
+  process.exitCode = 1;
+});

--- a/src/billings/managementFeeBillingService.ts
+++ b/src/billings/managementFeeBillingService.ts
@@ -1,0 +1,170 @@
+/**
+ * 管理料の年度請求(Billing)自動生成サービス（#196）
+ *
+ * 管理料は「毎年・年度末(3月)に1年分を請求する定期課金」が基本モデル（実データで確認:
+ * management_fees.billing_month は 3 が最多、入金も 2026 まで毎年ほぼ一定で繰り返し発生）。
+ * 設定テーブル(ManagementFee)はあるが請求(Billing)が未起票だと「未入金・管理料あり・請求タブ空」
+ * になるため、対象年度の管理料 Billing を設定から冪等に生成する。
+ *
+ * 対象: contract_status=active かつ管理料設定(amount 解釈可)を持つ契約区画。
+ * 冪等: 同一区画・同一カテゴリ(management_fee)・同一 use_start_year の請求が既にあればスキップ。
+ * 前納ガード: ManagementFee.billing_years > 1（5年/10年一括前納）は二重請求回避のため既定でスキップし
+ *   ログに出す（前納の次回請求年判定は業務確認が必要なため、既定では自動起票しない）。
+ *   includePrepaid=true で対象に含められる。
+ *
+ * 使用料(usage_fee)は契約時一括のため本バッチの対象外。
+ */
+import { PrismaClient, ContractStatus, BillingCategory } from '@prisma/client';
+import { recalculateContractPlotPaymentStatus } from '../plots/services/paymentStatusService';
+
+/** billing_month 未設定時の既定（年度末 3 月。実データで最多）。 */
+export const DEFAULT_BILLING_MONTH = 3;
+
+export interface GenerateManagementBillingOptions {
+  /** 対象年度（西暦・use_start_year に入る） */
+  targetYear: number;
+  /** true で実際に Billing を作成。false は dry-run（件数のみ算出） */
+  apply: boolean;
+  /** 複数年一括前納(billing_years>1)も対象に含める（既定 false=二重請求回避でスキップ） */
+  includePrepaid?: boolean;
+}
+
+export interface GenerateManagementBillingResult {
+  targetYear: number;
+  scanned: number;
+  created: number;
+  skippedExisting: number;
+  skippedPrepaid: number;
+  skippedNoAmount: number;
+  skippedNoCustomer: number;
+  createdPlotIds: string[];
+}
+
+/** 文字列の管理料(VarChar)から金額intを取り出す。数字以外を除去。0/解釈不能は null。 */
+export function parseFeeAmount(raw: string | null | undefined): number | null {
+  if (raw == null) return null;
+  const digits = raw.replace(/[^\d]/g, '');
+  if (!digits) return null;
+  const n = parseInt(digits, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/** billing_month(VarChar)から 1..12 の月を取り出す。範囲外/未設定は既定 3 月。 */
+export function parseBillingMonth(raw: string | null | undefined): number {
+  if (raw == null) return DEFAULT_BILLING_MONTH;
+  const n = parseInt(raw.replace(/[^\d]/g, ''), 10);
+  return n >= 1 && n <= 12 ? n : DEFAULT_BILLING_MONTH;
+}
+
+/** billing_years(VarChar)から請求年数を取り出す。未設定/0/解釈不能は 1（年次）。 */
+export function parseBillingYears(raw: string | null | undefined): number {
+  if (raw == null) return 1;
+  const n = parseInt(raw.replace(/[^\d]/g, ''), 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+export async function generateManagementFeeBillings(
+  prisma: PrismaClient,
+  opts: GenerateManagementBillingOptions
+): Promise<GenerateManagementBillingResult> {
+  const { targetYear, apply, includePrepaid = false } = opts;
+  const result: GenerateManagementBillingResult = {
+    targetYear,
+    scanned: 0,
+    created: 0,
+    skippedExisting: 0,
+    skippedPrepaid: 0,
+    skippedNoAmount: 0,
+    skippedNoCustomer: 0,
+    createdPlotIds: [],
+  };
+
+  const contracts = await prisma.contractPlot.findMany({
+    where: {
+      deleted_at: null,
+      contract_status: ContractStatus.active,
+      managementFee: { is: { deleted_at: null } },
+    },
+    select: {
+      id: true,
+      managementFee: {
+        select: { management_fee: true, billing_month: true, billing_years: true },
+      },
+      saleContractRoles: {
+        where: { deleted_at: null, role: { in: ['contractor', 'applicant'] } },
+        select: { role: true, customer_id: true },
+      },
+      // 対象年度の管理料請求が既にあるか（冪等判定）
+      billings: {
+        where: {
+          deleted_at: null,
+          category: BillingCategory.management_fee,
+          use_start_year: targetYear,
+        },
+        select: { id: true },
+      },
+    },
+  });
+
+  for (const c of contracts) {
+    result.scanned++;
+    const mf = c.managementFee;
+    if (!mf) continue;
+
+    const amount = parseFeeAmount(mf.management_fee);
+    if (amount == null) {
+      result.skippedNoAmount++;
+      continue;
+    }
+
+    // 冪等: 対象年度の管理料請求が既にあればスキップ
+    if (c.billings.length > 0) {
+      result.skippedExisting++;
+      continue;
+    }
+
+    // 前納ガード: 複数年一括は既定で対象外（二重請求回避）
+    if (parseBillingYears(mf.billing_years) > 1 && !includePrepaid) {
+      result.skippedPrepaid++;
+      continue;
+    }
+
+    // 請求先顧客は契約者優先・なければ申込者
+    const roles = c.saleContractRoles;
+    const target =
+      roles.find((r) => r.role === 'contractor') ?? roles.find((r) => r.role === 'applicant');
+    if (!target) {
+      result.skippedNoCustomer++;
+      continue;
+    }
+
+    const month = parseBillingMonth(mf.billing_month);
+    const billingDate = new Date(Date.UTC(targetYear, month - 1, 1));
+
+    if (apply) {
+      await prisma.$transaction(async (tx) => {
+        await tx.billing.create({
+          data: {
+            contract_plot_id: c.id,
+            customer_id: target.customer_id,
+            category: BillingCategory.management_fee,
+            amount,
+            use_start_year: targetYear,
+            use_end_year: targetYear,
+            billing_years: 1,
+            target_month: month,
+            billing_date: billingDate,
+            status: 'billed',
+          },
+        });
+        // 請求が増えたので派生 payment_status を再計算（#162）
+        await recalculateContractPlotPaymentStatus(tx, c.id);
+      });
+    }
+
+    result.created++;
+    result.createdPlotIds.push(c.id);
+  }
+
+  return result;
+}

--- a/tests/billings/managementFeeBillingService.test.ts
+++ b/tests/billings/managementFeeBillingService.test.ts
@@ -1,0 +1,163 @@
+// payment_status 再計算はここでは検証対象外のため no-op に差し替える
+jest.mock('../../src/plots/services/paymentStatusService', () => ({
+  recalculateContractPlotPaymentStatus: jest.fn().mockResolvedValue('unpaid'),
+}));
+
+import {
+  generateManagementFeeBillings,
+  parseFeeAmount,
+  parseBillingMonth,
+  parseBillingYears,
+  DEFAULT_BILLING_MONTH,
+} from '../../src/billings/managementFeeBillingService';
+
+interface MockContract {
+  id: string;
+  managementFee: {
+    management_fee: string | null;
+    billing_month: string | null;
+    billing_years: string | null;
+  } | null;
+  saleContractRoles: Array<{ role: string; customer_id: string }>;
+  billings: Array<{ id: string }>;
+}
+
+const buildContract = (over: Partial<MockContract> = {}): MockContract => ({
+  id: 'cp1',
+  managementFee: { management_fee: '5000', billing_month: '3', billing_years: '1' },
+  saleContractRoles: [{ role: 'contractor', customer_id: 'c1' }],
+  billings: [],
+  ...over,
+});
+
+function buildPrisma(contracts: MockContract[]) {
+  const billingCreate = jest.fn().mockResolvedValue({ id: 'b-new' });
+  const prisma = {
+    contractPlot: { findMany: jest.fn().mockResolvedValue(contracts) },
+    $transaction: jest.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb({ billing: { create: billingCreate } })
+    ),
+  };
+  return { prisma: prisma as never, billingCreate };
+}
+
+describe('parse helpers (#196)', () => {
+  it('parseFeeAmount は数字以外を除去し 0/不能は null', () => {
+    expect(parseFeeAmount('5000')).toBe(5000);
+    expect(parseFeeAmount('¥5,000')).toBe(5000);
+    expect(parseFeeAmount('0')).toBeNull();
+    expect(parseFeeAmount('')).toBeNull();
+    expect(parseFeeAmount(null)).toBeNull();
+  });
+  it('parseBillingMonth は 1..12 以外を既定(3)に', () => {
+    expect(parseBillingMonth('3')).toBe(3);
+    expect(parseBillingMonth('10')).toBe(10);
+    expect(parseBillingMonth('0')).toBe(DEFAULT_BILLING_MONTH);
+    expect(parseBillingMonth('13')).toBe(DEFAULT_BILLING_MONTH);
+    expect(parseBillingMonth(null)).toBe(DEFAULT_BILLING_MONTH);
+  });
+  it('parseBillingYears は未設定/0 を 1(年次) に', () => {
+    expect(parseBillingYears('1')).toBe(1);
+    expect(parseBillingYears('10')).toBe(10);
+    expect(parseBillingYears('0')).toBe(1);
+    expect(parseBillingYears(null)).toBe(1);
+  });
+});
+
+describe('generateManagementFeeBillings (#196)', () => {
+  it('対象契約に対象年度の管理料Billingを生成する', async () => {
+    const { prisma, billingCreate } = buildPrisma([buildContract()]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(1);
+    expect(billingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          contract_plot_id: 'cp1',
+          customer_id: 'c1',
+          category: 'management_fee',
+          amount: 5000,
+          use_start_year: 2026,
+          target_month: 3,
+        }),
+      })
+    );
+  });
+
+  it('対象年度の管理料Billingが既にあれば冪等スキップ', async () => {
+    const { prisma, billingCreate } = buildPrisma([buildContract({ billings: [{ id: 'b0' }] })]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(0);
+    expect(r.skippedExisting).toBe(1);
+    expect(billingCreate).not.toHaveBeenCalled();
+  });
+
+  it('複数年一括前納(billing_years>1)は既定でスキップする', async () => {
+    const { prisma } = buildPrisma([
+      buildContract({
+        managementFee: { management_fee: '5000', billing_month: '3', billing_years: '10' },
+      }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(0);
+    expect(r.skippedPrepaid).toBe(1);
+  });
+
+  it('includePrepaid=true なら前納契約も対象にする', async () => {
+    const { prisma } = buildPrisma([
+      buildContract({
+        managementFee: { management_fee: '5000', billing_month: '3', billing_years: '10' },
+      }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, {
+      targetYear: 2026,
+      apply: true,
+      includePrepaid: true,
+    });
+
+    expect(r.created).toBe(1);
+    expect(r.skippedPrepaid).toBe(0);
+  });
+
+  it('金額が解釈不能ならスキップ', async () => {
+    const { prisma } = buildPrisma([
+      buildContract({
+        managementFee: { management_fee: null, billing_month: '3', billing_years: '1' },
+      }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(0);
+    expect(r.skippedNoAmount).toBe(1);
+  });
+
+  it('請求先顧客(契約者/申込者)が無ければスキップ', async () => {
+    const { prisma } = buildPrisma([buildContract({ saleContractRoles: [] })]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(0);
+    expect(r.skippedNoCustomer).toBe(1);
+  });
+
+  it('dry-run(apply=false)では作成せず件数のみ算出', async () => {
+    const { prisma, billingCreate } = buildPrisma([buildContract()]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: false });
+
+    expect(r.created).toBe(1);
+    expect(billingCreate).not.toHaveBeenCalled();
+  });
+
+  it('契約者が無くても申込者を請求先に使う', async () => {
+    const { prisma, billingCreate } = buildPrisma([
+      buildContract({ saleContractRoles: [{ role: 'applicant', customer_id: 'c-app' }] }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(1);
+    expect(billingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ customer_id: 'c-app' }) })
+    );
+  });
+});


### PR DESCRIPTION
## 概要
管理料設定(`ManagementFee`)はあるが請求(`Billing`)が未起票だと「未入金・管理料あり・請求タブ空」になり、毎年の管理料請求を全区画手動起票するのは非現実的だった。**対象年度の管理料 Billing を設定から冪等に生成するバッチ**を追加する。

## 課金モデル（本番の入金履歴から確認）
- `management_fees.billing_month` は **「3」(年度末)が最多**（2020件）
- 入金は **2018→2026 で毎年ほぼ一定に繰り返し発生**（年次定期課金）。8回入金=8年分払い続けている区画も多数
- 一部に `billing_years=5/10` の**複数年一括前納**が混在（10年:1028件 / 5年:326件）

→ 「**毎年・年度末(3月)に1年分を請求**」を基本モデルとして実装（ユーザー確認済み）。

## 実装
- `src/billings/managementFeeBillingService.ts` — `generateManagementFeeBillings(targetYear, {apply, includePrepaid})`
  - 対象: `contract_status=active` かつ管理料設定(金額解釈可)を持つ契約区画
  - **冪等**: 同一区画・`management_fee`・同一 `use_start_year` の請求があればスキップ
  - **前納ガード**: `billing_years>1` は既定でスキップ（二重請求回避・ログ出力）。`includePrepaid=true` で対象化
  - 請求先は契約者優先・なければ申込者。`billing_month` 既定3月
  - 生成後 `recalculateContractPlotPaymentStatus` で派生 payment_status を再計算（#162）
- `scripts/generate-management-fee-billings.ts`（`npm run billing:generate-management`）
  - `--year=YYYY` / `--apply` / `--include-prepaid`、dry-run 既定

## 検証
- 単体テスト 11 件（生成 / 冪等 / 前納スキップ / includePrepaid / 金額無 / 顧客無 / dry-run / 申込者フォールバック）
- **本番 dry-run(2026)で実データ動作確認**: scan 3443 / 生成予定 1827 / 既存26 / 前納スキップ1317 / 金額無273 / 顧客無0
- 全 1244 テスト green / tsc・lint clean

## スコープ外・残
- 使用料(usage_fee)は契約時一括のため本バッチ対象外
- 複数年一括前納の「次回請求年」判定は業務確認が必要（既定でスキップ・`--include-prepaid` で手動対象化）
- 起動方式（cron 自動 / 管理画面手動）は運用方針確定後に別途

Refs #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)