### PR TITLE
fix(masters): payment_method_master.code を VarChar(20) に拡張し seed:masters 失敗を解消 (#331)

### DIFF
--- a/prisma/migrations/20260609100000_widen_payment_method_master_code/migration.sql
+++ b/prisma/migrations/20260609100000_widen_payment_method_master_code/migration.sql
@@ -1,0 +1,9 @@
+-- payment_method_master.code を VarChar(10) → VarChar(20) に拡張する（#331）
+--
+-- 背景:
+--   seedMasters の正準コード ACCOUNT_TRANSFER(16字) / BANK_TRANSFER(13字) が VarChar(10) に収まらず、
+--   `npm run seed:masters` が payment_method の createMany で "value too long" で失敗していた。
+--   これにより後続の calc/tax/billing マスタ投入にも到達できず、料金区分の「旧コード」表示(#331)が
+--   解消できなかった。code 列を 20 に拡張して seed を完走できるようにする。
+--   （contractor_master / section_name_master は既に VarChar(20)）
+ALTER TABLE "payment_method_master" ALTER COLUMN "code" TYPE VARCHAR(20);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -634,7 +634,8 @@ model CemeteryTypeMaster {
 // 支払方法マスタ
 model PaymentMethodMaster {
   id          Int      @id @default(autoincrement()) // ID
-  code        String   @unique @db.VarChar(10) // 支払方法コード
+  // seedMasters の正準コード ACCOUNT_TRANSFER(16)/BANK_TRANSFER(13) を収めるため 20。VarChar(10) では seed が失敗していた（#331）
+  code        String   @unique @db.VarChar(20) // 支払方法コード
   name        String   @db.VarChar(50) // 支払方法名称
   description String?  @db.VarChar(200) // 説明
   sort_order  Int? // 表示順序


### PR DESCRIPTION
## 概要
本番反映作業中に発見した潜在バグの修正。本番で `npm run seed:masters` を実行すると、`seedMasters` の正準コード **`ACCOUNT_TRANSFER`(16字)/`BANK_TRANSFER`(13字)** が `payment_method_master.code` の **VarChar(10)** に収まらず `value too long` で失敗していた。

payment_method の `createMany` で中断するため、**後続の calc/tax/billing マスタ投入にも到達できず**、#331 の料金「旧コード」表示が解消できなかった（本番マスタには手動投入の `01`〜`04` しか無く、正準コードが入っていない状態）。

## 変更
- `payment_method_master.code` を `VarChar(10)` → `VarChar(20)` に拡張（`contractor_master` / `section_name_master` は既に20）
- migration `20260609100000_widen_payment_method_master_code`

## これで解消される流れ（#331 本番反映）
1. （本PRマージ・デプロイで migrate deploy 適用後）
2. `npm run seed:masters` が完走 → 正準コード（AREA/FIXED/INCLUSIVE/EXCLUSIVE/NONE/PRESENT/PERPETUAL）が本番マスタに入る
3. `npm run backfill:fee-master-codes -- --apply`（#363）でデータを正準codeへ remap
4. `resolveMasterName` が解決し「旧コード」表示が消える

## テスト
- 全 1281 テスト green / tsc clean（列幅変更のみ・ロジック影響なし）

Refs #331
関連: #355（本番反映トラッカー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)