### PR TITLE
docs(setup): メール送信設定（独自SMTP・URL設定）を SETUP.md に追記 (#351)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -158,6 +158,36 @@ npx prisma migrate deploy
    - Project URL → `SUPABASE_URL`
    - service_role key → `SUPABASE_SERVICE_ROLE_KEY`
 
+### メール送信設定（招待・パスワードリセット）※本番前必須（#351 / #350）
+
+スタッフ招待・パスワードリセットのメールが**確実に届くようにする**ための設定。抜けると「リンクが localhost に飛ぶ」「メールが届かない」事故になる。
+
+#### 1. 遷移先URL（`FRONTEND_URL`）
+
+招待/リセットメールのリンク先ベースURL。**末尾スラッシュ不可**（コード側で `${FRONTEND_URL}/set-password` `${FRONTEND_URL}/reset-password` と連結するため、`//set-password` になると Supabase の Redirect URL 許可リストにマッチせず Site URL にフォールバックする）。
+
+- backend env に設定（`render.yaml` / `.env.example` 記載済み・#349）。例: `FRONTEND_URL=https://komine-cemetery-crm.vercel.app`
+- 未設定だとリセットは `localhost`、招待は Supabase Site URL にフォールバックする。
+
+#### 2. Supabase Dashboard の URL 設定
+
+**Authentication** → **URL Configuration**:
+
+- **Site URL**: 本番フロントのオリジン（例 `https://komine-cemetery-crm.vercel.app`）
+- **Redirect URLs** に許可登録（`FRONTEND_URL` と一致させること）:
+  - `https://<本番フロント>/set-password`
+  - `https://<本番フロント>/reset-password`
+
+#### 3. 独自SMTP（本番必須・組み込みメールのレート制限対策 #351）
+
+Supabase の**組み込みメールはテスト用途で送信レート制限が非常に厳しい**（招待・リセット・確認メールが共通枠を消費し、同日に複数送ると「メール送信の制限に達しました」で失敗する）。本番では独自SMTPを設定する。
+
+- **Authentication** → **SMTP Settings** で SendGrid / Resend / Amazon SES 等を設定
+- 送信元ドメインの **SPF / DKIM** を設定（到達率・スパム回避）
+- 送信レート上限を引き上げる
+
+> レート制限に当たった場合、`forgot-password` は 429 + 専用メッセージを返す（#350）。それ以外のエラーは列挙対策で一律「送信しました」を維持。
+
 ### 初期 admin の作成
 
 顧客環境への初回デプロイ時は [顧客環境への初回デプロイ手順](#顧客環境への初回デプロイ手順) の bootstrap スクリプトを使用してください。


### PR DESCRIPTION
## 概要
招待・パスワードリセットメールが**本番で確実に届く**ための設定が複数箇所に散っており、抜けると「リンクが localhost に飛ぶ」「メールが届かない」事故になっていた。backend の `SETUP.md`「Supabase認証」セクションに集約する。

## 追記内容
1. **`FRONTEND_URL`**（遷移先ベースURL・**末尾スラッシュ不可**）— `//set-password` で許可リスト不一致になる罠を明記（#349 で render.yaml/.env.example に追加済み）
2. **Supabase Dashboard の URL 設定** — Site URL / Redirect URLs（`/set-password`・`/reset-password`）を `FRONTEND_URL` と一致させる
3. **独自SMTP**（SendGrid/Resend/SES）— 組み込みメールのレート制限対策（本番必須）＋ SPF/DKIM
4. レート制限時の 429 専用メッセージ（#350）との関係

## 残（別repo・手動）
- Supabase Dashboard 側の実際の SMTP 設定（手動）
- `リリース手順書.md` / `招待フロー動作確認チェックリスト.md`（komine-local）への反映
- システムテスト AUTH-06/07 の再実施

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)