### PR TITLE
fix: 確立済み修正パターンの横展開漏れ4件を一掃 (#394)

### DIFF
--- a/scripts/backfill-legacy-value-cleanup.ts
+++ b/scripts/backfill-legacy-value-cleanup.ts
@@ -8,6 +8,7 @@
  *     さらに #355 backfill が本番に残した旧センチネル 'unknown' を空文字へ補正（#375）。
  *  3. buried_persons.religion = 'legacy-shuuha-*' → null（宗派マスタ不要確定）
  *  4. construction_infos.contractor = 'legacy-gyousha-0'（=未設定）→ null + 業者マスタ無効化（#334）
+ *  5. buried_persons.chief_mourner_relationship = 'legacy-zokugara-*' → 続柄マスタ名 or null（#394）
  *
  * いずれもアプリ作成データには影響しない（0/センチネル/生int は移行由来のみ）。
  *
@@ -120,6 +121,45 @@ async function backfillGyousha(): Promise<Record<string, number>> {
   };
 }
 
+async function backfillChiefMournerRelationship(): Promise<Record<string, unknown>> {
+  // step08（旧版）が書き込んだ buried_persons.chief_mourner_relationship の
+  // 'legacy-zokugara-${moshu_zokugara}' センチネルを続柄マスタ名へ解決する（#394）。
+  // family_contacts.relationship と同じ resolver を共有。未解決/'0' は空文字 → nullable 列なので null へ。
+  const SENTINEL_PREFIX = 'legacy-zokugara-';
+  const nameMap = await loadRelationshipNameMap(prisma);
+
+  const groups = await prisma.buriedPerson.groupBy({
+    by: ['chief_mourner_relationship'],
+    where: { chief_mourner_relationship: { startsWith: SENTINEL_PREFIX } },
+    _count: { _all: true },
+  });
+
+  const plan = groups.map((g) => {
+    const from = g.chief_mourner_relationship!; // where 句で非null確定
+    const rawCode = from.slice(SENTINEL_PREFIX.length); // 'legacy-zokugara-13' → '13'
+    const resolved = resolveRelationship(rawCode, nameMap);
+    return {
+      from,
+      to: resolved === UNRESOLVED_RELATIONSHIP ? null : resolved,
+      count: g._count._all,
+    };
+  });
+
+  if (!APPLY) {
+    return { chief_mourner_relationship_groups: plan };
+  }
+
+  let updated = 0;
+  for (const p of plan) {
+    const r = await prisma.buriedPerson.updateMany({
+      where: { chief_mourner_relationship: p.from },
+      data: { chief_mourner_relationship: p.to },
+    });
+    updated += r.count;
+  }
+  return { updated, plan };
+}
+
 async function main(): Promise<void> {
   console.log(`[backfill legacy-value-cleanup] start (apply=${APPLY})`);
 
@@ -127,9 +167,21 @@ async function main(): Promise<void> {
   const relationship = await backfillRelationship();
   const religion = await backfillReligion();
   const gyousha = await backfillGyousha();
+  const chiefMournerRelationship = await backfillChiefMournerRelationship();
 
   console.log(
-    JSON.stringify({ apply: APPLY, directionPosition, relationship, religion, gyousha }, null, 2)
+    JSON.stringify(
+      {
+        apply: APPLY,
+        directionPosition,
+        relationship,
+        religion,
+        gyousha,
+        chiefMournerRelationship,
+      },
+      null,
+      2
+    )
   );
 }
 

--- a/scripts/legacy-migration/steps/08-buried-person.ts
+++ b/scripts/legacy-migration/steps/08-buried-person.ts
@@ -3,6 +3,7 @@ import type { RowDataPacket } from 'mysql2/promise';
 import { legacyQuery } from '../legacyDb';
 import { rebuildIdMap } from '../lib/id-map-loader';
 import { assertIdMapsReady } from '../lib/invariants';
+import { loadRelationshipNameMap, resolveRelationship } from '../lib/relationship-resolver';
 import { cleanStr, joinName, parseGender, parseLegacyDate } from '../transforms';
 import type { MigrationStep } from '../types';
 
@@ -45,6 +46,10 @@ export const stepBuriedPerson: MigrationStep = {
     // dry-run でも resume 用に再構築（読み取り専用・冪等、full dry-run では no-op）
     await rebuildIdMap(prisma, idMaps, 'contractPlot', logger);
     assertIdMapsReady('buriedPerson', idMaps, ['contractPlot']);
+
+    // 喪主続柄（moshu_zokugara）を続柄マスタ名へ解決するための対応表（#394）。
+    // family_contacts と同じ resolver を共有し、生int/未解決センチネルの露出を防ぐ。
+    const relationshipNameMap = await loadRelationshipNameMap(prisma);
 
     const rows = await legacyQuery<MaisouRow>(
       `SELECT maisou_cd, danka_cd, grave_cd, kaimyou, kaimyou_kana,
@@ -118,8 +123,13 @@ export const stepBuriedPerson: MigrationStep = {
           death_place: cleanStr(row.siboubasyo),
           cause_of_death: cleanStr(row.siin),
           chief_mourner_name: joinName(row.moshu_sei, row.moshu_mei),
+          // 続柄マスタ名へ解決（#394）。未解決/null は resolveRelationship が空文字を返すため
+          // `|| null` で nullable 列の「未設定」を null に統一する（旧 legacy-zokugara-* センチネル廃止）。
           chief_mourner_relationship:
-            row.moshu_zokugara != null ? `legacy-zokugara-${row.moshu_zokugara}` : null,
+            resolveRelationship(
+              row.moshu_zokugara != null ? String(row.moshu_zokugara) : '',
+              relationshipNameMap
+            ) || null,
           notes: cleanStr(row.note),
         },
       });

--- a/src/auth/authController.ts
+++ b/src/auth/authController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import prisma from '../db/prisma';
 import { getRequestLogger, logger } from '../utils/logger';
+import { isRateLimitError } from './isRateLimitError';
 
 // Cookie設定の定数
 // secure/sameSite は NODE_ENV ではなく実際の提供スキームに連動させる（#299）。
@@ -758,10 +759,7 @@ export const forgotPassword = async (req: Request, res: Response) => {
       // （実例: "For security purposes, you can only request this after N seconds."）、
       // 旧来の message.includes('rate limit') ではこの文言を取りこぼして「送信成功」を
       // 偽装していた（実際は1通も送られない）。status と文言の両方で判定する。
-      const isRateLimited =
-        error.status === 429 ||
-        /rate limit|you can only request this|too many requests/i.test(error.message);
-      if (isRateLimited) {
+      if (isRateLimitError(error)) {
         return res.status(429).json({
           success: false,
           error: {

--- a/src/auth/isRateLimitError.ts
+++ b/src/auth/isRateLimitError.ts
@@ -1,0 +1,33 @@
+/**
+ * Supabase 認証系エラーのレート制限判定（#371 / PR#372 の横展開・#394）
+ *
+ * Supabase のレート制限は HTTP 429 を返すが、文言は版・状況で変わる
+ * （実例: "For security purposes, you can only request this after N seconds."）。
+ * 旧来の `message.includes('rate limit')` ではこの文言を取りこぼし、
+ * クールダウン中なのに「rate_limit ではない」と誤判定して生英語メッセージを
+ * 400 で UI 露出させていた。status を主軸に、文言フォールバックを併用する。
+ *
+ * authController の forgot-password と同一の判定を共有するための共通ヘルパ。
+ */
+
+/**
+ * Supabase が返すエラー風オブジェクトの最小形。`@supabase/supabase-js` の
+ * `AuthError` は `status?: number` と `message: string` を持つ。
+ */
+export interface RateLimitCandidateError {
+  status?: number;
+  message?: string;
+}
+
+/**
+ * Supabase 認証エラーがレート制限由来かを判定する。
+ *
+ * @param error - Supabase の error オブジェクト（status / message を持つ）
+ * @returns レート制限なら true
+ */
+export const isRateLimitError = (error: RateLimitCandidateError | null | undefined): boolean => {
+  if (!error) return false;
+  if (error.status === 429) return true;
+  const message = error.message ?? '';
+  return /rate limit|you can only request this|too many requests/i.test(message);
+};

--- a/src/collective-burials/utils.ts
+++ b/src/collective-burials/utils.ts
@@ -106,6 +106,10 @@ export const getBillingTargets = async (prisma: PrismaClient) => {
         lte: today, // 請求予定日が今日以前
       },
       deleted_at: null,
+      // 親契約が論理削除された孤児合祀（#358 以前の削除由来）を請求対象から除外する。
+      // getCollectiveBurialList/ById（layer2 ガード #361）と同じ不変条件を請求バッチ経路にも揃え、
+      // 削除済み契約の合祀が billed に遷移して「成功」レポートされるのを防ぐ。
+      contractPlot: { is: { deleted_at: null } },
     },
     include: {
       contractPlot: {

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -4,6 +4,8 @@
  */
 import { createClient, SupabaseClient, User } from '@supabase/supabase-js';
 
+import { isRateLimitError } from '../auth/isRateLimitError';
+
 // 環境変数
 const supabaseUrl = process.env['SUPABASE_URL'] || '';
 const supabaseServiceKey = process.env['SUPABASE_SERVICE_ROLE_KEY'] || '';
@@ -99,7 +101,7 @@ export const createSupabaseUser = async (
       if (error.message.includes('already registered')) {
         errorMessage = 'このメールアドレスは既にSupabaseに登録されています';
         errorCode = 'already_registered';
-      } else if (error.message.includes('rate limit')) {
+      } else if (isRateLimitError(error)) {
         errorMessage = '招待メールの送信制限に達しました。しばらく待ってから再試行してください';
         errorCode = 'rate_limit';
       }
@@ -290,7 +292,7 @@ export const resendInvitation = async (
       if (error.message.includes('already registered')) {
         errorMessage = 'このメールアドレスは既にSupabaseに登録されています';
         errorCode = 'already_registered';
-      } else if (error.message.includes('rate limit')) {
+      } else if (isRateLimitError(error)) {
         errorMessage = '招待メールの送信制限に達しました。しばらく待ってから再試行してください';
         errorCode = 'rate_limit';
       }
@@ -344,7 +346,7 @@ export const sendPasswordReset = async (
     if (error) {
       let errorMessage = error.message;
       let errorCode: InviteUserResult['errorCode'];
-      if (error.message.includes('rate limit')) {
+      if (isRateLimitError(error)) {
         errorMessage =
           'パスワード再設定メールの送信制限に達しました。しばらく待ってから再試行してください';
         errorCode = 'rate_limit';

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -29,6 +29,7 @@ import {
 } from '../../collective-burials/utils';
 import prisma from '../../db/prisma';
 import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
+import { assertAssignableCustomer } from '../services/assertAssignableCustomer';
 import {
   recordContractPlotCreated,
   recordCustomerCreated,
@@ -225,6 +226,11 @@ export async function createPlotCore(
   const createdRoles: { id: string; role: string; customer_id: string }[] = [];
   if (input.saleContract.roles && input.saleContract.roles.length > 0) {
     for (const roleData of input.saleContract.roles) {
+      // 既存顧客を指定した場合は解約者・論理削除顧客を契約者にできないようガード（#394）。
+      // customerId 未指定時はこの作成で生成した customer を使うため検証不要。
+      if (roleData.customerId) {
+        await assertAssignableCustomer(tx, roleData.customerId);
+      }
       const created = await tx.saleContractRole.create({
         data: {
           contract_plot_id: contractPlot.id,

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -31,6 +31,7 @@ import {
   updateCollectiveBurialCount,
   resolveBillingScheduledDate,
 } from '../../collective-burials/utils';
+import { assertAssignableCustomer } from '../services/assertAssignableCustomer';
 
 type Tx = Prisma.TransactionClient;
 
@@ -274,6 +275,8 @@ export async function updatePlotCore(
       if (!roleData.customerId) {
         throw new ValidationError('役割更新時は customerId が必須です');
       }
+      // 解約者・論理削除顧客を契約者にできないようガード（changeContractor と同一不変条件・#394）
+      await assertAssignableCustomer(tx, roleData.customerId);
 
       const created = await tx.saleContractRole.create({
         data: {

--- a/src/plots/services/assertAssignableCustomer.ts
+++ b/src/plots/services/assertAssignableCustomer.ts
@@ -1,0 +1,41 @@
+/**
+ * 契約役割（SaleContractRole）に割り当て可能な顧客かを検証する共通ガード（#394）
+ *
+ * 背景: changeContractor は新契約者に `deleted_at: null`（論理削除拒否）と
+ * `is_terminated` 拒否（解約者拒否）を実装している（#311/#318/#319）。一方
+ * updatePlot の roles 全件入替・createPlot/createPlotContract の roles 作成は
+ * customerId の存在チェックしかしておらず、/customers/terminated（viewer 可）で得た
+ * 解約者 UUID を roles に指定すると、解約者・論理削除顧客を active 契約の contractor に
+ * できてしまっていた。changeContractor と同じ不変条件をこのヘルパで共有する。
+ */
+import { Prisma } from '@prisma/client';
+
+import { ValidationError, NotFoundError } from '../../middleware/errorHandler';
+
+type Tx = Prisma.TransactionClient;
+
+/**
+ * 指定 customerId が契約役割に割り当て可能かを検証する。
+ * 違反時は例外を投げる（呼び出し側のトランザクションをロールバックさせる）。
+ *
+ * @param tx - Prisma トランザクションクライアント
+ * @param customerId - 役割に割り当てたい顧客 UUID
+ * @throws NotFoundError 顧客が存在しない / 論理削除済み
+ * @throws ValidationError 解約済み（終了）顧客
+ */
+export const assertAssignableCustomer = async (tx: Tx, customerId: string): Promise<void> => {
+  const customer = await tx.customer.findUnique({
+    where: { id: customerId },
+    select: { id: true, deleted_at: true, is_terminated: true },
+  });
+
+  // 論理削除済み顧客は契約者に指定不可（changeContractor の deleted_at: null と整合）
+  if (!customer || customer.deleted_at !== null) {
+    throw new NotFoundError('指定された顧客が見つかりません');
+  }
+
+  // 終了顧客（is_terminated、del_flg=2 由来 #129）は契約者に指定不可
+  if (customer.is_terminated) {
+    throw new ValidationError('解約済み（終了）顧客は契約者に指定できません');
+  }
+};

--- a/tests/auth/isRateLimitError.test.ts
+++ b/tests/auth/isRateLimitError.test.ts
@@ -1,0 +1,32 @@
+import { isRateLimitError } from '../../src/auth/isRateLimitError';
+
+describe('isRateLimitError (#394 / #371・PR#372 横展開)', () => {
+  it('status 429 をレート制限と判定する', () => {
+    expect(isRateLimitError({ status: 429, message: 'whatever' })).toBe(true);
+  });
+
+  it('Supabase のクールダウン文言（rate limit 非含有）も取りこぼさない', () => {
+    // 旧 `message.includes('rate limit')` がすり抜けていた実例の文言
+    expect(
+      isRateLimitError({
+        message: 'For security purposes, you can only request this after 35 seconds.',
+      })
+    ).toBe(true);
+  });
+
+  it('"rate limit" / "too many requests" 文言も判定する（大文字小文字非依存）', () => {
+    expect(isRateLimitError({ message: 'Email rate limit exceeded' })).toBe(true);
+    expect(isRateLimitError({ message: 'Too Many Requests' })).toBe(true);
+  });
+
+  it('レート制限と無関係なエラーは false', () => {
+    expect(isRateLimitError({ status: 400, message: 'invalid email' })).toBe(false);
+    expect(isRateLimitError({ message: 'already registered' })).toBe(false);
+  });
+
+  it('null / undefined / 空オブジェクトは false', () => {
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+    expect(isRateLimitError({})).toBe(false);
+  });
+});

--- a/tests/plots/assertAssignableCustomer.test.ts
+++ b/tests/plots/assertAssignableCustomer.test.ts
@@ -1,0 +1,36 @@
+import { assertAssignableCustomer } from '../../src/plots/services/assertAssignableCustomer';
+import { ValidationError, NotFoundError } from '../../src/middleware/errorHandler';
+
+describe('assertAssignableCustomer (#394 / #311・#318・#319 ガード共有)', () => {
+  const makeTx = (customer: unknown) => {
+    const findUnique = jest.fn().mockResolvedValue(customer);
+    return { tx: { customer: { findUnique } } as never, findUnique };
+  };
+
+  it('有効な顧客（deleted_at:null / is_terminated:false）は通過する', async () => {
+    const { tx } = makeTx({ id: 'c-1', deleted_at: null, is_terminated: false });
+    await expect(assertAssignableCustomer(tx, 'c-1')).resolves.toBeUndefined();
+  });
+
+  it('存在しない顧客は NotFoundError', async () => {
+    const { tx } = makeTx(null);
+    await expect(assertAssignableCustomer(tx, 'missing')).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('論理削除済み顧客は NotFoundError（changeContractor の deleted_at:null と整合）', async () => {
+    const { tx } = makeTx({ id: 'c-2', deleted_at: new Date(), is_terminated: false });
+    await expect(assertAssignableCustomer(tx, 'c-2')).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('解約済み（終了）顧客は ValidationError で契約者指定を拒否', async () => {
+    const { tx } = makeTx({ id: 'c-3', deleted_at: null, is_terminated: true });
+    await expect(assertAssignableCustomer(tx, 'c-3')).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('割り当て可否は id で 1 回だけ問い合わせる', async () => {
+    const { tx, findUnique } = makeTx({ id: 'c-1', deleted_at: null, is_terminated: false });
+    await assertAssignableCustomer(tx, 'c-1');
+    expect(findUnique).toHaveBeenCalledTimes(1);
+    expect(findUnique.mock.calls[0][0]).toMatchObject({ where: { id: 'c-1' } });
+  });
+});

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -46,6 +46,7 @@ const mockPrisma: any = {
   customer: {
     create: jest.fn(),
     update: jest.fn(),
+    findUnique: jest.fn(),
   },
   workInfo: {
     create: jest.fn(),
@@ -233,6 +234,13 @@ describe('Plot Controller (ContractPlot Model)', () => {
     mockPrisma.$transaction.mockImplementation((callback: any) =>
       Promise.resolve(callback(mockPrisma))
     );
+    // roles 入替/作成経路の assertAssignableCustomer ガード（#394）はデフォルトで
+    // 割り当て可能な顧客（論理削除なし・未解約）を返す。拒否ケースは個別テストで上書き。
+    mockPrisma.customer.findUnique.mockResolvedValue({
+      id: 'c-assignable',
+      deleted_at: null,
+      is_terminated: false,
+    });
   });
 
   describe('getPlots', () => {
@@ -1761,6 +1769,49 @@ describe('Plot Controller (ContractPlot Model)', () => {
       );
       expect(mockPrisma.saleContractRole.create).toHaveBeenCalledTimes(2);
       expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('roles 入替で解約済み顧客を契約者指定すると拒否し role を作成しない (#394)', async () => {
+      const mockExistingPlot = {
+        id: 'cp1',
+        physical_plot_id: 'pp1',
+        contract_area_sqm: new Prisma.Decimal(3.6),
+        physicalPlot: { id: 'pp1', area_sqm: new Prisma.Decimal(7.2) },
+        saleContractRoles: [
+          {
+            id: 'scr1',
+            role: 'contractor',
+            customer: { id: 'c1', workInfo: null },
+            customer_id: 'c1',
+            deleted_at: null,
+          },
+        ],
+        usageFee: null,
+        managementFee: null,
+      };
+
+      mockPrisma.contractPlot.findUnique.mockResolvedValue(mockExistingPlot);
+      mockPrisma.contractPlot.findMany.mockResolvedValue([]);
+      mockPrisma.saleContractRole.findMany.mockResolvedValue([]);
+      mockPrisma.saleContractRole.updateMany.mockResolvedValue({ count: 0 });
+      // 指定 customerId は解約済み（is_terminated）→ assertAssignableCustomer が拒否する
+      mockPrisma.customer.findUnique.mockResolvedValue({
+        id: 'terminated-1',
+        deleted_at: null,
+        is_terminated: true,
+      });
+
+      mockRequest.params = { id: 'cp1' };
+      mockRequest.body = {
+        saleContract: {
+          roles: [{ role: 'contractor', customerId: 'terminated-1' }],
+        },
+      };
+
+      await updatePlot(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockPrisma.saleContractRole.create).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/scripts/legacy-migration/steps/idempotency.test.ts
+++ b/tests/scripts/legacy-migration/steps/idempotency.test.ts
@@ -97,6 +97,8 @@ describe('移行ステップの冪等性 (#220)', () => {
         create: buriedPersonCreate,
         findUnique: jest.fn().mockResolvedValue({ id: 'bp-existing', legacy_maisou_cd: 7 }),
       },
+      // step08 は喪主続柄を続柄マスタ名へ解決するため findMany を参照する（#394）
+      relationshipMaster: { findMany: jest.fn().mockResolvedValue([]) },
     } as unknown as PrismaClient;
 
     mockedLegacyQuery.mockResolvedValueOnce([

--- a/tests/utils/collectiveBurialUtils.test.ts
+++ b/tests/utils/collectiveBurialUtils.test.ts
@@ -300,6 +300,8 @@ describe('collectiveBurialUtils', () => {
       expect(callArgs.where.billing_status).toBe('pending');
       expect(callArgs.where.billing_scheduled_date.lte).toBeInstanceOf(Date);
       expect(callArgs.where.deleted_at).toBeNull();
+      // 親契約が論理削除された孤児合祀を請求バッチ経路でも除外する（layer2 ガード横展開・#394）
+      expect(callArgs.where.contractPlot).toEqual({ is: { deleted_at: null } });
       expect(callArgs).toMatchObject({
         include: {
           contractPlot: {


### PR DESCRIPTION
## 概要

過去PRで確立した修正パターンが別経路へ横展開されていない「直し漏れ」4件を、共通ヘルパ抽出を伴って一掃（#394）。

| # | 内容 | 出典 |
|---|------|------|
| (1) | Supabase レート制限判定を `isRateLimitError`（status 429 主軸＋文言フォールバック）に統一。`createSupabaseUser`/`resendInvitation`/`sendPasswordReset` の旧 `includes('rate limit')` 3箇所＋forgot-password が共有。クールダウン文言の取りこぼし（送信成功偽装）を解消 | #371 / PR#372 |
| (2) | 合祀請求バッチ `getBillingTargets` に親契約 `deleted_at` ガード追加。孤児合祀が billed に遷移する漏れを塞ぐ | #358 / PR#361 layer2 |
| (3) | 喪主続柄 `legacy-zokugara-*` センチネル廃止。`step08` を `resolveRelationship` に統一、`backfill-legacy-value-cleanup` に補正セクション追加 | #340 |
| (4) | roles 入替/作成経路に `assertAssignableCustomer` ガード導入。解約者・論理削除顧客の契約者指定を `updatePlot`/`createPlot` でも拒否 | #318 / #319 |

根本対策として (1) `src/auth/isRateLimitError.ts`、(4) `src/plots/services/assertAssignableCustomer.ts` を共通ヘルパとして抽出。

## テスト

`isRateLimitError` 5件 / `assertAssignableCustomer` 5件 / `getBillingTargets` ガード1件 / `updatePlot` 解約者拒否1件 を追加。関連テスト全 pass（plotController 66 / collectiveBurialUtils / authController）、`npx tsc --noEmit`・`npm run lint` clean。

## 本番反映

(1)(2)(4) は **デプロイのみ**。(3) はデプロイに加え、既存の `legacy-zokugara-*` センチネル（本番 buried_persons）を消すため `scripts/backfill-legacy-value-cleanup.ts --apply` の実行が必要（#355 の legacy-value-cleanup 運用ステップに新セクションが相乗り。現状 UI 非露出のため緊急度は低）。

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)