### PR TITLE
fix(auth): パスワードリセットのレート制限判定をstatus 429ベースに修正 (Closes #371)

### DIFF
--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -744,13 +744,24 @@ export const forgotPassword = async (req: Request, res: Response) => {
 
     if (error) {
       // エラーが発生してもセキュリティ上同一レスポンスを返す
-      log.warn({ email, error: error.message }, 'Auth: password reset email failed');
+      log.warn(
+        { email, status: error.status, error: error.message },
+        'Auth: password reset email failed'
+      );
 
       // レート制限だけは専用メッセージを返す（#350）。
       // レート制限は「送信元の送信枠」の話でメアドの存在に依存しないため、
       // 専用メッセージを返しても登録済みかどうかの列挙情報は漏れない＝安全。
       // それ以外のエラー（user無し含む）は従来どおり一律成功で返し列挙対策を維持する。
-      if (error.message.includes('rate limit')) {
+      //
+      // 判定は HTTP 429 を主軸にする。Supabase のレート制限文言は版・状況で変わり
+      // （実例: "For security purposes, you can only request this after N seconds."）、
+      // 旧来の message.includes('rate limit') ではこの文言を取りこぼして「送信成功」を
+      // 偽装していた（実際は1通も送られない）。status と文言の両方で判定する。
+      const isRateLimited =
+        error.status === 429 ||
+        /rate limit|you can only request this|too many requests/i.test(error.message);
+      if (isRateLimited) {
         return res.status(429).json({
           success: false,
           error: {

--- a/tests/auth/authController.test.ts
+++ b/tests/auth/authController.test.ts
@@ -947,6 +947,47 @@ describe('Auth Controller', () => {
         expect(mockResponse.status).toHaveBeenCalledWith(200);
         expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
       });
+
+      it('"For security purposes..." クールダウン文言（rate limit を含まない）でも429を返すこと', async () => {
+        // 本番ログで確認された実文言。旧 message.includes('rate limit') では取りこぼし、
+        // 失敗にもかかわらず success:true を返していた（成功偽装バグ）。
+        mockRequest.body = { email: 'active@example.com' };
+        mockPrisma.staff.findFirst.mockResolvedValue(null);
+        mockSupabaseAuth.resetPasswordForEmail.mockResolvedValue({
+          error: {
+            message: 'For security purposes, you can only request this after 4 seconds.',
+            status: 429,
+          },
+        });
+
+        await forgotPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(429);
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: expect.objectContaining({ code: 'RATE_LIMIT_EXCEEDED' }),
+          })
+        );
+      });
+
+      it('status 429 なら文言に依らず429を返すこと', async () => {
+        mockRequest.body = { email: 'active@example.com' };
+        mockPrisma.staff.findFirst.mockResolvedValue(null);
+        mockSupabaseAuth.resetPasswordForEmail.mockResolvedValue({
+          error: { message: 'over_email_send_rate_limit', status: 429 },
+        });
+
+        await forgotPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(429);
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: expect.objectContaining({ code: 'RATE_LIMIT_EXCEEDED' }),
+          })
+        );
+      });
     });
 
     describe('COOKIE_SECURE によるCookie属性制御（#299）', () => {


### PR DESCRIPTION
## 背景
システムテスト **AUTH-06** で「リセットメールが届かないのに『送信しました』と表示される」事象を確認。本番ログで真因が確定した。

```
"error":"For security purposes, you can only request this after 4 seconds.",
"msg":"Auth: password reset email failed"
status: 200 / success: true   ← 失敗なのに成功偽装
```

Supabase はレート制限で送信を拒否していたが、`forgotPassword` の判定 `error.message.includes('rate limit')` がこの文言（`rate limit` を含まない）を取りこぼし、成功レスポンスに落ちていた。

## 変更
- レート制限判定を **`error.status === 429` 主軸**に変更（文言依存を脱却）。後方互換として `rate limit` / `you can only request this` / `too many requests` の文言マッチも併用。
- 429 時は従来どおり `RATE_LIMIT_EXCEEDED`（429・専用メッセージ）を返す。送信枠の話でメアド存在に依存しないため列挙対策上も安全。
- 診断用に `log.warn` へ `status` を追記。
- それ以外のエラーは従来どおり一律成功（列挙対策）を維持。

## テスト
- 既存 forgotPassword テスト全green（41件）。
- 追加:
  - "For security purposes, you can only request this after 4 seconds."（status 429）→ 429 を返す
  - `over_email_send_rate_limit`（status 429）→ 429 を返す

`tsc --noEmit` / `eslint` / `jest tests/auth/authController.test.ts` ローカル green。

## 注意（運用要因は別issue）
本PRは「失敗を成功偽装するバグ」を解消する。**メールが実際に届かない根本（組み込みメールの共通レート制限）は #351（独自SMTP）で別途対応**。本修正適用後は、枯渇時に正しく「送信制限に達しました」が表示されるようになる。

Closes #371
Refs #351, #350, #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)