### PR TITLE
fix(plots): 埋葬者4項目のnull上書き破壊(#383)と作成経路の破棄(#384)を修正

### DIFF
--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -1280,6 +1280,21 @@ export async function updatePlotCore(
     }
 
     for (const bp of input.buriedPersons) {
+      // 編集フォームがラウンドトリップしない4項目（死亡場所/死因/喪主名/喪主続柄）は、
+      // 入力に存在する場合のみ書き込む。常に bp.xxx || null とすると、フォーム非対応の
+      // これらが毎保存で undefined→null に潰れ、移行投入済み（step08-buried-person.ts）の
+      // 値を破壊する（#383, critical）。undefined=変更なし / 値あり=更新 で部分更新化する。
+      const formUnmanagedFields = {
+        ...(bp.deathPlace !== undefined && { death_place: bp.deathPlace || null }),
+        ...(bp.causeOfDeath !== undefined && { cause_of_death: bp.causeOfDeath || null }),
+        ...(bp.chiefMournerName !== undefined && {
+          chief_mourner_name: bp.chiefMournerName || null,
+        }),
+        ...(bp.chiefMournerRelationship !== undefined && {
+          chief_mourner_relationship: bp.chiefMournerRelationship || null,
+        }),
+      };
+
       const bpData = {
         name: bp.name,
         name_kana: bp.nameKana || null,
@@ -1292,10 +1307,7 @@ export async function updatePlotCore(
         posthumous_name: bp.posthumousName || null,
         report_date: bp.reportDate ? new Date(bp.reportDate) : null,
         religion: bp.religion || null,
-        death_place: bp.deathPlace || null,
-        cause_of_death: bp.causeOfDeath || null,
-        chief_mourner_name: bp.chiefMournerName || null,
-        chief_mourner_relationship: bp.chiefMournerRelationship || null,
+        ...formUnmanagedFields,
         validity_period_years_override: bp.validityPeriodYearsOverride ?? null,
         notes: bp.notes || null,
       };

--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -312,6 +312,9 @@ export const createPlotSchema = z.object({
   gravestoneInfo: gravestoneInfoSchema,
   collectiveBurial: collectiveBurialSchema,
   familyContacts: z.array(familyContactSchema).optional(),
+  // 埋葬者（任意）。スキーマ欠落により validate() で剥がされ、createPlot の保存処理
+  // （createPlot.ts:375-424, PR#335）に届かず HTTP 経路で破棄されていた（#384, #320 同型）
+  buriedPersons: z.array(buriedPersonSchema).optional(),
 });
 
 /**

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -2386,6 +2386,124 @@ describe('Plot Controller (ContractPlot Model)', () => {
       expect(mockPrisma.buriedPerson.create).not.toHaveBeenCalled();
       expect(mockNext).not.toHaveBeenCalled();
     });
+
+    // --- #383: updatePlot で移行投入済みの4項目（死亡場所/死因/喪主名/喪主続柄）を
+    //     保存のたびに null 上書き破壊しないこと（部分更新化） ---
+    const setupUpdateBuriedPersonMocks = () => {
+      // 既存埋葬者を 1 件返し、入力 id と突合させて update パスに入れる
+      mockPrisma.contractPlot.findUnique.mockResolvedValue({
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(3.6) },
+        saleContractRoles: [{ id: 'scr1', customer: { id: 'c1', workInfo: null } }],
+        usageFee: null,
+        managementFee: null,
+      });
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.buriedPerson.findMany.mockResolvedValue([
+        {
+          id: 'bp1',
+          name: '山田一郎',
+          death_place: '東京都病院', // 移行投入済みの値
+          cause_of_death: '老衰',
+          chief_mourner_name: '山田太郎',
+          chief_mourner_relationship: '長男',
+        },
+      ]);
+      mockPrisma.buriedPerson.update.mockResolvedValue({ id: 'bp1' });
+    };
+
+    it('updatePlot は4項目未指定なら update data に含めず移行値を破壊しない（#383）', async () => {
+      setupUpdateBuriedPersonMocks();
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        // 死亡場所/死因/喪主名/喪主続柄は未指定（編集フォームがラウンドトリップしない）
+        buriedPersons: [{ id: 'bp1', name: '山田一郎', relationship: '父' }],
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockPrisma.buriedPerson.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'bp1' },
+          data: expect.not.objectContaining({
+            death_place: expect.anything(),
+            cause_of_death: expect.anything(),
+            chief_mourner_name: expect.anything(),
+            chief_mourner_relationship: expect.anything(),
+          }),
+        })
+      );
+    });
+
+    it('updatePlot は4項目指定なら update data に反映する（#383）', async () => {
+      setupUpdateBuriedPersonMocks();
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        buriedPersons: [
+          {
+            id: 'bp1',
+            name: '山田一郎',
+            deathPlace: '大阪府病院',
+            causeOfDeath: '心不全',
+            chiefMournerName: '山田次郎',
+            chiefMournerRelationship: '次男',
+          },
+        ],
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockPrisma.buriedPerson.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'bp1' },
+          data: expect.objectContaining({
+            death_place: '大阪府病院',
+            cause_of_death: '心不全',
+            chief_mourner_name: '山田次郎',
+            chief_mourner_relationship: '次男',
+          }),
+        })
+      );
+    });
+
+    it('updatePlot は4項目空文字なら null 化して反映する（#383）', async () => {
+      setupUpdateBuriedPersonMocks();
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        buriedPersons: [
+          {
+            id: 'bp1',
+            name: '山田一郎',
+            deathPlace: '',
+            causeOfDeath: '',
+            chiefMournerName: '',
+            chiefMournerRelationship: '',
+          },
+        ],
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockPrisma.buriedPerson.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'bp1' },
+          data: expect.objectContaining({
+            death_place: null,
+            cause_of_death: null,
+            chief_mourner_name: null,
+            chief_mourner_relationship: null,
+          }),
+        })
+      );
+    });
   });
 
   describe('deletePlot', () => {

--- a/tests/validations/plotValidation.test.ts
+++ b/tests/validations/plotValidation.test.ts
@@ -416,6 +416,30 @@ describe('Plot Validation (ContractPlot Model)', () => {
       const parsed = createPlotSchema.parse(data);
       expect(parsed.gravestoneInfo).toMatchObject({ gravestoneDealer: '〇〇石材' });
     });
+
+    // #384: createPlotSchema に buriedPersons が無く、validate ミドルウェアが
+    // 未知キーとして strip → createPlot の保存処理に届かず破棄されていた回帰テスト（#320 同型）
+    it('buriedPersons が parse 結果に保持されること（#384）', () => {
+      const data = {
+        ...validCreatePlotData,
+        buriedPersons: [
+          {
+            name: '山田一郎',
+            nameKana: 'ヤマダイチロウ',
+            relationship: '父',
+            deathPlace: '東京都病院',
+            causeOfDeath: '老衰',
+          },
+        ],
+      };
+      const parsed = createPlotSchema.parse(data) as typeof data;
+      expect(parsed.buriedPersons).toHaveLength(1);
+      expect(parsed.buriedPersons[0]).toMatchObject({
+        name: '山田一郎',
+        deathPlace: '東京都病院',
+        causeOfDeath: '老衰',
+      });
+    });
   });
 
   describe('updatePlotSchema', () => {


### PR DESCRIPTION
## 概要

埋葬者(BuriedPerson)に関する2件のバグを修正する。

### #383 (critical): 区画編集保存で移行済み埋葬者の4項目が null 上書き破壊される

`updatePlot` の埋葬者同期処理が、編集フォームがラウンドトリップしない4項目
(死亡場所 `death_place` / 死因 `cause_of_death` / 喪主名 `chief_mourner_name` /
喪主続柄 `chief_mourner_relationship`)を常に `bp.xxx || null` で書き込んでいた。
そのため区画を編集保存するたびにこれら4項目が `undefined → null` に潰れ、
移行投入済み(`step08-buried-person.ts`)の値を破壊していた。

**修正**: 条件付きスプレッド `...(bp.deathPlace !== undefined && { ... })` で
部分更新化。入力に値がある場合のみ書き込み、`undefined` は変更なし扱いとする。

### #384: createPlotSchema に buriedPersons が無く HTTP 経路で埋葬者が破棄される

`createPlotSchema` に `buriedPersons` が定義されておらず、validate ミドルウェアが
未知キーとして strip するため、保存処理(`createPlot.ts`, PR#335)に届かず破棄されていた
(#320 と同型のスキーマ欠落)。

**修正**: `createPlotSchema` に `buriedPersons: z.array(buriedPersonSchema).optional()` を追加。

## テスト

- `tests/plots/plotController.test.ts`: `updatePlot` の4項目について部分更新を検証する回帰テスト3ケース追加(未指定→data に含めない / 値指定→反映 / 空文字→null 化)
- `tests/validations/plotValidation.test.ts`: `createPlotSchema` が `buriedPersons` を parse 結果に保持する回帰テスト追加
- 検証済み: plotController 63 passed / plotValidation 78 passed / `tsc --noEmit` clean / `eslint` clean

## 補足: #383 は本番データ修復 backfill が別途必要

本 PR のコード修正は「**今後の保存で潰さない**」だけで、既存の破壊データは修復しない。
PR#335 デプロイ後に区画編集保存された行は既に4項目 null 破壊の可能性があるため、
`History.before_record` またはレガシー DB(`step08-buried-person.ts` 元データ)からの
復元 backfill が**別途必要**(本 PR スコープ外)。

Closes #383
Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
