### PR TITLE
fix(collective-burials): 一括投入後に埋葬者実数へ再同期 (#396)

### DIFF
--- a/src/collective-burials/collectiveBurialImportService.ts
+++ b/src/collective-burials/collectiveBurialImportService.ts
@@ -10,7 +10,7 @@
  * 値の意味は台帳UIの合祀トグル（createCollectiveBurial）と揃える。
  */
 import { PrismaClient } from '@prisma/client';
-import { resolveBillingScheduledDate } from './utils';
+import { resolveBillingScheduledDate, updateCollectiveBurialCount } from './utils';
 
 export interface CollectiveBurialImportRow {
   /** 区画番号（display_number 優先・無ければ plot_number） */
@@ -93,6 +93,11 @@ function validateRow(row: CollectiveBurialImportRow): string | null {
     (!Number.isInteger(row.currentBurialCount) || row.currentBurialCount < 0)
   )
     return '現在埋葬数は0以上の整数で指定してください';
+  // 現在埋葬数が上限を超える行は要確認リストへ回す（#396）。
+  // 投入後に updateCollectiveBurialCount で実数へ再同期するが、入力時点の
+  // 整合性チェックとして上限超過を検出しておく。
+  if (row.currentBurialCount !== undefined && row.currentBurialCount > row.burialCapacity)
+    return '現在埋葬数が埋葬上限数を超えています';
   return null;
 }
 
@@ -157,6 +162,8 @@ export async function importCollectiveBurials(
       resolved.contract_date,
       row.validityPeriodYears
     );
+    // CSV の現在埋葬数は初期値として書くが、apply 時は直後の
+    // updateCollectiveBurialCount で BuriedPerson 実数に再同期される（#396）。
     const currentBurialCount = row.currentBurialCount ?? 0;
     const data = {
       burial_capacity: row.burialCapacity,
@@ -181,6 +188,12 @@ export async function importCollectiveBurials(
           data: { contract_plot_id: contractPlotId, ...data },
         });
       }
+      // 実埋葬者（BuriedPerson）の実数から current_burial_count と capacity_reached_date を
+      // 再同期する（#281 と同じ整合ルール・#396）。本番には移行済み埋葬者を持つ有効区画が
+      // 多数あり、CSV の現在埋葬数（省略時0）をそのまま残すと「count=0 なのに埋葬者一覧に
+      // 実データが並ぶ」「count>=capacity でも上限到達日 null で一覧に出ない」矛盾が生じ、
+      // 次に UI で埋葬者編集した時点で CSV 値が黙って実数に上書きされる。
+      await updateCollectiveBurialCount(prisma, contractPlotId);
     }
 
     if (willUpdate) {

--- a/tests/collective-burials/collectiveBurialImportService.test.ts
+++ b/tests/collective-burials/collectiveBurialImportService.test.ts
@@ -1,11 +1,21 @@
 jest.mock('../../src/collective-burials/utils', () => ({
   resolveBillingScheduledDate: jest.fn(() => null),
+  updateCollectiveBurialCount: jest.fn(() => Promise.resolve(null)),
 }));
 
 import {
   importCollectiveBurials,
   CollectiveBurialImportRow,
 } from '../../src/collective-burials/collectiveBurialImportService';
+import { updateCollectiveBurialCount } from '../../src/collective-burials/utils';
+
+const mockedSync = updateCollectiveBurialCount as jest.MockedFunction<
+  typeof updateCollectiveBurialCount
+>;
+
+beforeEach(() => {
+  mockedSync.mockClear();
+});
 
 const baseRow = (over: Partial<CollectiveBurialImportRow> = {}): CollectiveBurialImportRow => ({
   plotNumber: '樹林-1',
@@ -131,5 +141,63 @@ describe('importCollectiveBurials (#359)', () => {
 
     expect(r.created).toBe(1);
     expect(create).not.toHaveBeenCalled();
+  });
+
+  // #396: 投入後に埋葬者実数へ再同期する（合祀数⇔実数の矛盾を再導入しない）
+  it('作成後に updateCollectiveBurialCount で実数へ再同期する', async () => {
+    const { prisma } = buildPrisma({
+      contractPlots: [{ id: 'cp1', contract_date: null }],
+      existing: null,
+    });
+    await importCollectiveBurials(prisma, [baseRow({ currentBurialCount: 0 })], { apply: true });
+
+    expect(mockedSync).toHaveBeenCalledWith(prisma, 'cp1');
+  });
+
+  it('更新（--overwrite）後も updateCollectiveBurialCount で再同期する', async () => {
+    const { prisma } = buildPrisma({
+      contractPlots: [{ id: 'cp1', contract_date: null }],
+      existing: { id: 'cb1', deleted_at: null },
+    });
+    await importCollectiveBurials(prisma, [baseRow()], { apply: true, overwrite: true });
+
+    expect(mockedSync).toHaveBeenCalledWith(prisma, 'cp1');
+  });
+
+  it('復活更新後も updateCollectiveBurialCount で再同期する', async () => {
+    const { prisma } = buildPrisma({
+      contractPlots: [{ id: 'cp1', contract_date: null }],
+      existing: { id: 'cb1', deleted_at: new Date('2026-01-01') },
+    });
+    await importCollectiveBurials(prisma, [baseRow()], { apply: true });
+
+    expect(mockedSync).toHaveBeenCalledWith(prisma, 'cp1');
+  });
+
+  it('dry-run(apply=false)では再同期を呼ばない', async () => {
+    const { prisma } = buildPrisma({
+      contractPlots: [{ id: 'cp1', contract_date: null }],
+      existing: null,
+    });
+    await importCollectiveBurials(prisma, [baseRow()], { apply: false });
+
+    expect(mockedSync).not.toHaveBeenCalled();
+  });
+
+  it('現在埋葬数が上限を超える行は invalid（要確認）として弾く', async () => {
+    const { prisma, create } = buildPrisma({
+      contractPlots: [{ id: 'cp1', contract_date: null }],
+      existing: null,
+    });
+    const r = await importCollectiveBurials(
+      prisma,
+      [baseRow({ burialCapacity: 2, currentBurialCount: 3 })],
+      { apply: true }
+    );
+
+    expect(r.invalid).toBe(1);
+    expect(r.results[0]).toMatchObject({ outcome: 'invalid' });
+    expect(create).not.toHaveBeenCalled();
+    expect(mockedSync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 概要

合祀の一括投入（CSV import / `importCollectiveBurials`）が #281 で確立した「合祀数 ⇔ 埋葬者実数」の再同期を行わず、#378 の一括投入実施時に矛盾を再導入する構造バグを修正する。

## 根本原因

`src/collective-burials/collectiveBurialImportService.ts`

UI 合祀登録（`createCollectiveBurial`）は作成・復活後に必ず `updateCollectiveBurialCount` で `BuriedPerson` 実数から `current_burial_count` / `capacity_reached_date` を再同期する（#281）。しかし一括投入は CSV 値をそのまま `current_burial_count` に書き、update パスで `capacity_reached_date: null` を無条件設定し、同期を行っていなかった。

本番には移行済み `BuriedPerson` を持つ有効区画が多数あり、#378 の一括投入で CSV を適用すると:
1. CSV 現在埋葬数（省略時0）と実数が食い違う
2. `count >= capacity` でも上限到達日 null で請求/一覧に出ない
3. `currentBurialCount > capacity` も無検証で通る

→ 次に UI で埋葬者編集した時点で CSV 値が黙って実数に上書きされる。

## 修正内容

- apply 時、create / update / 復活の各パス直後に `updateCollectiveBurialCount(prisma, contractPlotId)` を呼び、実数・到達日を再同期（UI 登録と同じ整合ルール）。
- `validateRow` に `currentBurialCount <= burialCapacity` 検証を追加し、上限超過行は `invalid`（要確認リスト）へ回す。
- 再同期（create / overwrite / 復活 / dry-run 不呼び出し）と上限超過の回帰テストを追加（計 17 → 全 pass）。

## 検証

- `npm test -- tests/collective-burials/collectiveBurialImportService.test.ts tests/scripts/import-collective-burials-csv.test.ts` 全 pass
- `npx tsc --noEmit` clean
- `npm run lint` clean

## 本番反映

コード修正のみ（DB 変更なし）。本修正は #378（合祀一括投入の運用実施・業務回答 Q34 待ち）で投入スクリプトを実行する際に効く。デプロイ反映のみで追加作業なし。

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)