### PR TITLE
fix(scripts): konryu-establishment backfill の捏造防止ガードと代理投入補完 (Refs #390)

### DIFF
--- a/scripts/backfill-konryu-establishment.ts
+++ b/scripts/backfill-konryu-establishment.ts
@@ -1,27 +1,40 @@
 /// <reference types="node" />
 /**
- * 建立期限/建立日の器ずれ backfill スクリプト（#326）
+ * 建立期限/建立日の器ずれ backfill スクリプト（#326 / #390）
  *
- * レガシー移行（step05）が建立期限(konryu_kigen)/建立日(konryu_date) を
+ * ⚠️ **新移行コード（PR#342 以降の step05）で移行した DB には不要・実行禁止**。
+ *   現行 step05 は establishment を GravestoneInfo へ正しく入れ、permit_date/start_date には
+ *   contract_date を投入する（許可日＝開始日＝契約日 / komine-docs#10 Q4/Q5）。
+ *   このスクリプトは **旧移行コード（konryu を permit/start へ誤投入していた版）で投入した DB** の
+ *   是正専用。新コード移行済み行は下記ガード(1)で除外され処理されない（#390 の捏造防止）。
+ *
+ * 旧移行（step05 旧版）が建立期限(konryu_kigen)/建立日(konryu_date) を
  * 誤って ContractPlot.permit_date(許可日)/start_date(開始日) に投入していた。
  * 正しい器は GravestoneInfo.establishment_deadline/establishment_date。
  *
- * 本スクリプトはレガシーDB不要で、移行済み行（legacy_grave_cd IS NOT NULL）の
- * permit_date → establishment_deadline / start_date → establishment_date へ DB 内で移送し、
- * その後 permit_date/start_date には契約日(contract_date)を代理投入する
- * （業務確認 komine-docs#10 Q4/Q5: 許可日＝開始日＝契約日相当）。
+ * 本スクリプトはレガシーDB不要で、以下 2 パスを実行する。
+ *
+ *   パス1（是正）: 旧誤投入行の permit_date → establishment_deadline /
+ *     start_date → establishment_date へ DB 内で移送し、その後 permit_date/start_date には
+ *     契約日(contract_date)を代理投入する。
+ *   パス2（代理投入の取りこぼし補完 / #390 low）: konryu_kigen/konryu_date が両方 null で
+ *     permit_date=start_date=null のまま移行された行へ、許可日＝開始日＝契約日を代理投入する
+ *     （establishment 非干渉・冪等）。
  *
  * アプリ作成行（legacy_grave_cd IS NULL）は正規の許可日/開始日が入りうるため対象外。
  *
- * ⚠️ 安全ガード: establishment_deadline/establishment_date が**未投入**の行だけ処理する。
- *   これにより、新移行コード（permit=contract_date を投入する版）適用済みの行や、
- *   既に本スクリプトで処理済みの行を再処理して establishment を壊すことを防ぐ。
+ * 安全ガード（パス1）:
+ *   (1) permit_date/start_date が既に contract_date と一致する行（= 新移行コード適用済み or
+ *       本スクリプト処理済み）は除外する（#390: 契約日を establishment へ捏造するのを防ぐ）。
+ *   (2) establishment_deadline/establishment_date が**未投入**の行だけ処理する。
+ *       これにより、既に establishment が埋まっている行を再処理して壊すことを防ぐ。
  *
  * 使い方:
  *   npx ts-node scripts/backfill-konryu-establishment.ts          # dry-run（件数のみ）
  *   npx ts-node scripts/backfill-konryu-establishment.ts --apply  # 実際に更新
  *
- * 冪等: 実行後は establishment が埋まるため、同じ行は次回ガードで除外され再処理されない。
+ * 冪等: 実行後は establishment が埋まり、permit/start が contract_date と一致するため、
+ *   同じ行は次回ガード(1)(2)で除外され再処理されない。
  */
 import 'dotenv/config';
 
@@ -30,9 +43,49 @@ import { prisma } from '../src/db/prisma';
 const APPLY = process.argv.includes('--apply');
 const CONCURRENCY = 25;
 
-async function main(): Promise<void> {
-  console.log(`[backfill konryu→establishment] start (apply=${APPLY})`);
+/** 2 つの Date / null が同一日付か（参照ではなく値で比較） */
+export function sameDate(a: Date | null, b: Date | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.getTime() === b.getTime();
+}
 
+type CandidateRow = {
+  permit_date: Date | null;
+  start_date: Date | null;
+  contract_date: Date | null;
+  gravestoneInfo: {
+    establishment_deadline: Date | null;
+    establishment_date: Date | null;
+  } | null;
+};
+
+/**
+ * パス1の是正対象か判定する（DB 非依存の純関数 / #390）。
+ *
+ * - 新移行コード適用済み（permit_date と start_date が両方 contract_date と一致）は除外。
+ *   → 契約日を establishment へ捏造するのを防ぐ。
+ * - establishment が既に埋まっている行（新コード or 処理済み）は除外。
+ */
+export function isPass1Target(row: CandidateRow): boolean {
+  // ガード(1): 新マッピング済み（permit=start=contract_date）は除外。
+  const newMappingApplied =
+    sameDate(row.permit_date, row.contract_date) && sameDate(row.start_date, row.contract_date);
+  if (newMappingApplied) return false;
+
+  // ガード(2): establishment 未投入の行だけが「旧マッピングの未処理行」。
+  return (
+    row.gravestoneInfo == null ||
+    (row.gravestoneInfo.establishment_deadline == null &&
+      row.gravestoneInfo.establishment_date == null)
+  );
+}
+
+async function runPass1(): Promise<{
+  candidates: number;
+  targets: number;
+  updated: number;
+  createdGravestone: number;
+}> {
   // 候補: 移行行で permit_date か start_date が入っているもの（= 誤投入された建立期限/建立日の疑い）
   const candidates = await prisma.contractPlot.findMany({
     where: {
@@ -51,25 +104,19 @@ async function main(): Promise<void> {
     },
   });
 
-  // 安全ガード: establishment が未投入の行だけが「旧マッピングの未処理行」。
-  // どちらか埋まっていれば（新移行コード適用済み or 本スクリプト処理済み）除外する。
-  const targets = candidates.filter(
-    (t) =>
-      t.gravestoneInfo == null ||
-      (t.gravestoneInfo.establishment_deadline == null &&
-        t.gravestoneInfo.establishment_date == null)
+  const targets = candidates.filter((t) => isPass1Target(t));
+  console.log(
+    `[パス1 是正] 候補 ${candidates.length} 件 / 対象（新マッピング除外・establishment 未投入）${targets.length} 件`
   );
-  console.log(`候補 ${candidates.length} 件 / 対象（establishment 未投入）${targets.length} 件`);
-
-  let updated = 0;
-  let createdGravestone = 0;
 
   if (!APPLY) {
     const missingGravestone = targets.filter((t) => !t.gravestoneInfo).length;
     console.log(
       JSON.stringify(
         {
+          pass: 1,
           dryRun: true,
+          candidates: candidates.length,
           targets: targets.length,
           would_create_gravestone_info: missingGravestone,
           sample: targets.slice(0, 5).map((t) => ({
@@ -83,9 +130,16 @@ async function main(): Promise<void> {
         2
       )
     );
-    return;
+    return {
+      candidates: candidates.length,
+      targets: targets.length,
+      updated: 0,
+      createdGravestone: 0,
+    };
   }
 
+  let updated = 0;
+  let createdGravestone = 0;
   for (let i = 0; i < targets.length; i += CONCURRENCY) {
     const chunk = targets.slice(i, i + CONCURRENCY);
     await Promise.all(
@@ -120,24 +174,95 @@ async function main(): Promise<void> {
     );
     updated += chunk.length;
     if (updated % 500 === 0 || updated === targets.length) {
-      console.log(`  updated ${updated}/${targets.length}`);
+      console.log(`  [パス1] updated ${updated}/${targets.length}`);
     }
   }
 
+  return { candidates: candidates.length, targets: targets.length, updated, createdGravestone };
+}
+
+async function runPass2(): Promise<{ targets: number; updated: number }> {
+  // パス2（#390 low）: 移行行のうち permit_date=start_date=null（konryu 両方 null で
+  // 旧版が何も入れなかった行）で contract_date を持つものへ、許可日＝開始日＝契約日を代理投入。
+  // establishment には一切触れない（非干渉・冪等）。
+  const targets = await prisma.contractPlot.findMany({
+    where: {
+      legacy_grave_cd: { not: null },
+      deleted_at: null,
+      permit_date: null,
+      start_date: null,
+      contract_date: { not: null },
+    },
+    select: { id: true, contract_date: true },
+  });
+  console.log(`[パス2 代理投入補完] 対象（permit/start 両 null・契約日あり）${targets.length} 件`);
+
+  if (!APPLY) {
+    console.log(
+      JSON.stringify(
+        {
+          pass: 2,
+          dryRun: true,
+          targets: targets.length,
+          sample: targets.slice(0, 5).map((t) => ({ id: t.id, contract_date: t.contract_date })),
+        },
+        null,
+        2
+      )
+    );
+    return { targets: targets.length, updated: 0 };
+  }
+
+  let updated = 0;
+  for (let i = 0; i < targets.length; i += CONCURRENCY) {
+    const chunk = targets.slice(i, i + CONCURRENCY);
+    await Promise.all(
+      chunk.map((t) =>
+        prisma.contractPlot.update({
+          where: { id: t.id },
+          data: { permit_date: t.contract_date, start_date: t.contract_date },
+        })
+      )
+    );
+    updated += chunk.length;
+    if (updated % 500 === 0 || updated === targets.length) {
+      console.log(`  [パス2] updated ${updated}/${targets.length}`);
+    }
+  }
+
+  return { targets: targets.length, updated };
+}
+
+async function main(): Promise<void> {
+  console.log(`[backfill konryu→establishment] start (apply=${APPLY})`);
+
+  const pass1 = await runPass1();
+  const pass2 = await runPass2();
+
   console.log(
     JSON.stringify(
-      { targets: targets.length, updated, created_gravestone_info: createdGravestone },
+      {
+        pass1_candidates: pass1.candidates,
+        pass1_targets: pass1.targets,
+        pass1_updated: pass1.updated,
+        pass1_created_gravestone_info: pass1.createdGravestone,
+        pass2_targets: pass2.targets,
+        pass2_updated: pass2.updated,
+      },
       null,
       2
     )
   );
 }
 
-main()
-  .catch((e) => {
-    console.error('ERROR', e);
-    process.exitCode = 1;
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+// テストから import されたとき（require.main 不一致）は自動実行しない。
+if (require.main === module) {
+  main()
+    .catch((e) => {
+      console.error('ERROR', e);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/tests/scripts/backfill-konryu-establishment.test.ts
+++ b/tests/scripts/backfill-konryu-establishment.test.ts
@@ -1,0 +1,90 @@
+/**
+ * 回帰テスト: backfill-konryu-establishment の捏造防止ガード（#390）
+ *
+ * 新移行コード（PR#342 以降の step05）適用済み DB では permit_date=start_date=contract_date
+ * となり establishment は GravestoneInfo に正しく入る。この状態で本スクリプトを実行すると、
+ * 旧版なら全契約日有り行が候補に入り contract_date を establishment へ捏造していた。
+ * isPass1Target で「permit=start=contract_date」の新マッピング済み行を除外することを検証する。
+ */
+import { isPass1Target, sameDate } from '../../scripts/backfill-konryu-establishment';
+
+const d = (s: string): Date => new Date(s);
+
+describe('sameDate', () => {
+  it('同一日付は true', () => {
+    expect(sameDate(d('2019-04-01'), d('2019-04-01'))).toBe(true);
+  });
+  it('異なる日付は false', () => {
+    expect(sameDate(d('2019-04-01'), d('2020-01-01'))).toBe(false);
+  });
+  it('両方 null は true / 片方 null は false', () => {
+    expect(sameDate(null, null)).toBe(true);
+    expect(sameDate(d('2019-04-01'), null)).toBe(false);
+    expect(sameDate(null, d('2019-04-01'))).toBe(false);
+  });
+});
+
+describe('isPass1Target (#390 捏造防止)', () => {
+  it('新マッピング済み（permit=start=contract_date）の行は除外する', () => {
+    // 新移行コード適用済み・konryu 無し（establishment 未投入）。
+    // 旧版ガードでは establishment が null のため通過し contract_date を捏造していた。
+    expect(
+      isPass1Target({
+        permit_date: d('2019-04-01'),
+        start_date: d('2019-04-01'),
+        contract_date: d('2019-04-01'),
+        gravestoneInfo: null,
+      })
+    ).toBe(false);
+  });
+
+  it('新マッピング済みで establishment が既に入っている行も除外する', () => {
+    expect(
+      isPass1Target({
+        permit_date: d('2019-04-01'),
+        start_date: d('2019-04-01'),
+        contract_date: d('2019-04-01'),
+        gravestoneInfo: {
+          establishment_deadline: d('2020-01-01'),
+          establishment_date: d('2020-02-01'),
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('旧誤投入行（permit に konryu 値が入り contract_date と不一致・establishment 未投入）は対象', () => {
+    expect(
+      isPass1Target({
+        permit_date: d('2020-01-01'), // konryu_kigen が誤投入された値
+        start_date: d('2020-02-01'), // konryu_date が誤投入された値
+        contract_date: d('2019-04-01'),
+        gravestoneInfo: null,
+      })
+    ).toBe(true);
+  });
+
+  it('permit のみ contract_date と不一致でも対象（start は一致でも片方ずれていれば旧誤投入の疑い）', () => {
+    expect(
+      isPass1Target({
+        permit_date: d('2020-01-01'),
+        start_date: d('2019-04-01'),
+        contract_date: d('2019-04-01'),
+        gravestoneInfo: null,
+      })
+    ).toBe(true);
+  });
+
+  it('establishment が既に埋まっている誤投入行は二重処理しない（除外）', () => {
+    expect(
+      isPass1Target({
+        permit_date: d('2020-01-01'),
+        start_date: d('2020-02-01'),
+        contract_date: d('2019-04-01'),
+        gravestoneInfo: {
+          establishment_deadline: d('2020-01-01'),
+          establishment_date: null,
+        },
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

新移行コード（PR#342 以降の step05）は `permit_date=start_date=contract_date` を全行に投入し、建立期限/建立日（establishment）は `GravestoneInfo` へ正しく入れる。

この新コードで移行した DB に対して `backfill-konryu-establishment` を実行すると:

1. **（medium）契約日の捏造**: 旧候補条件 `OR[permit_date not null, start_date not null]` に全契約日有り行が該当し、安全ガード（establishment 未投入）も素通りして `?? t.permit_date` で `contract_date` を `establishment_deadline`/`establishment_date` へ移送＝**建立期限・建立日に契約日を捏造**していた。
2. **（low）代理投入の取りこぼし**: `konryu_kigen/konryu_date` が両方 null だった行（`permit_date=start_date=null`）は候補にすら入らず、契約日の代理投入が行われず本番で「許可日が入る行」と「未登録の行」が混在していた。

## 変更内容

- **ガード(1) 追加**（捏造防止）: `permit_date` と `start_date` が両方 `contract_date` と一致する行（= 新移行コード適用済み or 本スクリプト処理済み）をパス1対象から除外。純関数 `isPass1Target` / `sameDate` に切り出し。
- **パス2 追加**（代理投入補完 / #390 low）: `legacy_grave_cd != null AND deleted_at = null AND permit_date = null AND start_date = null AND contract_date != null` の行へ `permit_date/start_date = contract_date` を投入（establishment 非干渉・冪等）。
- ヘッダに「**新移行コード移行済み DB には不要・実行禁止**」を明記。
- `require.main` ガードで import 時の自動実行を抑止し、純関数の回帰テストを追加。

## 本番反映

本番が**新移行コードで投入済み**なら:
- パス1は捏造を起こさず（新マッピング行は全除外）、is no-op。
- パス2が「許可日/開始日が未投入のまま残った行」を補完する。

```
npx ts-node scripts/backfill-konryu-establishment.ts          # dry-run（パス1/パス2 件数確認）
npx ts-node scripts/backfill-konryu-establishment.ts --apply  # 実投入
```

パス2の補完が運用作業として残る可能性があるため `Refs #390`（自動クローズしない）。dry-run で件数を確認のうえ判断してください。

## 検証

- `npm test -- tests/scripts/backfill-konryu-establishment.test.ts` ✅ 8 passed
- `npx tsc --noEmit` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)