### PR TITLE
fix(yucho): 8桁ゆうちょ番号の口座番号先頭桁欠落を修正 (#392)

### DIFF
--- a/src/validations/plotValidation.ts
+++ b/src/validations/plotValidation.ts
@@ -219,9 +219,16 @@ const saleContractSchema = sharedSaleContractSchema.omit({ paymentStatus: true }
  */
 // ゆうちょ記号(5桁)・番号は @komine/types 未追加のため backend ローカルで受理する（#170）。
 // フロントのゆうちょ口座入力UI実装時に shared schema へ昇格予定。
+// ゆうちょ番号は振替用7桁が正だが、申込書・通帳は末尾チェックデジット込みの8桁で
+// 印字される。8桁許容で受理し、CSV 出力時に accountNumberFromYuchoNumber が
+// 末尾CD除去で7桁化する（#170/#392）。9桁以上は不正値として弾く。
 const customerSchema = sharedCustomerSchema.omit({ role: true }).extend({
   yuchoSymbol: z.string().max(5).optional().or(z.literal('')),
-  yuchoNumber: z.string().max(20).optional().or(z.literal('')),
+  yuchoNumber: z
+    .string()
+    .regex(/^\d{1,8}$/, 'ゆうちょ番号は8桁以内の数字で入力してください')
+    .optional()
+    .or(z.literal('')),
 });
 
 /**

--- a/src/yucho/yuchoAccount.ts
+++ b/src/yucho/yuchoAccount.ts
@@ -42,12 +42,28 @@ export function depositTypeFromSymbol(symbol: string | null | undefined): string
 }
 
 /**
- * 番号から口座番号（数字のみ）を取り出す。空なら null。
+ * 番号から振替用の口座番号（最大7桁）を取り出す。
+ *
+ * ゆうちょ番号は通帳・申込書では8桁（末尾1桁がチェックデジット）で印字されるが、
+ * 他金融機関フォーマットの振替用口座番号は末尾チェックデジットを除いた7桁が正。
+ * 通常貯金のチェックデジットは常に '1' のため、8桁かつ末尾 '1' のときは末尾1桁を
+ * 落として7桁化する（#392）。
+ *
+ * - 7桁以内: そのまま返す（数字のみ）
+ * - 8桁かつ末尾 '1': チェックデジットを除去して7桁を返す
+ * - それ以外（8桁で末尾≠'1' / 9桁以上）: 不正値として null を返し、CSV から静かに
+ *   壊れた口座番号が出力されないようにする（除外＝請求漏れ検知 #172 に計上される）
+ * - 空: null
  */
 export function accountNumberFromYuchoNumber(num: string | null | undefined): string | null {
   if (num == null) return null;
   const digits = num.replace(/[^\d]/g, '');
-  return digits.length > 0 ? digits : null;
+  if (digits.length === 0) return null;
+  if (digits.length <= 7) return digits;
+  // 8桁・末尾チェックデジット '1' は振替用7桁へ正規化
+  if (digits.length === 8 && digits.endsWith('1')) return digits.slice(0, 7);
+  // 8桁で末尾≠'1' / 9桁以上は振替用として解釈できない → null（CSV から除外）
+  return null;
 }
 
 /** 表示用に「記号-番号」形式へ整形する。どちらか欠ければ null。 */

--- a/tests/yucho/yuchoAccount.test.ts
+++ b/tests/yucho/yuchoAccount.test.ts
@@ -46,6 +46,18 @@ describe('yuchoAccount 記号番号変換 (#170)', () => {
       expect(accountNumberFromYuchoNumber('')).toBeNull();
       expect(accountNumberFromYuchoNumber(null)).toBeNull();
     });
+
+    it('8桁・末尾チェックデジット1は末尾を落として振替用7桁に正規化（#392）', () => {
+      // 印字8桁 '12345671' → 振替用 '1234567'（先頭桁欠落させない）
+      expect(accountNumberFromYuchoNumber('12345671')).toBe('1234567');
+      // ハイフン等を含む8桁印字も正規化される
+      expect(accountNumberFromYuchoNumber('1234567-1')).toBe('1234567');
+    });
+
+    it('8桁で末尾≠1 / 9桁以上は振替用として解釈できず null（CSV から静かに壊れない・#392）', () => {
+      expect(accountNumberFromYuchoNumber('12345678')).toBeNull();
+      expect(accountNumberFromYuchoNumber('123456789')).toBeNull();
+    });
   });
 
   describe('formatSymbolNumber', () => {

--- a/tests/yucho/yuchoCsv.test.ts
+++ b/tests/yucho/yuchoCsv.test.ts
@@ -135,6 +135,15 @@ describe('buildDataRow', () => {
     expect(cells[8]).toBe('0000089'); // 番号 89 → 0000089（口座番号 1234567 を上書き）
   });
 
+  it('8桁ゆうちょ番号（末尾チェックデジット1）は先頭桁欠落させず正しい7桁を出力する (#392)', () => {
+    const item = baseItem({
+      // 印字8桁 '12345671'。旧実装は padLeftZero(slice(-7)) で '2345671'（先頭欠落＋CD混入）
+      billingInfo: { ...baseItem().billingInfo!, accountNumber: null, yuchoNumber: '12345671' },
+    });
+    const cells = buildDataRow(item).split(',');
+    expect(cells[8]).toBe('1234567'); // 末尾CD除去で正しい7桁
+  });
+
   it('uses fixed deposit type code 1 (ordinary) by default', () => {
     const cells = buildDataRow(baseItem()).split(',');
     expect(cells[7]).toBe('1');
@@ -306,6 +315,28 @@ describe('isExportableBillingItem', () => {
     it('ハイフン区切りの正常な口座番号は出力対象', () => {
       const item = baseItem({
         billingInfo: { ...baseItem().billingInfo!, accountNumber: '123-4567' },
+      });
+      expect(isExportableBillingItem(item)).toBe(true);
+    });
+
+    it('ゆうちょ番号が振替用に解釈不能（8桁で末尾≠1）でフォールバック口座番号も無ければ出力対象外 (#392)', () => {
+      const item = baseItem({
+        billingInfo: {
+          ...baseItem().billingInfo!,
+          accountNumber: null,
+          yuchoNumber: '12345678', // 末尾≠1 → null 化されるため除外（静かに壊れた行を出さない）
+        },
+      });
+      expect(isExportableBillingItem(item)).toBe(false);
+    });
+
+    it('8桁ゆうちょ番号（末尾チェックデジット1）は出力対象 (#392)', () => {
+      const item = baseItem({
+        billingInfo: {
+          ...baseItem().billingInfo!,
+          accountNumber: null,
+          yuchoNumber: '12345671',
+        },
       });
       expect(isExportableBillingItem(item)).toBe(true);
     });


### PR DESCRIPTION
## 概要
ゆうちょ番号に8桁（末尾チェックデジット付き）を入力すると、CSV の口座番号が先頭桁欠落で静かに壊れ、誤った口座番号が銀行提出ファイルに混入していた（例外も出ず除外もされない）。

## 根本原因
ゆうちょ番号は通帳・申込書では末尾CD込みの**8桁**で印字されるが、振替用口座番号は末尾CDを除いた**7桁**が正。`accountNumberFromYuchoNumber` は数字抽出のみで CD 非処理、`padLeftZero` が `slice(-7)` で末尾7桁を採るため `'12345671'` → 正解 `'1234567'` ではなく `'2345671'`（先頭桁欠落＋CD混入）になっていた。zod も `max(20)` で8桁を素通し、`hasUsableAccountNumber` も通すため除外もされなかった。

## 修正
- `src/yucho/yuchoAccount.ts` `accountNumberFromYuchoNumber`:
  - 7桁以内 → そのまま
  - 8桁かつ末尾`'1'` → 末尾CDを除去して7桁化
  - 8桁で末尾≠`'1'` / 9桁以上 → `null`（振替用として解釈不能）。`isExportableBillingItem` で除外され、請求漏れ検知（#172）に計上されるため静かに壊れた行を出力しない。
- `src/validations/plotValidation.ts` `customerSchema.yuchoNumber`: `max(20)` → `^\d{1,8}$`（8桁以内の数字）に厳格化し、9桁以上を入口で明示エラー化。
- 回帰テスト追加（正規化/null化・CSV 出力7桁・除外判定）。

## 検証
- `npm test -- tests/yucho`（78件）/ `tests/schema-consistency` / `tests/validations/plotValidation.test.ts` 全 green
- `npx tsc --noEmit` clean / `npx eslint` clean

## 本番反映
- backend デプロイのみ。DB 変更・backfill 不要（#170 のゆうちょ番号入力は数十件の手入力予定で、印字どおり8桁入力しても正しく7桁化される）。

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)