### PR TITLE
fix(history): 移行UPDATE履歴の配列changed_fields正規化＋名義変更ラベル/UUID非表示 (#385 #386)

### DIFF
--- a/src/plots/services/historyLabels.ts
+++ b/src/plots/services/historyLabels.ts
@@ -41,6 +41,9 @@ export const HIDDEN_FIELDS: ReadonlySet<string> = new Set([
   'buried_person_id',
   'family_contact_id',
   'document_id',
+  // 名義変更履歴（changeContractor）が before/after に積む契約者の顧客UUID（#386）
+  // ＝対の contractor_name / contractor_name_kana で人物は読めるため、UUID 露出は不要。
+  'contractor_customer_id',
   // 移行履歴（t_dankalog/t_famlog）由来のレガシー surrogate key（#376）
   // ＝履歴は既にエンティティ単位にスコープ済みなので表示価値がなく、CREATE
   //   スナップショットでノイズになるため非表示にする。
@@ -85,6 +88,9 @@ export const FIELD_LABELS: Record<HistoryEntityType, Record<string, string>> = {
     uncollected_amount: '未収金額',
     burial_capacity: '埋葬可能数',
     validity_period_years: '有効期間（年）',
+    // 名義変更履歴（changeContractor）が before/after に記録する契約者名（#386）
+    contractor_name: '契約者名（名義変更）',
+    contractor_name_kana: '契約者フリガナ（名義変更）',
     notes: '備考',
   },
   Customer: {
@@ -441,13 +447,35 @@ export function formatHistoryWithLabels(history: {
     return Object.keys(filtered).length > 0 ? filtered : null;
   };
 
-  // changed_fields から非表示フィールドを除外
+  const asRecord = (record: unknown): Record<string, unknown> =>
+    record && typeof record === 'object' ? (record as Record<string, unknown>) : {};
+
+  // changed_fields の正規化（#385）
+  //
+  // アプリ内編集（detectChangedFields）は { field: { before, after } } 形で保存するが、
+  // 移行履歴（step14-history）は変更フィールド名の文字列配列（例 ["tel1","zip"]）で保存する。
+  // 配列を素朴に Object.entries すると { "0":"tel1", "1":"zip" } と数値キー化され、
+  // 項目名が「0,1」・前後値が「（未設定）」になる。配列形式を検出したら before_record /
+  // after_record（同じレガシー列名でキー化済み）から { field: { before, after } } を
+  // 再構成し、フロント HistoryTab が期待する形へ吸収する（本番 9290 件 #354 を無改修で可読化）。
   const filterChangedFields = (fields: unknown): Record<string, unknown> | null => {
-    if (!fields || typeof fields !== 'object') return null;
+    if (!fields) return null;
     const filtered: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(fields as Record<string, unknown>)) {
-      if (isHiddenField(key)) continue;
-      filtered[key] = value;
+    if (Array.isArray(fields)) {
+      const before = asRecord(history.before_record);
+      const after = asRecord(history.after_record);
+      for (const raw of fields) {
+        const key = typeof raw === 'string' ? raw : String(raw);
+        if (isHiddenField(key)) continue;
+        filtered[key] = { before: before[key] ?? null, after: after[key] ?? null };
+      }
+    } else if (typeof fields === 'object') {
+      for (const [key, value] of Object.entries(fields as Record<string, unknown>)) {
+        if (isHiddenField(key)) continue;
+        filtered[key] = value;
+      }
+    } else {
+      return null;
     }
     return Object.keys(filtered).length > 0 ? filtered : null;
   };

--- a/tests/plots/services/historyLabels.test.ts
+++ b/tests/plots/services/historyLabels.test.ts
@@ -46,6 +46,13 @@ describe('historyLabels', () => {
       expect(getFieldLabel('FamilyContact', 'zip')).toBe('郵便番号');
     });
 
+    it('名義変更履歴の契約者名フィールドを日本語ラベルに解決する (#386)', () => {
+      expect(getFieldLabel('ContractPlot', 'contractor_name')).toBe('契約者名（名義変更）');
+      expect(getFieldLabel('ContractPlot', 'contractor_name_kana')).toBe(
+        '契約者フリガナ（名義変更）'
+      );
+    });
+
     it('現行Prisma名を優先し、レガシーエイリアスは衝突しても上書きしない (#376)', () => {
       // FamilyContact.relationship は現行Prisma名としても定義済み
       expect(getFieldLabel('FamilyContact', 'relationship')).toBe('続柄');
@@ -100,6 +107,11 @@ describe('historyLabels', () => {
       expect(isHiddenField('danka_cd')).toBe(true);
       expect(isHiddenField('grave_cd')).toBe(true);
       expect(isHiddenField('family_cd')).toBe(true);
+    });
+
+    it('名義変更履歴の契約者顧客UUIDは非表示 (#386)', () => {
+      expect(isHiddenField('contractor_customer_id')).toBe(true);
+      expect(HIDDEN_FIELDS.has('contractor_customer_id')).toBe(true);
     });
   });
 
@@ -330,6 +342,148 @@ describe('historyLabels', () => {
 
         const result = formatHistoryWithLabels(history);
         expect(result['afterRecord']).toBeNull();
+      });
+    });
+
+    // issue #385: 移行UPDATE履歴の changed_fields(配列) を正規化する
+    describe('issue #385: 移行履歴の配列形式 changed_fields', () => {
+      it('文字列配列の changed_fields を {field:{before,after}} に再構成する', () => {
+        // step14-history は変更フィールド名の文字列配列で保存し、
+        // before_record/after_record はその列名でキー化されている
+        const history = {
+          id: 'h-mig-1',
+          entity_type: 'Customer',
+          entity_id: 'c-1',
+          action_type: 'UPDATE',
+          changed_fields: ['tel1', 'zip'],
+          before_record: { tel1: '03-1111', zip: '100-0001' },
+          after_record: { tel1: '03-2222', zip: '100-0002' },
+          changed_by: 'legacy-tancd-5',
+          change_reason: null,
+          ip_address: 'unknown',
+          created_at: new Date('2010-01-01T00:00:00Z'),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const changedFields = result['changedFields'] as Record<
+          string,
+          { before: unknown; after: unknown }
+        >;
+
+        // 数値キー化されず、実フィールド名でキー化され before/after を持つ
+        expect(changedFields).toEqual({
+          tel1: { before: '03-1111', after: '03-2222' },
+          zip: { before: '100-0001', after: '100-0002' },
+        });
+        expect(changedFields).not.toHaveProperty('0');
+        expect(changedFields).not.toHaveProperty('1');
+
+        // fieldLabels はレガシー列名（実フィールド名）から日本語解決される
+        expect(result['fieldLabels']).toEqual({
+          tel1: '電話番号1',
+          zip: '郵便番号',
+        });
+      });
+
+      it('配列形式でも非表示フィールド(surrogate key)は除外される (#385/#376)', () => {
+        const history = {
+          id: 'h-mig-2',
+          entity_type: 'Customer',
+          entity_id: 'c-1',
+          action_type: 'UPDATE',
+          changed_fields: ['danka_cd', 'owner_sei'],
+          before_record: { danka_cd: '1', owner_sei: '山田' },
+          after_record: { danka_cd: '1', owner_sei: '田中' },
+          changed_by: 'legacy-tancd-5',
+          change_reason: null,
+          ip_address: 'unknown',
+          created_at: new Date('2010-01-01T00:00:00Z'),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const changedFields = result['changedFields'] as Record<string, unknown>;
+
+        expect(changedFields).not.toHaveProperty('danka_cd');
+        expect(changedFields).toHaveProperty('owner_sei');
+        expect(result['fieldLabels']).toEqual({ owner_sei: '契約者姓' });
+      });
+
+      it('before/after に値が無い列は null を補う', () => {
+        const history = {
+          id: 'h-mig-3',
+          entity_type: 'FamilyContact',
+          entity_id: 'fc-1',
+          action_type: 'UPDATE',
+          changed_fields: ['zokugara'],
+          before_record: {},
+          after_record: { zokugara: '長男' },
+          changed_by: null,
+          change_reason: null,
+          ip_address: 'unknown',
+          created_at: new Date('2010-01-01T00:00:00Z'),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const changedFields = result['changedFields'] as Record<
+          string,
+          { before: unknown; after: unknown }
+        >;
+
+        expect(changedFields['zokugara']).toEqual({ before: null, after: '長男' });
+        expect(result['fieldLabels']).toEqual({ zokugara: '続柄' });
+      });
+    });
+
+    // issue #386: 名義変更履歴の英語生キー/顧客UUID露出を抑止する
+    describe('issue #386: 名義変更履歴のラベル/UUID非表示', () => {
+      it('contractor_name は日本語ラベル化され contractor_customer_id は非表示になる', () => {
+        const history = {
+          id: 'h-cc-1',
+          entity_type: 'ContractPlot',
+          entity_id: 'cp-1',
+          action_type: 'UPDATE',
+          changed_fields: {
+            contractor_customer_id: {
+              before: '11111111-1111-1111-1111-111111111111',
+              after: '22222222-2222-2222-2222-222222222222',
+            },
+            contractor_name: { before: '旧 太郎', after: '新 花子' },
+            contractor_name_kana: { before: 'キュウ タロウ', after: 'シン ハナコ' },
+          },
+          before_record: {
+            contractor_customer_id: '11111111-1111-1111-1111-111111111111',
+            contractor_name: '旧 太郎',
+            contractor_name_kana: 'キュウ タロウ',
+          },
+          after_record: {
+            contractor_customer_id: '22222222-2222-2222-2222-222222222222',
+            contractor_name: '新 花子',
+            contractor_name_kana: 'シン ハナコ',
+          },
+          changed_by: 'テストユーザー',
+          change_reason: '名義変更',
+          ip_address: '127.0.0.1',
+          created_at: new Date('2026-06-13T00:00:00Z'),
+        };
+
+        const result = formatHistoryWithLabels(history);
+        const changedFields = result['changedFields'] as Record<string, unknown>;
+        const fieldLabels = result['fieldLabels'] as Record<string, string>;
+        const beforeRecord = result['beforeRecord'] as Record<string, unknown>;
+        const afterRecord = result['afterRecord'] as Record<string, unknown>;
+
+        // 顧客UUIDは項目・前後値ともに露出しない
+        expect(changedFields).not.toHaveProperty('contractor_customer_id');
+        expect(fieldLabels).not.toHaveProperty('contractor_customer_id');
+        expect(beforeRecord).not.toHaveProperty('contractor_customer_id');
+        expect(afterRecord).not.toHaveProperty('contractor_customer_id');
+
+        // 契約者名は日本語ラベルで表示される（英語生キー露出しない）
+        expect(fieldLabels).toEqual({
+          contractor_name: '契約者名（名義変更）',
+          contractor_name_kana: '契約者フリガナ（名義変更）',
+        });
+        expect(changedFields).toHaveProperty('contractor_name');
       });
     });
   });


### PR DESCRIPTION
## 概要
区画詳細「履歴情報」タブの2件の表示バグを修正（どちらも表示側吸収・本番DB無改修）。

## #385 移行UPDATE履歴の changed_fields(配列) が崩れる
- **症状**: 移行UPDATE行の項目名が「0,1」・前後値が「（未設定）」（本番9290件 #354 のUPDATE分すべて）。
- **根本原因**: `step14-history` は `changed_fields` を文字列配列（例 `["tel1","zip"]`）で保存する。`formatHistoryWithLabels` の `Object.entries(配列)` が `{"0":"tel1","1":"zip"}` と数値キー化し、`fieldLabels={"0":"0","1":"1"}`、フロント HistoryTab は `changedFields[field].before/after` を引けず undefined（=「（未設定）」）になっていた。
- **修正**: `Array.isArray(changed_fields)` を検出したら `before_record`/`after_record`（同じレガシー列名でキー化済み）から `{field:{before,after}}` を再構成。`fieldLabels` は実フィールド名（`tel1` 等）から `getFieldLabel` で解決し、PR#379 の `LEGACY_FIELD_LABELS` に正しく載るようにした。非表示フィールド（surrogate key）も配列経路で除外。

## #386 名義変更履歴が英語生キー＋顧客UUIDを露出
- **症状**: 名義変更1回ごとに `contractor_customer_id` 等の物理カラム名が項目名表示され、値として顧客UUIDが露出。
- **根本原因**: `changeContractor` が記録する `contractor_*` が `FIELD_LABELS.ContractPlot`・`LEGACY_FIELD_LABELS`・`HIDDEN_FIELDS` のいずれにも未登録で、`getFieldLabel` がフォールバックで物理名をそのまま返していた。
- **修正**: `contractor_name`→「契約者名（名義変更）」/ `contractor_name_kana`→「契約者フリガナ（名義変更）」を `FIELD_LABELS.ContractPlot` に追加、`contractor_customer_id` を `HIDDEN_FIELDS` に追加。

## テスト
`tests/plots/services/historyLabels.test.ts` に回帰6件追加（配列正規化3 / ラベル・UUID非表示3）。`npm test -- historyLabels`（28件 green）、`changeContractor`（13件 green）、`npx tsc --noEmit`、`npm run lint` すべて通過。

## 本番反映
**backfill 不要**。どちらも表示API（`formatHistoryWithLabels`）側の吸収で、本番DBの移行履歴9290件はそのまま可読化される。backend デプロイのみ。

Closes #385
Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
