### PR TITLE
feat(scripts): 全区画 payment_status/uncollected 再計算スクリプト (Refs #389)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "backfill:legacy-value-cleanup": "ts-node --transpile-only scripts/backfill-legacy-value-cleanup.ts",
     "backfill:shiharai-payment-method": "ts-node --transpile-only scripts/backfill-shiharai-payment-method.ts",
     "backfill:fee-master-codes": "ts-node --transpile-only scripts/backfill-fee-master-codes.ts",
+    "recalc:payment-status": "ts-node --transpile-only scripts/recalculate-payment-status.ts",
     "verify:migration": "ts-node --transpile-only scripts/verify-migration.ts",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",

--- a/scripts/recalculate-payment-status.ts
+++ b/scripts/recalculate-payment-status.ts
@@ -1,0 +1,180 @@
+/// <reference types="node" />
+/**
+ * 全 ContractPlot の payment_status / uncollected_amount 再計算スクリプト（#389）
+ *
+ * `uncollected_amount` は請求 vs 入金の派生値（#170）で、ランタイムは請求/入金の
+ * ミューテーション経路でのみ再計算する（src/plots/services/paymentStatusService）。
+ * このため定義変更（PR#328: 未収金額を「全料金区分」→「護持費=管理料限定」へ絞り込み）が
+ * 既存の格納値に再適用されず、請求/入金を一度も触らない区画は旧定義の金額を表示し続ける。
+ *
+ * 本スクリプトは **レガシーDB不要**（Prisma 単独）で、全 ContractPlot を
+ * 請求群から再集計し、payment_status / uncollected_amount を現行定義へ収束させる。
+ * 判定は migrate:legacy の step12-payment-status と同じ deriveContractPlotPayment を共有する。
+ *
+ * 使い方:
+ *   npm run recalc:payment-status              # dry-run（差分件数のみ・更新なし）
+ *   npm run recalc:payment-status -- --apply   # 実際に更新
+ *
+ * 環境変数: DATABASE_URL のみ（レガシー接続不要）
+ *
+ * 冪等: 現行定義に収束した区画は次回 no-op。何度実行しても同じ結果になる。
+ */
+import 'dotenv/config';
+
+import type { BillingCategory, PaymentStatus } from '@prisma/client';
+
+import { prisma } from '../src/db/prisma';
+import { deriveContractPlotPayment } from '../src/plots/services/paymentStatusLogic';
+
+const APPLY = process.argv.includes('--apply');
+const CHUNK = 1000;
+
+type GroupedBilling = {
+  contract_plot_id: string;
+  category: BillingCategory;
+  _sum: { amount: number | null; paid_amount: number | null };
+};
+
+type CurrentPlot = {
+  id: string;
+  payment_status: PaymentStatus;
+  uncollected_amount: number;
+};
+
+export interface RecalcPlan {
+  /** 再計算後の (status, uncollected) 別に更新対象 ID をまとめたバケット群 */
+  buckets: Map<string, { status: PaymentStatus; uncollected: number; ids: string[] }>;
+  scanned: number;
+  changed: number;
+  noop: number;
+}
+
+/**
+ * 区画ごとの現在値と請求集計から「現行定義へ収束させるための更新計画」を組む（DB 非依存の純関数）。
+ *
+ * - 請求の無い区画も対象に含める: 旧定義で uncollected>0 が格納されたまま請求/入金が無い区画を
+ *   0 へ戻す必要があるため。請求が無い区画は status を現状維持し uncollected=0 を期待値とする。
+ * - 現在値と期待値が一致する区画は no-op（更新対象から除外）。
+ */
+export function buildRecalcPlan(plots: CurrentPlot[], grouped: GroupedBilling[]): RecalcPlan {
+  const byPlot = new Map<
+    string,
+    { amount: number; paid_amount: number; terminated: boolean; category: BillingCategory }[]
+  >();
+  for (const g of grouped) {
+    const list = byPlot.get(g.contract_plot_id) ?? [];
+    list.push({
+      amount: g._sum.amount ?? 0,
+      paid_amount: g._sum.paid_amount ?? 0,
+      terminated: false, // groupBy 側で terminated:false 済み
+      category: g.category,
+    });
+    byPlot.set(g.contract_plot_id, list);
+  }
+
+  const buckets = new Map<string, { status: PaymentStatus; uncollected: number; ids: string[] }>();
+  let changed = 0;
+  let noop = 0;
+
+  for (const plot of plots) {
+    const billings = byPlot.get(plot.id) ?? [];
+    // 現在の payment_status は手動設定（refunded/overdue）を尊重するため derive に渡す。
+    const { status, uncollectedAmount: uncollected } = deriveContractPlotPayment(
+      billings,
+      plot.payment_status
+    );
+
+    if (status === plot.payment_status && uncollected === plot.uncollected_amount) {
+      noop += 1;
+      continue;
+    }
+    changed += 1;
+
+    const key = `${status}|${uncollected}`;
+    const bucket = buckets.get(key);
+    if (bucket) bucket.ids.push(plot.id);
+    else buckets.set(key, { status, uncollected, ids: [plot.id] });
+  }
+
+  return { buckets, scanned: plots.length, changed, noop };
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+async function main(): Promise<void> {
+  console.log(`[recalc payment-status] start (apply=${APPLY})`);
+
+  // 全 active 区画の現在値
+  const plots = await prisma.contractPlot.findMany({
+    where: { deleted_at: null },
+    select: { id: true, payment_status: true, uncollected_amount: true },
+  });
+
+  // 解約済み・削除済みを除いた請求を「区画 × category」で集計
+  const grouped = (await prisma.billing.groupBy({
+    by: ['contract_plot_id', 'category'],
+    where: { deleted_at: null, terminated: false },
+    _sum: { amount: true, paid_amount: true },
+  })) as GroupedBilling[];
+
+  const plan = buildRecalcPlan(plots, grouped);
+
+  if (!APPLY) {
+    const sample: Array<{ status: PaymentStatus; uncollected: number; ids: number }> = [];
+    for (const b of plan.buckets.values()) {
+      sample.push({ status: b.status, uncollected: b.uncollected, ids: b.ids.length });
+    }
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          scanned: plan.scanned,
+          would_change: plan.changed,
+          noop: plan.noop,
+          buckets: sample.slice(0, 20),
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  let updated = 0;
+  for (const { status, uncollected, ids } of plan.buckets.values()) {
+    for (const idChunk of chunk(ids, CHUNK)) {
+      await prisma.contractPlot.updateMany({
+        where: { id: { in: idChunk }, deleted_at: null },
+        data: { payment_status: status, uncollected_amount: uncollected },
+      });
+      updated += idChunk.length;
+      if (updated % 1000 === 0 || updated === plan.changed) {
+        console.log(`  updated ${updated}/${plan.changed}`);
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      { scanned: plan.scanned, changed: plan.changed, noop: plan.noop, updated },
+      null,
+      2
+    )
+  );
+}
+
+// テストから import されたとき（require.main 不一致）は自動実行しない。
+if (require.main === module) {
+  main()
+    .catch((e) => {
+      console.error('ERROR', e);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/tests/scripts/recalculate-payment-status.test.ts
+++ b/tests/scripts/recalculate-payment-status.test.ts
@@ -1,0 +1,99 @@
+import { BillingCategory, PaymentStatus } from '@prisma/client';
+
+import { buildRecalcPlan } from '../../scripts/recalculate-payment-status';
+
+type Plot = {
+  id: string;
+  payment_status: PaymentStatus;
+  uncollected_amount: number;
+};
+
+type Grouped = {
+  contract_plot_id: string;
+  category: BillingCategory;
+  _sum: { amount: number | null; paid_amount: number | null };
+};
+
+const g = (id: string, category: BillingCategory, amount: number, paid: number): Grouped => ({
+  contract_plot_id: id,
+  category,
+  _sum: { amount, paid_amount: paid },
+});
+
+describe('buildRecalcPlan (#389)', () => {
+  it('旧定義（全区分）の未収格納値を現行定義（管理料限定）へ収束させる', () => {
+    // 区画 P1: 旧 backfill が「使用料未払い 50000 + 管理料完納」を全区分で未収 50000 と格納していた。
+    // 現行定義（管理料限定）では管理料は完納のため未収は 0 になるべき。
+    const plots: Plot[] = [
+      { id: 'P1', payment_status: PaymentStatus.partial_paid, uncollected_amount: 50000 },
+    ];
+    const grouped: Grouped[] = [
+      g('P1', BillingCategory.usage_fee, 50000, 0), // 使用料未払い
+      g('P1', BillingCategory.management_fee, 10000, 10000), // 管理料完納
+    ];
+
+    const plan = buildRecalcPlan(plots, grouped);
+
+    expect(plan.scanned).toBe(1);
+    expect(plan.changed).toBe(1);
+    // status は全区分で判定 → 使用料未払いがあるので partial_paid 維持、uncollected は管理料限定で 0。
+    const bucket = plan.buckets.get(`${PaymentStatus.partial_paid}|0`);
+    expect(bucket?.ids).toEqual(['P1']);
+  });
+
+  it('現行定義と既に一致する区画は no-op（更新対象外）', () => {
+    const plots: Plot[] = [
+      { id: 'P2', payment_status: PaymentStatus.unpaid, uncollected_amount: 10000 },
+    ];
+    const grouped: Grouped[] = [g('P2', BillingCategory.management_fee, 10000, 0)];
+
+    const plan = buildRecalcPlan(plots, grouped);
+
+    expect(plan.changed).toBe(0);
+    expect(plan.noop).toBe(1);
+    expect(plan.buckets.size).toBe(0);
+  });
+
+  it('請求の無い区画に残った旧未収格納値を 0 へ戻す', () => {
+    // 請求/入金を一度も触らない区画。旧 backfill 由来で uncollected>0 が残っているケース。
+    const plots: Plot[] = [
+      { id: 'P3', payment_status: PaymentStatus.unpaid, uncollected_amount: 30000 },
+    ];
+
+    const plan = buildRecalcPlan(plots, []);
+
+    expect(plan.changed).toBe(1);
+    const bucket = plan.buckets.get(`${PaymentStatus.unpaid}|0`);
+    expect(bucket?.ids).toEqual(['P3']);
+  });
+
+  it('管理料未払いの区画は未収を管理料額で再計算する', () => {
+    const plots: Plot[] = [
+      // 旧格納値が古い（5000）→ 現行で 10000 に直る。
+      { id: 'P4', payment_status: PaymentStatus.unpaid, uncollected_amount: 5000 },
+    ];
+    const grouped: Grouped[] = [
+      g('P4', BillingCategory.management_fee, 10000, 0),
+      g('P4', BillingCategory.usage_fee, 80000, 80000),
+    ];
+
+    const plan = buildRecalcPlan(plots, grouped);
+
+    expect(plan.changed).toBe(1);
+    const bucket = plan.buckets.get(`${PaymentStatus.partial_paid}|10000`);
+    expect(bucket?.ids).toEqual(['P4']);
+  });
+
+  it('refunded は手動設定を尊重し未収 0 のまま維持する', () => {
+    const plots: Plot[] = [
+      { id: 'P5', payment_status: PaymentStatus.refunded, uncollected_amount: 0 },
+    ];
+    const grouped: Grouped[] = [g('P5', BillingCategory.management_fee, 10000, 0)];
+
+    const plan = buildRecalcPlan(plots, grouped);
+
+    // refunded 維持 + uncollected 0 維持 → no-op
+    expect(plan.changed).toBe(0);
+    expect(plan.noop).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要

未収金額は #170 で「請求 vs 入金」の派生値となり、ランタイム（`paymentStatusService`）は請求/入金のミューテーション経路でのみ再計算する。このため PR#328 の定義変更（未収金額を全料金区分 → 護持費=管理料限定へ絞り込み）が**既存の格納値に再適用されず**、請求/入金を一度も触らない区画は旧定義（全区分）の金額を区画詳細・一覧に表示し続けていた。

全件再計算手段が `migrate:legacy --only=paymentStatus`（レガシーDB接続必須）の手動再実行しか無く、リリース手順・トラッカーに記載が無いのが恒久的な問題だった。

## 変更内容

- `scripts/recalculate-payment-status.ts` を追加（**レガシーDB接続不要**・Prisma 単独・`DATABASE_URL` のみ）。
  - 全 active `ContractPlot` を請求群から再集計し `payment_status` / `uncollected_amount` を現行定義へ収束。
  - 判定ロジックは `migrate:legacy` の step12-payment-status と同じ `deriveContractPlotPayment` を共有（単一ソース）。
  - **請求の無い区画も対象**に含め、旧 backfill 由来で残った `uncollected>0` を 0 へ戻す。
  - `refunded`/`overdue` の手動設定を尊重（derive に現在 status を渡す）。
  - dry-run デフォルト → `--apply` 実投入（既存 backfill 慣例に準拠）。
- 純関数 `buildRecalcPlan` を切り出し、回帰テスト（旧定義→現行定義への収束、no-op、請求なし区画の 0 戻し、refunded 維持）を追加。
- `npm run recalc:payment-status` を package.json に追加。

## 本番反映

⚠️ **デプロイだけでは既存格納値は直らない。本番でのスクリプト実行が必要。**

```
npm run recalc:payment-status              # dry-run（差分件数確認）
npm run recalc:payment-status -- --apply   # 実投入
```

スクリプト実行が運用作業として残るため `Refs #389`（自動クローズしない）。

## 検証

- `npm test -- tests/scripts/recalculate-payment-status.test.ts` ✅ 5 passed
- `npx tsc --noEmit` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)