### PR TITLE
fix(auth): reset-password で implicit フローの access_token を受理 (Closes #373)

### DIFF
--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -814,37 +814,82 @@ export const resetPassword = async (req: Request, res: Response) => {
       });
     }
 
-    const { code, newPassword } = req.body as { code: string; newPassword: string };
+    const { code, accessToken, newPassword } = req.body as {
+      code?: string;
+      accessToken?: string;
+      newPassword: string;
+    };
 
-    log.info('Auth: password reset attempt via code');
+    // 招待/リセットメールのリンクは Supabase の implicit フロー（セッションを
+    // URLハッシュ `#access_token=...` に載せて返す）で着地するため、フロントは
+    // ハッシュから access_token を取り出してここへ渡す。これがユーザー特定の主経路。
+    // PKCE の code（`?code=`）経路も後方互換として残す（デプロイ順で壊れないように）。
+    let userId: string;
 
-    // Supabaseのコードをセッションに交換してユーザーを特定
-    const { data: sessionData, error: exchangeError } =
-      await supabase.auth.exchangeCodeForSession(code);
+    if (accessToken) {
+      log.info('Auth: password reset attempt via access_token');
+      // access_token（リカバリ/招待で発行された短命JWT）を検証してユーザーを特定
+      const { data: userData, error: getUserError } = await supabase.auth.getUser(accessToken);
 
-    if (exchangeError || !sessionData?.user) {
-      log.warn(
-        { reason: 'invalid_code', error: exchangeError?.message || 'no user returned' },
-        'Auth: password reset failed'
-      );
+      if (getUserError || !userData?.user) {
+        log.warn(
+          { reason: 'invalid_access_token', error: getUserError?.message || 'no user returned' },
+          'Auth: password reset failed'
+        );
+        return res.status(400).json({
+          success: false,
+          error: {
+            code: 'INVALID_TOKEN',
+            message: 'リンクが無効または期限切れです。再度パスワードリセットをお試しください。',
+            details: [],
+          },
+        });
+      }
+
+      userId = userData.user.id;
+    } else if (code) {
+      log.info('Auth: password reset attempt via code');
+      // Supabaseのコードをセッションに交換してユーザーを特定（PKCEフロー）
+      const { data: sessionData, error: exchangeError } =
+        await supabase.auth.exchangeCodeForSession(code);
+
+      if (exchangeError || !sessionData?.user) {
+        log.warn(
+          { reason: 'invalid_code', error: exchangeError?.message || 'no user returned' },
+          'Auth: password reset failed'
+        );
+        return res.status(400).json({
+          success: false,
+          error: {
+            code: 'INVALID_TOKEN',
+            message: '認証コードが無効または期限切れです。再度パスワードリセットをお試しください。',
+            details: [],
+          },
+        });
+      }
+
+      userId = sessionData.user.id;
+    } else {
+      // バリデーションで担保済みだが防御的に（accessToken/code いずれも無い）
+      log.warn({ reason: 'missing_token' }, 'Auth: password reset failed');
       return res.status(400).json({
         success: false,
         error: {
           code: 'INVALID_TOKEN',
-          message: '認証コードが無効または期限切れです。再度パスワードリセットをお試しください。',
+          message: 'リンクが無効です。再度パスワードリセットをお試しください。',
           details: [],
         },
       });
     }
 
     // Admin APIでパスワードを更新
-    const { error: updateError } = await supabase.auth.admin.updateUserById(sessionData.user.id, {
+    const { error: updateError } = await supabase.auth.admin.updateUserById(userId, {
       password: newPassword,
     });
 
     if (updateError) {
       log.error(
-        { userId: sessionData.user.id, reason: 'update_error', error: updateError.message },
+        { userId, reason: 'update_error', error: updateError.message },
         'Auth: password reset failed'
       );
       return res.status(500).json({
@@ -857,7 +902,7 @@ export const resetPassword = async (req: Request, res: Response) => {
       });
     }
 
-    log.info({ userId: sessionData.user.id }, 'Auth: password reset success');
+    log.info({ userId }, 'Auth: password reset success');
     return res.status(200).json({
       success: true,
       data: {

--- a/src/validations/authValidation.ts
+++ b/src/validations/authValidation.ts
@@ -45,13 +45,20 @@ export const forgotPasswordSchema = z.object({
  */
 export const resetPasswordSchema = z
   .object({
-    code: z.string().min(1, '認証コードは必須です'),
+    // implicit フロー: メールリンクのハッシュから取り出した access_token（主経路）
+    accessToken: z.string().min(1).optional(),
+    // PKCE フロー: `?code=` クエリ（後方互換）
+    code: z.string().min(1).optional(),
     newPassword: passwordSchema,
     confirmPassword: z.string().min(1, 'パスワード確認は必須です'),
   })
   .refine((data) => data.newPassword === data.confirmPassword, {
     message: 'パスワードが一致しません',
     path: ['confirmPassword'],
+  })
+  .refine((data) => Boolean(data.accessToken) || Boolean(data.code), {
+    message: '認証情報（accessToken または code）が必要です',
+    path: ['accessToken'],
   });
 
 /**

--- a/tests/auth/authController.test.ts
+++ b/tests/auth/authController.test.ts
@@ -21,6 +21,7 @@ const mockSupabaseAuth = {
   signInWithPassword: jest.fn(),
   getUser: jest.fn(),
   resetPasswordForEmail: jest.fn(),
+  exchangeCodeForSession: jest.fn(),
   admin: {
     signOut: jest.fn(),
     updateUserById: jest.fn(),
@@ -987,6 +988,135 @@ describe('Auth Controller', () => {
             error: expect.objectContaining({ code: 'RATE_LIMIT_EXCEEDED' }),
           })
         );
+      });
+    });
+
+    describe('resetPassword（新パスワード設定）', () => {
+      let resetPassword: any;
+
+      beforeEach(async () => {
+        const authController = await import('../../src/auth/authController');
+        resetPassword = authController.resetPassword;
+      });
+
+      it('accessToken（implicitフロー）でユーザーを特定しパスワードを更新すること', async () => {
+        // メールリンクのハッシュ #access_token=... から取り出したトークンで本人特定
+        mockRequest.body = {
+          accessToken: 'valid-access-token',
+          newPassword: 'NewPass123',
+          confirmPassword: 'NewPass123',
+        };
+        mockSupabaseAuth.getUser.mockResolvedValue({
+          data: { user: { id: 'user-uid-1' } },
+          error: null,
+        });
+        mockSupabaseAuth.admin.updateUserById.mockResolvedValue({ data: {}, error: null });
+
+        await resetPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockSupabaseAuth.getUser).toHaveBeenCalledWith('valid-access-token');
+        expect(mockSupabaseAuth.admin.updateUserById).toHaveBeenCalledWith('user-uid-1', {
+          password: 'NewPass123',
+        });
+        expect(mockResponse.status).toHaveBeenCalledWith(200);
+        expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+      });
+
+      it('accessToken が無効/期限切れなら 400 INVALID_TOKEN を返し更新しないこと', async () => {
+        mockRequest.body = {
+          accessToken: 'expired-token',
+          newPassword: 'NewPass123',
+          confirmPassword: 'NewPass123',
+        };
+        mockSupabaseAuth.getUser.mockResolvedValue({
+          data: { user: null },
+          error: { message: 'invalid JWT' },
+        });
+
+        await resetPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockSupabaseAuth.admin.updateUserById).not.toHaveBeenCalled();
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: expect.objectContaining({ code: 'INVALID_TOKEN' }),
+          })
+        );
+      });
+
+      it('code（PKCEフロー後方互換）でもユーザーを特定して更新できること', async () => {
+        mockRequest.body = {
+          code: 'pkce-code',
+          newPassword: 'NewPass123',
+          confirmPassword: 'NewPass123',
+        };
+        mockSupabaseAuth.exchangeCodeForSession.mockResolvedValue({
+          data: { user: { id: 'user-uid-2' } },
+          error: null,
+        });
+        mockSupabaseAuth.admin.updateUserById.mockResolvedValue({ data: {}, error: null });
+
+        await resetPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockSupabaseAuth.exchangeCodeForSession).toHaveBeenCalledWith('pkce-code');
+        expect(mockSupabaseAuth.admin.updateUserById).toHaveBeenCalledWith('user-uid-2', {
+          password: 'NewPass123',
+        });
+        expect(mockResponse.status).toHaveBeenCalledWith(200);
+      });
+
+      it('accessToken と code 両方あれば accessToken を優先し code 交換を呼ばないこと', async () => {
+        mockRequest.body = {
+          accessToken: 'tok',
+          code: 'should-be-ignored',
+          newPassword: 'NewPass123',
+          confirmPassword: 'NewPass123',
+        };
+        mockSupabaseAuth.getUser.mockResolvedValue({
+          data: { user: { id: 'user-uid-3' } },
+          error: null,
+        });
+        mockSupabaseAuth.admin.updateUserById.mockResolvedValue({ data: {}, error: null });
+
+        await resetPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockSupabaseAuth.getUser).toHaveBeenCalledWith('tok');
+        expect(mockSupabaseAuth.exchangeCodeForSession).not.toHaveBeenCalled();
+      });
+
+      it('accessToken も code も無ければ 400 を返すこと（防御）', async () => {
+        mockRequest.body = {
+          newPassword: 'NewPass123',
+          confirmPassword: 'NewPass123',
+        };
+
+        await resetPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockSupabaseAuth.getUser).not.toHaveBeenCalled();
+        expect(mockSupabaseAuth.exchangeCodeForSession).not.toHaveBeenCalled();
+        expect(mockSupabaseAuth.admin.updateUserById).not.toHaveBeenCalled();
+        expect(mockResponse.status).toHaveBeenCalledWith(400);
+      });
+
+      it('Admin パスワード更新が失敗したら 500 を返すこと', async () => {
+        mockRequest.body = {
+          accessToken: 'tok',
+          newPassword: 'NewPass123',
+          confirmPassword: 'NewPass123',
+        };
+        mockSupabaseAuth.getUser.mockResolvedValue({
+          data: { user: { id: 'user-uid-4' } },
+          error: null,
+        });
+        mockSupabaseAuth.admin.updateUserById.mockResolvedValue({
+          data: {},
+          error: { message: 'update failed' },
+        });
+
+        await resetPassword(mockRequest as Request, mockResponse as Response);
+
+        expect(mockResponse.status).toHaveBeenCalledWith(500);
       });
     });
 

--- a/tests/validations/authValidation.test.ts
+++ b/tests/validations/authValidation.test.ts
@@ -1,4 +1,8 @@
-import { loginSchema, changePasswordSchema } from '../../src/validations/authValidation';
+import {
+  loginSchema,
+  changePasswordSchema,
+  resetPasswordSchema,
+} from '../../src/validations/authValidation';
 
 describe('Auth Validation', () => {
   describe('loginSchema', () => {
@@ -155,6 +159,47 @@ describe('Auth Validation', () => {
       };
 
       expect(() => changePasswordSchema.parse(invalidData)).toThrow();
+    });
+  });
+
+  describe('resetPasswordSchema', () => {
+    it('accessToken（implicitフロー）で成功すること', () => {
+      const validData = {
+        accessToken: 'some-access-token',
+        newPassword: 'NewPassword1',
+        confirmPassword: 'NewPassword1',
+      };
+
+      expect(() => resetPasswordSchema.parse(validData)).not.toThrow();
+    });
+
+    it('code（PKCEフロー後方互換）で成功すること', () => {
+      const validData = {
+        code: 'some-code',
+        newPassword: 'NewPassword1',
+        confirmPassword: 'NewPassword1',
+      };
+
+      expect(() => resetPasswordSchema.parse(validData)).not.toThrow();
+    });
+
+    it('accessToken も code も無ければエラーになること', () => {
+      const invalidData = {
+        newPassword: 'NewPassword1',
+        confirmPassword: 'NewPassword1',
+      };
+
+      expect(() => resetPasswordSchema.parse(invalidData)).toThrow();
+    });
+
+    it('パスワードと確認が一致しない場合エラーになること', () => {
+      const invalidData = {
+        accessToken: 'some-access-token',
+        newPassword: 'NewPassword1',
+        confirmPassword: 'DifferentPassword1',
+      };
+
+      expect(() => resetPasswordSchema.parse(invalidData)).toThrow();
     });
   });
 });


### PR DESCRIPTION
## 背景
システムテスト AUTH-06/07 で、リセット/招待メールのリンクが必ず「無効」になる事象。実機URLで原因確定：

```
https://<frontend>/reset-password#access_token=eyJ...&type=recovery
```

Supabase は **implicit フロー**でセッションを **URLハッシュ**で返すが、backend `resetPassword` は `exchangeCodeForSession(code)`（PKCE専用）のみ対応。フロントにSupabaseクライアントが無い構成では code_verifier が無く成立しない。access_token 自体は正規・有効なJWT。

## 変更
- `resetPassword`: `accessToken` を受けたら `supabase.auth.getUser(accessToken)` で本人特定 → 既存の `admin.updateUserById(userId, {password})` で更新。
- `code`（PKCE）経路は**後方互換として温存**（フロントと同時デプロイでなくても壊れない）。
- `resetPasswordSchema`: `accessToken` / `code` いずれか必須に変更。

## テスト
- `resetPassword` コントローラの単体テストを新設（**従来 exchangeCodeForSession 経路は未カバーだった**）: accessToken成功 / 無効token=400 / code後方互換 / accessToken優先 / token無し=400 / admin更新失敗=500。
- `resetPasswordSchema` のスキーマテスト追加。
- `tsc --noEmit` 0 / `eslint` clean / auth+validation **65件 green**。

## 対になる変更（要同時または後続デプロイ）
frontend 側で **URLハッシュから access_token を取り出して送る**実装が必要（別issue/PR）。本PRは後方互換を保つので**先行マージしても既存挙動を壊さない**。

Closes #373
Refs #371, #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)