### PR TITLE
fix(plots): 区画番号ソートを display_number 基準にして表示と一致させる (#388)

### DIFF
--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -226,10 +226,21 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
     }
 
     // ソート条件の構築
-    let orderByCondition: Prisma.ContractPlotOrderByWithRelationInput;
+    let orderByCondition:
+      | Prisma.ContractPlotOrderByWithRelationInput
+      | Prisma.ContractPlotOrderByWithRelationInput[];
     switch (sortBy) {
       case 'plotNumber':
-        orderByCondition = { physicalPlot: { plot_number: sortOrder } };
+        // 区画番号ソートは画面に表示している display_number（#158）を基準にする。
+        // 移行 plot_number は `legacy-{grave_cd}` 文字列で表示順と乖離するため、
+        // display_number 優先 → plot_number フォールバック → id の複合 orderBy にする。
+        // display_number 未設定（本番 6255 件中 1 件のみ）は nulls:'last' で末尾固定し、
+        // 同値時の安定性のため id を最終キーに付与してページ跨ぎ順序を固定する（#388）。
+        orderByCondition = [
+          { physicalPlot: { display_number: { sort: sortOrder, nulls: 'last' } } },
+          { physicalPlot: { plot_number: sortOrder } },
+          { id: 'asc' },
+        ];
         break;
       case 'contractDate':
         orderByCondition = { contract_date: sortOrder };

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -395,6 +395,39 @@ describe('Plot Controller (ContractPlot Model)', () => {
       ]);
     });
 
+    it('sortBy=plotNumber は display_number 優先＋plot_number フォールバックの複合 orderBy にする (#388)', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: '1', limit: '10', sortBy: 'plotNumber', sortOrder: 'asc' };
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const query = mockPrisma.contractPlot.findMany.mock.calls[0][0];
+      // 画面表示中の display_number を基準にする（legacy plot_number 基準の乖離を解消）
+      expect(query.orderBy).toEqual([
+        { physicalPlot: { display_number: { sort: 'asc', nulls: 'last' } } },
+        { physicalPlot: { plot_number: 'asc' } },
+        { id: 'asc' },
+      ]);
+    });
+
+    it('sortBy=plotNumber 降順でも display_number 未設定は末尾固定（nulls:last）にする (#388)', async () => {
+      mockPrisma.contractPlot.findMany.mockResolvedValueOnce([]);
+      mockPrisma.contractPlot.count.mockResolvedValue(0);
+
+      mockRequest.query = { page: '1', limit: '10', sortBy: 'plotNumber', sortOrder: 'desc' };
+
+      await getPlots(mockRequest as Request, mockResponse as Response, mockNext);
+
+      const query = mockPrisma.contractPlot.findMany.mock.calls[0][0];
+      expect(query.orderBy).toEqual([
+        { physicalPlot: { display_number: { sort: 'desc', nulls: 'last' } } },
+        { physicalPlot: { plot_number: 'desc' } },
+        { id: 'asc' },
+      ]);
+    });
+
     it('一覧 include の saleContractRoles を snapshot と同一順序（created_at asc, id asc）で取得する (#303)', async () => {
       // 同一区画に contractor ロールが複数ある場合、orderBy 無しでは DB 返却順が
       // 任意のため、ソートキー（snapshot は created_at asc の顧客）と表示名


### PR DESCRIPTION
## 概要
台帳一覧の区画番号ソートが legacy `plot_number` 基準のままで、画面に表示される `display_number`（#158）と無関係な並び順になっていた。本番6250件の既定並び順が区画番号列の表示と一致せず、列ソートトグルも見かけ機能していなかった。

## 根本原因
PR#332（#158）は検索条件に `display_number` を追加したがソートは未対応で、`sortBy=plotNumber` は `orderBy: { physicalPlot: { plot_number: sortOrder } }` のまま。移行 `plot_number` は `legacy-{grave_cd}` 文字列で、フロント台帳一覧は既定 sortKey='plotNumber' asc・区画番号列に displayNumber を優先表示するため乖離する。

## 修正
`sortBy=plotNumber` を複合 orderBy（配列）に変更:
```ts
[
  { physicalPlot: { display_number: { sort: sortOrder, nulls: 'last' } } },
  { physicalPlot: { plot_number: sortOrder } },
  { id: 'asc' },
]
```
- 画面表示中の `display_number` を主キーにし、表示と並び順を一致させる。
- `display_number` 未設定行（本番6255件中1件のみ）は `nulls:'last'` で末尾固定。
- 同値時のページ跨ぎ順序を安定化するため `id` を最終キーに付与。
- `orderByCondition` 型を単体／配列の union に拡張（Prisma は両方受理）。

回帰テスト2件追加（昇順／降順の複合 orderBy 固定）。

## 検証
- `npm test -- tests/plots/plotController.test.ts`（65件）green
- `npx tsc --noEmit` clean / `npx eslint src/plots/controllers/getPlots.ts` clean

## 本番反映
- backend デプロイのみ。DB 変更・backfill 不要（display_number は #158 で backfill 済み）。

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)