### PR TITLE
fix(customers): 解約者検索の INT4 超数値で P2020→500 を回避 (#387)

### DIFF
--- a/src/customers/customerController.ts
+++ b/src/customers/customerController.ts
@@ -53,9 +53,12 @@ export const getTerminatedCustomers = async (
         // notes には旧区画手がかり（旧区画cd / 区画No: legacy-X）が記録済み
         { notes: { contains: search, mode: 'insensitive' } },
       ];
-      // 数値なら旧檀家コード一致も検索対象にする
+      // 数値なら旧檀家コード一致も検索対象にする。
+      // legacy_danka_cd は Prisma Int（INT4）のため、11桁電話番号など
+      // INT4 上限（2147483647）超の値を渡すと Prisma P2020 → 500 になる。
+      // 上限ガードで範囲内の値のみ条件に追加する（#387）。
       const numeric = Number(search);
-      if (Number.isInteger(numeric) && numeric > 0) {
+      if (Number.isInteger(numeric) && numeric > 0 && numeric <= 2147483647) {
         conditions.push({ legacy_danka_cd: numeric });
       }
       where.OR = conditions;

--- a/tests/customers/customerController.test.ts
+++ b/tests/customers/customerController.test.ts
@@ -165,6 +165,52 @@ describe('getTerminatedCustomers (#311)', () => {
     );
   });
 
+  it('search が INT4 上限超（11桁電話番号など）でも legacy_danka_cd 条件を追加しない（#387 P2020回避）', async () => {
+    mockPrisma.customer.count.mockResolvedValue(0);
+    mockPrisma.customer.findMany.mockResolvedValue([]);
+
+    // '09012345678' → 9012345678（INT4 上限 2147483647 超）
+    mockRequest.query = {
+      page: 1,
+      limit: 20,
+      search: '09012345678',
+    } as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockNext).not.toHaveBeenCalled();
+
+    const callArg = mockPrisma.customer.findMany.mock.calls[0][0];
+    const orConditions = callArg.where.OR as Array<Record<string, unknown>>;
+    // legacy_danka_cd 条件は付与されない（範囲超過で Prisma P2020 になるため）
+    expect(orConditions.some((c) => 'legacy_danka_cd' in c)).toBe(false);
+    // 電話番号など他の OR 条件はそのまま機能する
+    expect(orConditions).toEqual(
+      expect.arrayContaining([{ phone_number: { contains: '09012345678' } }])
+    );
+  });
+
+  it('search が INT4 上限ちょうど（2147483647）なら legacy_danka_cd 条件を追加する（#387 境界）', async () => {
+    mockPrisma.customer.count.mockResolvedValue(0);
+    mockPrisma.customer.findMany.mockResolvedValue([]);
+
+    mockRequest.query = {
+      page: 1,
+      limit: 20,
+      search: '2147483647',
+    } as unknown as Request['query'];
+
+    await getTerminatedCustomers(mockRequest as Request, mockResponse as Response, mockNext);
+
+    expect(mockPrisma.customer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([{ legacy_danka_cd: 2147483647 }]),
+        }),
+      })
+    );
+  });
+
   it('ページネーションが skip/take と totalPages に反映される', async () => {
     mockPrisma.customer.count.mockResolvedValue(45);
     mockPrisma.customer.findMany.mockResolvedValue([]);


### PR DESCRIPTION
## 概要
解約者検索 API（`GET /customers/terminated`）で 11桁電話番号など INT4 上限（2147483647）超の数値を検索すると、`legacy_danka_cd`（Prisma `Int`）の範囲超過で Prisma **P2020 → 500** になっていた。電話番号検索はこの API の正規ユースケース（swagger 記載）。`errorHandler` は P2020 を扱わず default 500 に落ちる。

## 根本原因
`src/customers/customerController.ts` の数値検索ガードが `Number.isInteger && > 0` のみで上限なし。`'09012345678'` → 9012345678 が INT4 を超え P2020。

## 修正
- 数値条件の上限ガードに `numeric <= 2147483647` を追加。範囲超過時は `legacy_danka_cd` 条件を付与せず、氏名・カナ・電話・備考の OR 検索はそのまま機能する。
- 回帰テスト2件追加（上限超で条件不付与・上限ちょうどで条件付与）。

## 検証
- `npm test -- tests/customers/customerController.test.ts` 7件 green
- `npx tsc --noEmit` clean / `npx eslint src/customers/customerController.ts` clean

## 本番反映
- backend デプロイのみ。DB 変更・backfill 不要。

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)