### PR TITLE
fix(billings): 管理料Billing自動生成の冪等判定をレンジ被覆へ拡張 (Closes #391)

### DIFF
--- a/scripts/generate-management-fee-billings.ts
+++ b/scripts/generate-management-fee-billings.ts
@@ -11,7 +11,9 @@
  *   npm run billing:generate-management -- --year=2026 --apply --include-prepaid
  *     （複数年一括前納の契約も含める。既定は二重請求回避でスキップ）
  *
- * 冪等: 同一区画・management_fee・同一 use_start_year の請求が既にあれば再実行でも作らない。
+ * 冪等（#391）: 同一区画・management_fee の既存請求が対象年をカバー（等値 or 前納レンジ被覆）
+ *   していれば再実行でも作らない。既存請求の use_start_year が NULL の区画は被覆判定不能のため
+ *   自動生成せず needsReview として報告する（要確認）。
  */
 import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
@@ -51,6 +53,9 @@ async function main(): Promise<void> {
         {
           ...result,
           createdPlotIds: `${result.createdPlotIds.length} 件（省略）`,
+          needsReviewPlotIds: `${result.needsReviewPlotIds.length} 件（先頭10件: ${result.needsReviewPlotIds
+            .slice(0, 10)
+            .join(', ')}）`,
         },
         null,
         2
@@ -64,6 +69,12 @@ async function main(): Promise<void> {
       console.log(
         `\n⚠️ 複数年一括前納の契約 ${result.skippedPrepaid} 件をスキップしました（二重請求回避）。` +
           ' 前納の次回請求年を確認のうえ、必要なら --include-prepaid で対象化してください。'
+      );
+    }
+    if (result.needsReview > 0) {
+      console.log(
+        `\n⚠️ 既存請求の use_start_year が NULL で対象年の被覆を判定できない契約 ${result.needsReview} 件を` +
+          ' 自動生成から除外しました（二重請求回避）。対象区画の請求年を手動確認のうえ必要なら個別起票してください。'
       );
     }
   } finally {

--- a/src/billings/managementFeeBillingService.ts
+++ b/src/billings/managementFeeBillingService.ts
@@ -7,7 +7,13 @@
  * になるため、対象年度の管理料 Billing を設定から冪等に生成する。
  *
  * 対象: contract_status=active かつ管理料設定(amount 解釈可)を持つ契約区画。
- * 冪等: 同一区画・同一カテゴリ(management_fee)・同一 use_start_year の請求が既にあればスキップ。
+ * 冪等（#391）: 同一区画・同一カテゴリ(management_fee)の既存請求が対象年を**カバー**していればスキップ。
+ *   - use_start_year == targetYear（年次の同一年）
+ *   - use_start_year <= targetYear <= use_end_year（5年/10年前納のレンジ被覆。レガシー移行請求は
+ *     use_start_year=2022, use_end_year=2026 のようにレンジを持つ — #196 実データ確認）
+ *   等値一致のみだと前納レンジを取り逃して支払済年度に二重請求してしまう（#391 の主因）。
+ * 要確認（#391）: 既存請求の use_start_year が NULL（年が判定不能）の区画は、対象年を含むか
+ *   機械判定できないため**自動生成せず** needsReview として別カウントに出す（二重請求の予防）。
  * 前納ガード: ManagementFee.billing_years > 1（5年/10年一括前納）は二重請求回避のため既定でスキップし
  *   ログに出す（前納の次回請求年判定は業務確認が必要なため、既定では自動起票しない）。
  *   includePrepaid=true で対象に含められる。
@@ -37,7 +43,46 @@ export interface GenerateManagementBillingResult {
   skippedPrepaid: number;
   skippedNoAmount: number;
   skippedNoCustomer: number;
+  /** 既存請求の use_start_year が NULL で対象年の被覆を判定できず、自動生成を見送った区画数（#391） */
+  needsReview: number;
   createdPlotIds: string[];
+  /** 要確認（use_start_year NULL の既存請求あり）区画 ID（#391） */
+  needsReviewPlotIds: string[];
+}
+
+/** 既存管理料請求の年情報（被覆判定に必要な最小限） */
+export interface ExistingMgmtBilling {
+  use_start_year: number | null;
+  use_end_year: number | null;
+}
+
+export type ExistingCoverage = 'covered' | 'needs_review' | 'none';
+
+/**
+ * 既存の管理料請求群が targetYear をカバーしているか判定する（DB 非依存の純関数 / #391）。
+ *
+ *  - covered: use_start_year == targetYear、または
+ *             use_start_year <= targetYear <= use_end_year（前納レンジ被覆）の請求がある。
+ *  - needs_review: 上記カバーは無いが、use_start_year が NULL の請求が1件以上ある
+ *                  （対象年を含むか機械判定できない → 自動生成を見送り要確認に回す）。
+ *  - none: カバーも NULL 請求も無い → 新規生成対象。
+ */
+export function existingBillingCoverage(
+  billings: ExistingMgmtBilling[],
+  targetYear: number
+): ExistingCoverage {
+  let hasNullYear = false;
+  for (const b of billings) {
+    if (b.use_start_year == null) {
+      hasNullYear = true;
+      continue;
+    }
+    if (b.use_start_year === targetYear) return 'covered';
+    // 前納レンジ被覆: 終了年が無ければ開始年単年とみなす。
+    const endYear = b.use_end_year ?? b.use_start_year;
+    if (b.use_start_year <= targetYear && endYear >= targetYear) return 'covered';
+  }
+  return hasNullYear ? 'needs_review' : 'none';
 }
 
 /** 文字列の管理料(VarChar)から金額intを取り出す。数字以外を除去。0/解釈不能は null。 */
@@ -76,7 +121,9 @@ export async function generateManagementFeeBillings(
     skippedPrepaid: 0,
     skippedNoAmount: 0,
     skippedNoCustomer: 0,
+    needsReview: 0,
     createdPlotIds: [],
+    needsReviewPlotIds: [],
   };
 
   const contracts = await prisma.contractPlot.findMany({
@@ -94,14 +141,14 @@ export async function generateManagementFeeBillings(
         where: { deleted_at: null, role: { in: ['contractor', 'applicant'] } },
         select: { role: true, customer_id: true },
       },
-      // 対象年度の管理料請求が既にあるか（冪等判定）
+      // 管理料の既存請求（冪等判定）。等値だけだと前納レンジ／use_start_year NULL を
+      // 取り逃すため、active な管理料請求を全件取得しコード側でレンジ被覆を判定する（#391）。
       billings: {
         where: {
           deleted_at: null,
           category: BillingCategory.management_fee,
-          use_start_year: targetYear,
         },
-        select: { id: true },
+        select: { use_start_year: true, use_end_year: true },
       },
     },
   });
@@ -117,9 +164,16 @@ export async function generateManagementFeeBillings(
       continue;
     }
 
-    // 冪等: 対象年度の管理料請求が既にあればスキップ
-    if (c.billings.length > 0) {
+    // 冪等（#391）: 既存の管理料請求が対象年をカバー（等値 or 前納レンジ被覆）していればスキップ。
+    // use_start_year NULL の既存請求しか無い区画は被覆判定不能 → 自動生成せず要確認に回す。
+    const coverage = existingBillingCoverage(c.billings, targetYear);
+    if (coverage === 'covered') {
       result.skippedExisting++;
+      continue;
+    }
+    if (coverage === 'needs_review') {
+      result.needsReview++;
+      result.needsReviewPlotIds.push(c.id);
       continue;
     }
 

--- a/tests/billings/managementFeeBillingService.test.ts
+++ b/tests/billings/managementFeeBillingService.test.ts
@@ -5,6 +5,7 @@ jest.mock('../../src/plots/services/paymentStatusService', () => ({
 
 import {
   generateManagementFeeBillings,
+  existingBillingCoverage,
   parseFeeAmount,
   parseBillingMonth,
   parseBillingYears,
@@ -19,7 +20,7 @@ interface MockContract {
     billing_years: string | null;
   } | null;
   saleContractRoles: Array<{ role: string; customer_id: string }>;
-  billings: Array<{ id: string }>;
+  billings: Array<{ use_start_year: number | null; use_end_year: number | null }>;
 }
 
 const buildContract = (over: Partial<MockContract> = {}): MockContract => ({
@@ -64,6 +65,52 @@ describe('parse helpers (#196)', () => {
   });
 });
 
+describe('existingBillingCoverage (#391)', () => {
+  it('use_start_year 等値は covered', () => {
+    expect(existingBillingCoverage([{ use_start_year: 2026, use_end_year: 2026 }], 2026)).toBe(
+      'covered'
+    );
+  });
+  it('前納レンジに含まれれば covered', () => {
+    expect(existingBillingCoverage([{ use_start_year: 2022, use_end_year: 2026 }], 2026)).toBe(
+      'covered'
+    );
+    expect(existingBillingCoverage([{ use_start_year: 2022, use_end_year: 2026 }], 2024)).toBe(
+      'covered'
+    );
+  });
+  it('use_end_year が NULL なら開始年単年として扱う', () => {
+    expect(existingBillingCoverage([{ use_start_year: 2026, use_end_year: null }], 2026)).toBe(
+      'covered'
+    );
+    expect(existingBillingCoverage([{ use_start_year: 2025, use_end_year: null }], 2026)).toBe(
+      'none'
+    );
+  });
+  it('use_start_year NULL のみは needs_review', () => {
+    expect(existingBillingCoverage([{ use_start_year: null, use_end_year: null }], 2026)).toBe(
+      'needs_review'
+    );
+  });
+  it('カバーする請求があれば NULL 請求が混在しても covered を優先', () => {
+    expect(
+      existingBillingCoverage(
+        [
+          { use_start_year: null, use_end_year: null },
+          { use_start_year: 2022, use_end_year: 2026 },
+        ],
+        2026
+      )
+    ).toBe('covered');
+  });
+  it('該当もNULLも無ければ none', () => {
+    expect(existingBillingCoverage([{ use_start_year: 2020, use_end_year: 2024 }], 2026)).toBe(
+      'none'
+    );
+    expect(existingBillingCoverage([], 2026)).toBe('none');
+  });
+});
+
 describe('generateManagementFeeBillings (#196)', () => {
   it('対象契約に対象年度の管理料Billingを生成する', async () => {
     const { prisma, billingCreate } = buildPrisma([buildContract()]);
@@ -85,12 +132,50 @@ describe('generateManagementFeeBillings (#196)', () => {
   });
 
   it('対象年度の管理料Billingが既にあれば冪等スキップ', async () => {
-    const { prisma, billingCreate } = buildPrisma([buildContract({ billings: [{ id: 'b0' }] })]);
+    const { prisma, billingCreate } = buildPrisma([
+      buildContract({ billings: [{ use_start_year: 2026, use_end_year: 2026 }] }),
+    ]);
     const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
 
     expect(r.created).toBe(0);
     expect(r.skippedExisting).toBe(1);
     expect(billingCreate).not.toHaveBeenCalled();
+  });
+
+  it('前納レンジ(use_start_year=2022, use_end_year=2026)が対象年を含めば二重請求しない(#391)', async () => {
+    // レガシー移行の5/10年前納請求。targetYear=2026 は等値一致しないが、レンジに含まれる。
+    const { prisma, billingCreate } = buildPrisma([
+      buildContract({ billings: [{ use_start_year: 2022, use_end_year: 2026 }] }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(0);
+    expect(r.skippedExisting).toBe(1);
+    expect(billingCreate).not.toHaveBeenCalled();
+  });
+
+  it('既存請求の use_start_year が NULL の区画は自動生成せず needsReview に回す(#391)', async () => {
+    const { prisma, billingCreate } = buildPrisma([
+      buildContract({ billings: [{ use_start_year: null, use_end_year: null }] }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(0);
+    expect(r.needsReview).toBe(1);
+    expect(r.needsReviewPlotIds).toEqual(['cp1']);
+    expect(billingCreate).not.toHaveBeenCalled();
+  });
+
+  it('前納レンジが対象年より過去で終わっていれば新規生成する(#391)', async () => {
+    // 2020〜2024 の前納が終わり、2026 は未請求 → 生成対象。
+    const { prisma, billingCreate } = buildPrisma([
+      buildContract({ billings: [{ use_start_year: 2020, use_end_year: 2024 }] }),
+    ]);
+    const r = await generateManagementFeeBillings(prisma, { targetYear: 2026, apply: true });
+
+    expect(r.created).toBe(1);
+    expect(r.skippedExisting).toBe(0);
+    expect(billingCreate).toHaveBeenCalledTimes(1);
   });
 
   it('複数年一括前納(billing_years>1)は既定でスキップする', async () => {


### PR DESCRIPTION
## 概要

管理料 Billing 自動生成バッチの既存請求検知が `use_start_year: targetYear` の**等値一致のみ**だったため、年レンジ請求（前納）や `use_start_year` NULL の既存請求を取り逃し、支払済年度に二重請求を生成し得た。

- レガシー移行請求（step10-billing）は 5/10 年前納で `use_start_year=2022, use_end_year=2026` のレンジを持つ（#196 実データ確認）。`targetYear=2026` で実行すると `use_start_year≠2026` のため skip されず、`billing_years` が NULL/1 の契約は前納ガードもすり抜けて新規 `Billing(billed)` を作成していた。
- `use_start_year` は NULL 許容（`billingValidation.ts` optional / schema `Int?`）でも同様にすり抜けた。

## 変更内容

- 純関数 `existingBillingCoverage(billings, targetYear)` を追加し、被覆判定を拡張:
  - `use_start_year == targetYear` → covered
  - `use_start_year <= targetYear <= use_end_year`（前納レンジ被覆）→ covered（`use_end_year` NULL は開始年単年扱い）
  - 上記カバー無し + `use_start_year` NULL の請求あり → **needs_review**（被覆判定不能 → 自動生成せず別カウント）
  - それ以外 → none（新規生成）
- Prisma 側 `billings` フィルタを「対象年等値」から「active な管理料請求全件取得」に変更し、コード側でレンジ被覆を判定。
- `use_start_year` NULL の既存請求を持つ区画は `skippedExisting` でなく **`needsReview`** として `needsReviewPlotIds` に出し、二重請求を予防。
- 生成バッチに needsReview の警告出力を追加。
- 回帰テスト追加（前納レンジ被覆 / NULL 年要確認 / 過去前納の新規生成 / 純関数の網羅）。

## 本番反映

**デプロイのみ**でOK。既存の格納データ補正は不要です。

- 本バッチは自動実行されず、手動（`npm run billing:generate-management -- --year=YYYY [--apply]`）でのみ走ります。今回の修正は**今後のバッチ実行時の二重請求を防ぐコードロジック修正**で、既に格納済みのデータを壊す問題ではありません。
- 次回バッチ実行時は、まず `--apply` 無しの dry-run で `created` / `skippedExisting` / `needsReview` を確認してから本投入してください。`needsReview` 件（既存請求の `use_start_year` NULL）が出たら、対象区画の請求年を手動確認のうえ個別対応してください。

スクリプト実行は不要なので `Closes #391`。

## 検証

- `npm test -- tests/billings/managementFeeBillingService.test.ts` ✅ 20 passed
- `npx tsc --noEmit` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)