### PR TITLE
fix(migration): 続柄の未解決センチネルを空文字化し本番'unknown'を補正 (#375)

### DIFF
--- a/scripts/backfill-legacy-value-cleanup.ts
+++ b/scripts/backfill-legacy-value-cleanup.ts
@@ -4,7 +4,8 @@
  *
  * 移行済みデータに残る「未設定センチネル/生レガシーint」を正規化する:
  *  1. gravestone_infos.direction_id / position_id = 0 → null（方位/位置の「旧コード:0」）
- *  2. family_contacts.relationship の生int → 続柄マスタ名（'0'/未解決は 'unknown'）
+ *  2. family_contacts.relationship の生int → 続柄マスタ名（'0'/未解決は空文字）。
+ *     さらに #355 backfill が本番に残した旧センチネル 'unknown' を空文字へ補正（#375）。
  *  3. buried_persons.religion = 'legacy-shuuha-*' → null（宗派マスタ不要確定）
  *  4. construction_infos.contractor = 'legacy-gyousha-0'（=未設定）→ null + 業者マスタ無効化（#334）
  *
@@ -20,8 +21,10 @@ import 'dotenv/config';
 
 import { prisma } from '../src/db/prisma';
 import {
+  LEGACY_UNKNOWN_RELATIONSHIP,
   loadRelationshipNameMap,
   resolveRelationship,
+  UNRESOLVED_RELATIONSHIP,
 } from './legacy-migration/lib/relationship-resolver';
 
 const APPLY = process.argv.includes('--apply');
@@ -46,21 +49,28 @@ async function backfillDirectionPosition(): Promise<Record<string, number>> {
 async function backfillRelationship(): Promise<Record<string, unknown>> {
   const nameMap = await loadRelationshipNameMap(prisma);
 
-  // 生int（数字のみ）の relationship を持つ family_contacts を値ごとに集計
+  // 補正対象の relationship を値ごとに集計:
+  //  - 生int（数字のみ）: マスタ名へ解決（'0'/未解決は空文字）
+  //  - 旧センチネル 'unknown': #355 backfill が本番に残した値を空文字へ補正（#375）
   const groups = await prisma.familyContact.groupBy({
     by: ['relationship'],
     _count: { _all: true },
   });
-  const numericGroups = groups.filter((g) => /^\d+$/.test(g.relationship));
+  const targetGroups = groups.filter(
+    (g) => /^\d+$/.test(g.relationship) || g.relationship === LEGACY_UNKNOWN_RELATIONSHIP
+  );
 
-  const plan = numericGroups.map((g) => ({
+  const plan = targetGroups.map((g) => ({
     from: g.relationship,
-    to: resolveRelationship(g.relationship, nameMap),
+    to:
+      g.relationship === LEGACY_UNKNOWN_RELATIONSHIP
+        ? UNRESOLVED_RELATIONSHIP
+        : resolveRelationship(g.relationship, nameMap),
     count: g._count._all,
   }));
 
   if (!APPLY) {
-    return { numeric_relationship_groups: plan };
+    return { relationship_groups: plan };
   }
 
   let updated = 0;

--- a/scripts/legacy-migration/lib/relationship-resolver.ts
+++ b/scripts/legacy-migration/lib/relationship-resolver.ts
@@ -12,6 +12,23 @@ import type { PrismaClient } from '@prisma/client';
 
 const RELATIONSHIP_KBNNO = '2009';
 
+/**
+ * 未解決の続柄を表すセンチネル（#375）。
+ *
+ * FamilyContact.relationship は NOT NULL VarChar のため未設定を空文字で表す。
+ * フロントの空値規約（#181 `isEmptyDisplayValue('')`）でそのまま「未登録」表示になり、
+ * 日本語UIに英単語が露出しない。以前は英語 `'unknown'` を使っていたが、それが
+ * #355 backfill で本番に live していたため本値へ統一する。
+ */
+export const UNRESOLVED_RELATIONSHIP = '';
+
+/**
+ * #355 backfill が本番に生成してしまった旧センチネル（英語 `'unknown'`、#375）。
+ * 本番の既存 `relationship = 'unknown'` を {@link UNRESOLVED_RELATIONSHIP} に補正する
+ * ために参照する。
+ */
+export const LEGACY_UNKNOWN_RELATIONSHIP = 'unknown';
+
 /** 続柄マスタを読み込み NMCODE(文字列) → 名称 の対応表を返す。 */
 export async function loadRelationshipNameMap(
   prisma: Pick<PrismaClient, 'relationshipMaster'>
@@ -31,18 +48,18 @@ export async function loadRelationshipNameMap(
 /**
  * 生 zokugara 値を保存用の続柄文字列に解決する。
  *  - 数字（マスタにあり） → マスタ名称
- *  - 数字（'0' やマスタに無い） → 'unknown'（未設定。relationship は NOT NULL のため）
+ *  - 数字（'0' やマスタに無い） → 空文字（未設定。UIで「未登録」表示・#375）
  *  - 自由記述（数字でない） → そのまま（既に名称）
- *  - null/空 → 'unknown'
+ *  - null/空 → 空文字
  */
 export function resolveRelationship(
   raw: string | null | undefined,
   nameMap: Map<string, string>
 ): string {
   const cleaned = raw?.trim();
-  if (!cleaned) return 'unknown';
+  if (!cleaned) return UNRESOLVED_RELATIONSHIP;
   if (/^\d+$/.test(cleaned)) {
-    return nameMap.get(cleaned) ?? 'unknown';
+    return nameMap.get(cleaned) ?? UNRESOLVED_RELATIONSHIP;
   }
   return cleaned;
 }

--- a/tests/scripts/legacy-migration/relationship-resolver.test.ts
+++ b/tests/scripts/legacy-migration/relationship-resolver.test.ts
@@ -4,8 +4,10 @@
 import type { PrismaClient } from '@prisma/client';
 
 import {
+  LEGACY_UNKNOWN_RELATIONSHIP,
   loadRelationshipNameMap,
   resolveRelationship,
+  UNRESOLVED_RELATIONSHIP,
 } from '../../../scripts/legacy-migration/lib/relationship-resolver';
 
 describe('loadRelationshipNameMap', () => {
@@ -38,18 +40,25 @@ describe('resolveRelationship', () => {
     expect(resolveRelationship('1', nameMap)).toBe('本人');
   });
 
-  it("'0' やマスタ未登録の数字は 'unknown'（未設定）になる", () => {
-    expect(resolveRelationship('0', nameMap)).toBe('unknown');
-    expect(resolveRelationship('99', nameMap)).toBe('unknown');
+  it("'0' やマスタ未登録の数字は空文字（未設定）になる (#375)", () => {
+    expect(resolveRelationship('0', nameMap)).toBe('');
+    expect(resolveRelationship('99', nameMap)).toBe('');
   });
 
-  it('null/空は unknown', () => {
-    expect(resolveRelationship(null, nameMap)).toBe('unknown');
-    expect(resolveRelationship('   ', nameMap)).toBe('unknown');
+  it('null/空は空文字 (#375)', () => {
+    expect(resolveRelationship(null, nameMap)).toBe('');
+    expect(resolveRelationship('   ', nameMap)).toBe('');
   });
 
   it('数字でない自由記述はそのまま（既に名称）', () => {
     expect(resolveRelationship('配偶者', nameMap)).toBe('配偶者');
     expect(resolveRelationship('友人', nameMap)).toBe('友人');
+  });
+
+  it('未解決センチネルは空文字・旧センチネルは英語unknown (#375)', () => {
+    expect(UNRESOLVED_RELATIONSHIP).toBe('');
+    expect(LEGACY_UNKNOWN_RELATIONSHIP).toBe('unknown');
+    // 解決できない値は新センチネル（空文字）に揃う
+    expect(resolveRelationship('0', nameMap)).toBe(UNRESOLVED_RELATIONSHIP);
   });
 });

--- a/tests/scripts/legacy-migration/steps/family-relationship-mapping.test.ts
+++ b/tests/scripts/legacy-migration/steps/family-relationship-mapping.test.ts
@@ -45,7 +45,7 @@ describe('stepFamilyContact: 続柄の名称解決 (#333)', () => {
     mockedLegacyQuery.mockReset();
   });
 
-  it('生int zokugara を続柄マスタ名に解決し、0/未解決は unknown にする', async () => {
+  it('生int zokugara を続柄マスタ名に解決し、0/未解決は空文字にする (#375)', async () => {
     const created: Array<Record<string, unknown>> = [];
     const prisma = {
       customer: { findMany: jest.fn().mockResolvedValue([{ id: 'cust-1', legacy_danka_cd: 100 }]) },
@@ -72,7 +72,7 @@ describe('stepFamilyContact: 続柄の名称解決 (#333)', () => {
       .mockResolvedValueOnce([]) // 解約者 danka なし
       .mockResolvedValueOnce([
         familyRow({ family_cd: 1, zokugara: '13' }), // → 配偶者
-        familyRow({ family_cd: 2, zokugara: '0', family_mei: '次郎' }), // → unknown（未設定）
+        familyRow({ family_cd: 2, zokugara: '0', family_mei: '次郎' }), // → 空文字（未設定）
         familyRow({ family_cd: 3, zokugara: '友人', family_mei: '三郎' }), // 自由記述はそのまま
       ]);
 
@@ -85,7 +85,7 @@ describe('stepFamilyContact: 続柄の名称解決 (#333)', () => {
 
     const byCd = (cd: number) => created.find((d) => d['legacy_family_cd'] === cd);
     expect(byCd(1)?.['relationship']).toBe('配偶者');
-    expect(byCd(2)?.['relationship']).toBe('unknown');
+    expect(byCd(2)?.['relationship']).toBe('');
     expect(byCd(3)?.['relationship']).toBe('友人');
   });
 });


### PR DESCRIPTION
## 概要

区画詳細 → 連絡先タブ → 家族連絡先 → 続柄が、英語の文字列 **`unknown`** のまま表示される（日本語UIに英単語が露出）症状を修正する。

Closes #375

## 根本原因

続柄解決 `resolveRelationship()` が、マスタで解決できない値・`null`・`'0'` を **リテラル英文字列 `'unknown'`** に変換していた（`FamilyContact.relationship` が NOT NULL VarChar のためのセンチネル）。これが詳細画面・編集フォームのフォールバック選択肢にそのまま露出。

### ⚠️ 本番状態

このセンチネルは **#355 で本番適用された backfill 自身が生成**。移行済 family 2734 件のうち `zokugara` が `'0'`/null/マスタ未登録だったレコードが現在 **本番で英語 `unknown` 表示** になっている（仮説でなく live なデータ不整合）。

## 対応（案1・空文字 → 「未登録」）

- `resolveRelationship` の未解決センチネルを **`''`（空文字）** へ変更。フロントの空値規約（#181 `isEmptyDisplayValue('')`）でそのまま **「未登録」** 表示になるため、**フロント改修なし**で日本語UIに英単語が出なくなる。NOT NULL VarChar は `''` で満たす。
- 旧/新センチネルを定数化（`UNRESOLVED_RELATIONSHIP=''` / `LEGACY_UNKNOWN_RELATIONSHIP='unknown'`）して resolver と backfill で共有。
- `backfill-legacy-value-cleanup.ts` に、本番に残る `relationship = 'unknown'` を `''` へ補正するステップを追加（生int補正と同じ更新経路・冪等）。resolver 変更により再実行で `'unknown'` が再生成されないことも担保。

## 影響範囲

- **家族連絡先（`FamilyContact.relationship`）のみ**（`resolveRelationship` は step07 でしか使われない）。埋葬者は元から名称保存・nullable で対象外。
- フォームの続柄は `required` のため、`''` の連絡先を編集保存する際は入力が促される（=データ整備の契機・妥当）。

## 本番反映（マージ後に必要）

```bash
# dry-run（件数確認: SELECT count(*) ... WHERE relationship = 'unknown'）
npx ts-node scripts/backfill-legacy-value-cleanup.ts
# 反映
npx ts-node scripts/backfill-legacy-value-cleanup.ts --apply
```

## テスト

- resolver の '0'/null/未登録 → `''` 期待値更新、センチネル定数テスト、step07 マッピングテストの期待値更新。
- `npx tsc --noEmit` clean / 関連 7 件 green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)