### PR TITLE
feat(yucho): ゆうちょ記号番号のデータモデルを整備し店番/口座番号を正準化 (#170)

### DIFF
--- a/prisma/migrations/20260609000000_add_customer_yucho_symbol_number/migration.sql
+++ b/prisma/migrations/20260609000000_add_customer_yucho_symbol_number/migration.sql
@@ -1,0 +1,12 @@
+-- Customer にゆうちょ記号(5桁)・番号フィールドを追加する（#170）
+--
+-- 背景:
+--   ゆうちょ自動払込CSVの店番は、これまで支店名(branch_name)から漢数字/数字を推定して
+--   採番しており、不明時は 000 になっていた（src/yucho/yuchoCsv.ts extractBranchCode）。
+--   ゆうちょの記号番号方式（記号 = 1 + 店番3桁 + 預金種目1桁、番号 = 口座番号）を
+--   正しく保持できるよう、記号・番号を Customer に持たせる。
+--   変換ロジックは src/yucho/yuchoAccount.ts に集約し、CSV と表示で同一ロジックを使う。
+--
+-- いずれも nullable。既存データは null（未入力）。新システムで入力していく。
+ALTER TABLE "customers" ADD COLUMN "yucho_symbol" VARCHAR(5);
+ALTER TABLE "customers" ADD COLUMN "yucho_number" VARCHAR(20);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -248,6 +248,10 @@ model Customer {
   account_type              String?   @db.VarChar(10) // 預金種目（ordinary/current/savings）
   account_number            String?   @db.VarChar(20) // 口座番号
   account_holder            String?   @db.VarChar(100) // 口座名義
+  // ゆうちょ記号(5桁)・番号。店番/口座番号を名称から推定せず、記号番号方式で正しく保持する（#170）。
+  // 変換は src/yucho/yuchoAccount.ts に集約（記号 = 1 + 店番3桁 + 預金種目1桁）。
+  yucho_symbol              String?   @db.VarChar(5) // ゆうちょ記号（5桁）
+  yucho_number              String?   @db.VarChar(20) // ゆうちょ番号
   notes                     String?   @db.Text // 備考
   staff_id                  Int? // 担当スタッフFK（レガシー tancd → matant）
   legacy_danka_cd           Int? // 移行用（レガシー t_danka.danka_cd）

--- a/src/plots/controllers/changeContractor.ts
+++ b/src/plots/controllers/changeContractor.ts
@@ -22,7 +22,7 @@ import prisma from '../../db/prisma';
 import { NotFoundError, ConflictError, ValidationError } from '../../middleware/errorHandler';
 import { recordEntityUpdated } from '../services/historyService';
 import { syncPrimaryContractorNameKana } from '../utils';
-import type { ChangeContractorRequest } from '../../validations/plotValidation';
+import type { ChangeContractorRequest, CustomerYuchoInput } from '../../validations/plotValidation';
 
 export const changeContractor = async (
   req: Request,
@@ -110,6 +110,8 @@ export const changeContractor = async (
               account_type: nc.accountType || null,
               account_number: nc.accountNumber || null,
               account_holder: nc.accountHolder || null,
+              yucho_symbol: (nc as unknown as CustomerYuchoInput).yuchoSymbol || null,
+              yucho_number: (nc as unknown as CustomerYuchoInput).yuchoNumber || null,
               notes: nc.notes || null,
               staff_id: nc.staffId ?? null,
             },

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -16,6 +16,7 @@ import {
   AddressType,
 } from '@prisma/client';
 import { CreatePlotRequest } from '@komine/types';
+import type { CustomerYuchoInput } from '../../validations/plotValidation';
 import {
   validateContractArea,
   updatePhysicalPlotStatus,
@@ -117,6 +118,8 @@ export async function createPlotCore(
       account_type: input.customer.accountType || null,
       account_number: input.customer.accountNumber || null,
       account_holder: input.customer.accountHolder || null,
+      yucho_symbol: (input.customer as unknown as CustomerYuchoInput).yuchoSymbol || null,
+      yucho_number: (input.customer as unknown as CustomerYuchoInput).yuchoNumber || null,
       notes: input.customer.notes || null,
       staff_id: input.customer.staffId ?? null,
       legacy_danka_cd: input.customer.legacyDankaCd ?? null,

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -345,6 +345,8 @@ export const getPlotById = async (
             accountType: role.customer.account_type,
             accountNumber: role.customer.account_number,
             accountHolder: role.customer.account_holder,
+            yuchoSymbol: role.customer.yucho_symbol,
+            yuchoNumber: role.customer.yucho_number,
             notes: role.customer.notes,
             workInfo: role.customer.workInfo
               ? {

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -8,6 +8,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Prisma, ContractRole } from '@prisma/client';
 import { UpdatePlotRequest } from '@komine/types';
+import type { CustomerYuchoInput } from '../../validations/plotValidation';
 import {
   updatePhysicalPlotStatus,
   buildGravestoneInfoData,
@@ -347,6 +348,11 @@ export async function updatePlotCore(
         customerUpdateData.account_number = input.customer.accountNumber;
       if (input.customer.accountHolder !== undefined)
         customerUpdateData.account_holder = input.customer.accountHolder;
+      const customerYucho = input.customer as unknown as CustomerYuchoInput;
+      if (customerYucho.yuchoSymbol !== undefined)
+        customerUpdateData.yucho_symbol = customerYucho.yuchoSymbol;
+      if (customerYucho.yuchoNumber !== undefined)
+        customerUpdateData.yucho_number = customerYucho.yuchoNumber;
       if (input.customer.notes !== undefined) customerUpdateData.notes = input.customer.notes;
 
       // issue #66: update 戻り値を保持し section 13 で再取得しないようにする

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -216,7 +216,21 @@ const saleContractSchema = sharedSaleContractSchema.omit({ paymentStatus: true }
  * 顧客情報のバリデーションスキーマ
  * 共有スキーマをベースに、バックエンド固有の要件（role は saleContract.roles で管理）に合わせる。
  */
-const customerSchema = sharedCustomerSchema.omit({ role: true });
+// ゆうちょ記号(5桁)・番号は @komine/types 未追加のため backend ローカルで受理する（#170）。
+// フロントのゆうちょ口座入力UI実装時に shared schema へ昇格予定。
+const customerSchema = sharedCustomerSchema.omit({ role: true }).extend({
+  yuchoSymbol: z.string().max(5).optional().or(z.literal('')),
+  yuchoNumber: z.string().max(20).optional().or(z.literal('')),
+});
+
+/**
+ * controller の input.customer は @komine/types 由来の型でゆうちょ記号/番号を持たないため、
+ * これらを読むときに使う補助型（#170）。runtime は customerSchema が受理済み。
+ */
+export type CustomerYuchoInput = {
+  yuchoSymbol?: string | null;
+  yuchoNumber?: string | null;
+};
 
 /**
  * 勤務先情報のバリデーションスキーマ

--- a/src/validations/yuchoValidation.ts
+++ b/src/validations/yuchoValidation.ts
@@ -73,6 +73,9 @@ export interface YuchoBillingItem {
     accountType: string | null;
     accountNumber: string | null;
     accountHolder: string | null;
+    // ゆうちょ記号(5桁)・番号。店番/口座番号の正準ソース（#170）。
+    yuchoSymbol: string | null;
+    yuchoNumber: string | null;
   } | null;
 }
 

--- a/src/yucho/yuchoAccount.ts
+++ b/src/yucho/yuchoAccount.ts
@@ -1,0 +1,62 @@
+/**
+ * ゆうちょ記号番号 ⇔ 店番・口座番号 の変換を集約する（#170）
+ *
+ * ゆうちょ口座を他金融機関フォーマット（店番＋口座番号）で扱うときの方式A:
+ *   記号(5桁) = "1" + 店番(3桁) + 預金種目(1桁)
+ *     - 先頭 "1" は通常貯金を表す固定値
+ *     - 中央3桁が店番（振込用の3桁店番）
+ *     - 末尾1桁は預金種目（通常 0）
+ *   番号       = 口座番号（末尾のチェックデジットを除いた値で運用される）
+ *
+ * これまで CSV 出力では店番を支店名から推定していた（yuchoCsv.extractBranchCode）。
+ * Customer.yucho_symbol / yucho_number を保持し、ここで一元変換することで、
+ * 表示(フロント)と CSV で同一ロジックを使えるようにする。
+ */
+
+/** 記号が方式A（5桁・先頭1）として妥当か。 */
+export function isValidYuchoSymbol(symbol: string | null | undefined): boolean {
+  if (symbol == null) return false;
+  const digits = symbol.replace(/[^\d]/g, '');
+  return digits.length === 5 && digits.startsWith('1');
+}
+
+/**
+ * 記号(5桁)から店番(3桁)を取り出す。方式A: 記号の中央3桁。
+ * 妥当でない場合は null を返す（呼び出し側で支店名推定にフォールバック）。
+ */
+export function branchCodeFromSymbol(symbol: string | null | undefined): string | null {
+  if (symbol == null) return null;
+  const digits = symbol.replace(/[^\d]/g, '');
+  if (digits.length !== 5 || !digits.startsWith('1')) return null;
+  return digits.slice(1, 4);
+}
+
+/**
+ * 記号(5桁)から預金種目コード（末尾1桁）を取り出す。妥当でなければ null。
+ */
+export function depositTypeFromSymbol(symbol: string | null | undefined): string | null {
+  if (symbol == null) return null;
+  const digits = symbol.replace(/[^\d]/g, '');
+  if (digits.length !== 5 || !digits.startsWith('1')) return null;
+  return digits.slice(4, 5);
+}
+
+/**
+ * 番号から口座番号（数字のみ）を取り出す。空なら null。
+ */
+export function accountNumberFromYuchoNumber(num: string | null | undefined): string | null {
+  if (num == null) return null;
+  const digits = num.replace(/[^\d]/g, '');
+  return digits.length > 0 ? digits : null;
+}
+
+/** 表示用に「記号-番号」形式へ整形する。どちらか欠ければ null。 */
+export function formatSymbolNumber(
+  symbol: string | null | undefined,
+  num: string | null | undefined
+): string | null {
+  const s = symbol?.replace(/[^\d]/g, '') ?? '';
+  const n = num?.replace(/[^\d]/g, '') ?? '';
+  if (!s || !n) return null;
+  return `${s}-${n}`;
+}

--- a/src/yucho/yuchoCsv.ts
+++ b/src/yucho/yuchoCsv.ts
@@ -22,6 +22,7 @@
  */
 
 import type { YuchoBillingItem } from '../validations/yuchoValidation';
+import { branchCodeFromSymbol, accountNumberFromYuchoNumber } from './yuchoAccount';
 
 const LINE_SEP = '\r\n';
 const BANK_CODE = '9900';
@@ -238,16 +239,23 @@ export const buildDataRow = (item: YuchoBillingItem): string => {
     ACCOUNT_HOLDER_WIDTH
   ).replace(/"/g, '""');
 
+  // 店番・口座番号はゆうちょ記号番号があればそれを正準ソースにする（#170）。
+  // 記号(方式A)から店番3桁を取り、無ければ従来どおり支店名から推定する。
+  const branchCode =
+    branchCodeFromSymbol(info?.yuchoSymbol) ?? extractBranchCode(info?.branchName ?? '');
+  const accountNumber =
+    accountNumberFromYuchoNumber(info?.yuchoNumber) ?? info?.accountNumber ?? '';
+
   const cells = [
     '', // 1: 空
     BANK_CODE, // 2: 金融機関コード
     padRight(BANK_NAME_KANA, BANK_NAME_KANA_WIDTH), // 3: 金融機関名 半角カナ
     BANK_NAME_KANJI, // 4: 金融機関名 漢字
-    padLeftZero(extractBranchCode(info?.branchName ?? ''), 3), // 5: 店番
+    padLeftZero(branchCode, 3), // 5: 店番
     '', // 6: 空
     '', // 7: 空
     accountTypeCode(info?.accountType), // 8: 預金種目
-    padLeftZero(info?.accountNumber ?? '', 7), // 9: 口座番号
+    padLeftZero(accountNumber, 7), // 9: 口座番号
     `"${accountHolder}"`, // 10: 口座名義
     String(item.billingAmount), // 11: 引落金額
     FLAG, // 12: フラグ
@@ -265,7 +273,12 @@ interface BuildCsvParams {
  * ここで弾かないと「構造上正しいが口座が存在しない」不正振替行が出力される（#266）。
  */
 const hasUsableAccountNumber = (item: YuchoBillingItem): boolean => {
-  const digits = (item.billingInfo?.accountNumber ?? '').replace(/[^\d]/g, '');
+  // ゆうちょ番号があればそれを、無ければ従来の口座番号を口座番号として扱う（#170）
+  const source =
+    accountNumberFromYuchoNumber(item.billingInfo?.yuchoNumber) ??
+    item.billingInfo?.accountNumber ??
+    '';
+  const digits = source.replace(/[^\d]/g, '');
   return digits.length > 0 && Number(digits) > 0;
 };
 

--- a/src/yucho/yuchoService.ts
+++ b/src/yucho/yuchoService.ts
@@ -70,6 +70,8 @@ type PayerCustomer = {
   account_type: string | null;
   account_number: string | null;
   account_holder: string | null;
+  yucho_symbol: string | null;
+  yucho_number: string | null;
 };
 
 /**
@@ -91,13 +93,24 @@ const pickPayer = (
  */
 const buildBillingInfo = (payer: PayerCustomer | null): YuchoBillingItem['billingInfo'] => {
   if (!payer) return null;
-  if (!payer.bank_name && !payer.branch_name && !payer.account_number) return null;
+  // ゆうちょ記号番号だけ入っているケース（銀行/支店名なし）も口座情報ありとして扱う（#170）
+  if (
+    !payer.bank_name &&
+    !payer.branch_name &&
+    !payer.account_number &&
+    !payer.yucho_symbol &&
+    !payer.yucho_number
+  ) {
+    return null;
+  }
   return {
     bankName: payer.bank_name,
     branchName: payer.branch_name,
     accountType: payer.account_type,
     accountNumber: payer.account_number,
     accountHolder: payer.account_holder,
+    yuchoSymbol: payer.yucho_symbol,
+    yuchoNumber: payer.yucho_number,
   };
 };
 

--- a/tests/yucho/yuchoAccount.test.ts
+++ b/tests/yucho/yuchoAccount.test.ts
@@ -1,0 +1,58 @@
+import {
+  isValidYuchoSymbol,
+  branchCodeFromSymbol,
+  depositTypeFromSymbol,
+  accountNumberFromYuchoNumber,
+  formatSymbolNumber,
+} from '../../src/yucho/yuchoAccount';
+
+describe('yuchoAccount 記号番号変換 (#170)', () => {
+  describe('branchCodeFromSymbol (方式A: 記号=1+店番3桁+種目1桁)', () => {
+    it('記号の中央3桁を店番として返す', () => {
+      expect(branchCodeFromSymbol('11280')).toBe('128');
+      expect(branchCodeFromSymbol('10080')).toBe('008');
+    });
+    it('5桁でない/先頭1でない記号は null（呼び出し側で支店名推定にフォールバック）', () => {
+      expect(branchCodeFromSymbol('1128')).toBeNull();
+      expect(branchCodeFromSymbol('21280')).toBeNull();
+      expect(branchCodeFromSymbol(null)).toBeNull();
+      expect(branchCodeFromSymbol('')).toBeNull();
+    });
+  });
+
+  describe('isValidYuchoSymbol', () => {
+    it('5桁・先頭1のみ妥当', () => {
+      expect(isValidYuchoSymbol('11280')).toBe(true);
+      expect(isValidYuchoSymbol('21280')).toBe(false);
+      expect(isValidYuchoSymbol('1128')).toBe(false);
+      expect(isValidYuchoSymbol(null)).toBe(false);
+    });
+  });
+
+  describe('depositTypeFromSymbol', () => {
+    it('記号末尾1桁を返す', () => {
+      expect(depositTypeFromSymbol('11280')).toBe('0');
+      expect(depositTypeFromSymbol('11281')).toBe('1');
+    });
+    it('妥当でない記号は null', () => {
+      expect(depositTypeFromSymbol('abc')).toBeNull();
+    });
+  });
+
+  describe('accountNumberFromYuchoNumber', () => {
+    it('数字のみ抽出。空は null', () => {
+      expect(accountNumberFromYuchoNumber('1234567')).toBe('1234567');
+      expect(accountNumberFromYuchoNumber('12-345')).toBe('12345');
+      expect(accountNumberFromYuchoNumber('')).toBeNull();
+      expect(accountNumberFromYuchoNumber(null)).toBeNull();
+    });
+  });
+
+  describe('formatSymbolNumber', () => {
+    it('記号-番号 形式。どちらか欠ければ null', () => {
+      expect(formatSymbolNumber('11280', '1234567')).toBe('11280-1234567');
+      expect(formatSymbolNumber('11280', null)).toBeNull();
+      expect(formatSymbolNumber(null, '1234567')).toBeNull();
+    });
+  });
+});

--- a/tests/yucho/yuchoCsv.test.ts
+++ b/tests/yucho/yuchoCsv.test.ts
@@ -26,6 +26,8 @@ const baseItem = (overrides: Partial<YuchoBillingItem> = {}): YuchoBillingItem =
     accountType: 'ordinary',
     accountNumber: '1234567',
     accountHolder: 'ヤマダタロウ',
+    yuchoSymbol: null,
+    yuchoNumber: null,
   },
   ...overrides,
 });
@@ -115,6 +117,22 @@ describe('buildDataRow', () => {
   it('emits 3-digit branch code derived from branch name', () => {
     const cells = buildDataRow(baseItem()).split(',');
     expect(cells[4]).toBe('018'); // 〇一八 → 018
+  });
+
+  it('ゆうちょ記号があれば店番は記号の中央3桁を優先する (#170)', () => {
+    const item = baseItem({
+      billingInfo: { ...baseItem().billingInfo!, branchName: '〇一八', yuchoSymbol: '11280' },
+    });
+    const cells = buildDataRow(item).split(',');
+    expect(cells[4]).toBe('128'); // 記号 11280 → 店番 128（支店名推定 018 を上書き）
+  });
+
+  it('ゆうちょ番号があれば口座番号に番号を優先する (#170)', () => {
+    const item = baseItem({
+      billingInfo: { ...baseItem().billingInfo!, accountNumber: '1234567', yuchoNumber: '89' },
+    });
+    const cells = buildDataRow(item).split(',');
+    expect(cells[8]).toBe('0000089'); // 番号 89 → 0000089（口座番号 1234567 を上書き）
   });
 
   it('uses fixed deposit type code 1 (ordinary) by default', () => {


### PR DESCRIPTION
## 概要
ゆうちょ自動払込CSVの店番は支店名から漢数字/数字を**推定**しており、不明時 `000` になっていた。ゆうちょの**記号番号方式**で正しく保持できるよう、データモデルを整備する。

> 委託者コード・収納口座・引落日の**実値**はゆうちょBizダイレクト契約確定後に投入（ユーザー方針: 「データモデルを先に整備」）。

## 変更
- **schema/migration**: `Customer` に `yucho_symbol`(記号5桁)/`yucho_number`(番号) を追加（nullable・非破壊）
- **`src/yucho/yuchoAccount.ts`（新規）**: 記号⇔店番/預金種目・番号⇔口座番号の変換を**1箇所に集約**（方式A: 記号 = `1` + 店番3桁 + 預金種目1桁）。表示とCSVで同一ロジックを使えるようにする
- **`yuchoCsv.buildDataRow`**: 記号があれば店番を記号の中央3桁、番号があれば口座番号に番号を優先（無ければ従来の支店名推定/口座番号にフォールバック）。`hasUsableAccountNumber` も番号を口座番号源として判定
- **`yuchoService`/`yuchoValidation`**: `billingInfo` に `yuchoSymbol`/`yuchoNumber` を載せる
- **書き込み/読み出し経路**（`createPlot`/`updatePlot`/`changeContractor`/`getPlotById`）に記号/番号を追加。`@komine/types` 未追加のため backend ローカル `customerSchema` を `.extend()` し補助型 `CustomerYuchoInput` でマップ（フロントUI実装時に shared へ昇格予定）

## テスト
- `yuchoAccount` 変換 util 単体（記号→店番中央3桁 / 5桁先頭1検証 / 番号→口座番号 / 表示整形）
- `buildDataRow`: 記号があれば店番、番号があれば口座番号を優先すること
- 全 1242 テスト green / tsc・lint clean

## スコープ外・残
- 委託者コード・委託者名・収納口座・引落日（#170 項目1-3）は現行 CSV では既に query param が廃止済みのため本PR対象外。実値はゆうちょ契約確定後
- 記号番号の**入力フォーム**（フロント）は別途。`@komine/types` への昇格もその際に

Refs #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)