### PR TITLE
refactor: inscription を廃止し契約備考へ一本化

### DIFF
--- a/prisma/migrations/20260705120000_drop_contract_plot_inscription/migration.sql
+++ b/prisma/migrations/20260705120000_drop_contract_plot_inscription/migration.sql
@@ -1,0 +1,18 @@
+-- 碑文（inscription）を廃止し、契約備考（notes）へ一本化する（システム確認 項目②）。
+-- 業務要望: 「碑文」は項目として不要。今まで碑文に入れていた情報は備考へ移す。
+-- 墓誌(gravestone_inscription) は別物のため対象外（残す）。
+
+-- 1) 既存の inscription 値を notes（契約備考）へ結合してデータを保全する。
+--    - notes が既に入っている場合は改行区切りで追記
+--    - notes が空/NULL の場合は inscription をそのまま設定
+--    - inscription が空/NULL の行は対象外（変更しない）
+UPDATE "contract_plots"
+SET "notes" = CASE
+  WHEN "notes" IS NOT NULL AND btrim("notes") <> ''
+    THEN "notes" || E'\n' || "inscription"
+  ELSE "inscription"
+END
+WHERE "inscription" IS NOT NULL AND btrim("inscription") <> '';
+
+-- 2) inscription カラムを削除する。
+ALTER TABLE "contract_plots" DROP COLUMN "inscription";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,7 +161,6 @@ model ContractPlot {
   // 契約区画情報
   contract_area_sqm    Decimal @db.Decimal(5, 2) // 契約された面積（例: 3.6, 1.8, 0.9）
   location_description String? @db.VarChar(200) // 物理区画内のどの位置か（例: 左半分、右側）
-  inscription          String? @db.VarChar(120) // 碑文（注意書きの一言・一覧表示用）。墓誌(GravestoneInfo)とは別物
 
   // 合祀設定（設定されている場合、この区画は合祀対象）
   burial_capacity       Int? // 埋葬上限人数（nullの場合は合祀対象外）

--- a/src/plots/controllers/createPlot.ts
+++ b/src/plots/controllers/createPlot.ts
@@ -156,7 +156,6 @@ export async function createPlotCore(
       contract_status: ContractStatus.active,
       contract_area_sqm: new Prisma.Decimal(input.contractPlot.contractAreaSqm),
       location_description: input.contractPlot.locationDescription || null,
-      inscription: input.contractPlot.inscription || null,
       burial_capacity: input.collectiveBurial?.burialCapacity ?? null,
       validity_period_years: input.collectiveBurial?.validityPeriodYears ?? null,
       contract_date: input.saleContract.contractDate

--- a/src/plots/controllers/getPlotById.ts
+++ b/src/plots/controllers/getPlotById.ts
@@ -126,7 +126,6 @@ export const getPlotById = async (
       startDate: contractPlot.start_date,
       uncollectedAmount: contractPlot.uncollected_amount,
       contractNotes: contractPlot.notes,
-      inscription: contractPlot.inscription,
 
       // レガシー由来の区分コード
       graveKind: contractPlot.grave_kind,

--- a/src/plots/controllers/getPlots.ts
+++ b/src/plots/controllers/getPlots.ts
@@ -412,9 +412,6 @@ export const getPlots = async (req: Request, res: Response, next: NextFunction) 
         contractNotes: contractPlot.notes || null,
         customerNotes: primaryCustomer?.notes || null,
 
-        // 碑文（注意書きの一言・一覧表示用）
-        inscription: contractPlot.inscription || null,
-
         // 埋葬者名（一覧表示用）
         buriedPersonNames:
           contractPlot.buriedPersons?.map((bp: { name: string }) => bp.name).filter(Boolean) || [],

--- a/src/plots/controllers/updatePlot.ts
+++ b/src/plots/controllers/updatePlot.ts
@@ -155,10 +155,6 @@ export async function updatePlotCore(
     if (input.contractPlot.locationDescription !== undefined) {
       updateData.location_description = input.contractPlot.locationDescription;
     }
-
-    if (input.contractPlot.inscription !== undefined) {
-      updateData.inscription = input.contractPlot.inscription;
-    }
   }
 
   if (input.saleContract) {
@@ -1540,7 +1536,6 @@ export async function updatePlotCore(
     const beforeContractPlotData = {
       contract_area_sqm: existingContractPlot.contract_area_sqm.toString(),
       location_description: existingContractPlot.location_description,
-      inscription: existingContractPlot.inscription,
       contract_date: existingContractPlot.contract_date?.toISOString(),
       price: existingContractPlot.price,
       payment_status: existingContractPlot.payment_status,
@@ -1558,7 +1553,6 @@ export async function updatePlotCore(
       ? {
           contract_area_sqm: updatedCp.contract_area_sqm.toString(),
           location_description: updatedCp.location_description,
-          inscription: updatedCp.inscription,
           contract_date: updatedCp.contract_date?.toISOString(),
           price: updatedCp.price,
           payment_status: updatedCp.payment_status,

--- a/src/plots/services/historyLabels.ts
+++ b/src/plots/services/historyLabels.ts
@@ -73,7 +73,6 @@ export const FIELD_LABELS: Record<HistoryEntityType, Record<string, string>> = {
   ContractPlot: {
     contract_area_sqm: '契約面積',
     location_description: '位置情報',
-    inscription: '碑文',
     contract_date: '契約日',
     price: '契約金額',
     payment_status: '支払ステータス',

--- a/tests/plots/plotController.test.ts
+++ b/tests/plots/plotController.test.ts
@@ -679,7 +679,6 @@ describe('Plot Controller (ContractPlot Model)', () => {
         physical_plot_id: 'pp1',
         contract_area_sqm: new Prisma.Decimal(3.6),
         location_description: 'A区画',
-        inscription: '連絡は長男へ',
         created_at: new Date('2024-01-01'),
         updated_at: new Date('2024-01-01'),
         deleted_at: null,
@@ -781,7 +780,6 @@ describe('Plot Controller (ContractPlot Model)', () => {
             contractStatus: 'active',
             paymentStatus: 'paid',
             requestDate: new Date('2023-12-01'),
-            inscription: '連絡は長男へ',
             graveKind: 1,
             graveKubun: 2,
             graveType: 3,
@@ -822,7 +820,6 @@ describe('Plot Controller (ContractPlot Model)', () => {
         contractPlot: {
           contractAreaSqm: 3.6,
           saleStatus: 'contracted',
-          inscription: '連絡は長男へ',
         },
         saleContract: {
           contractDate: '2024-01-01',
@@ -887,12 +884,6 @@ describe('Plot Controller (ContractPlot Model)', () => {
       expect(mockPrisma.$transaction).toHaveBeenCalled();
       expect(validateContractArea).toHaveBeenCalled();
       expect(updatePhysicalPlotStatus).toHaveBeenCalled();
-      // 碑文(inscription)が contractPlot.create の data に渡る（komine-docs#10 項目1）
-      expect(mockPrisma.contractPlot.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ inscription: '連絡は長男へ' }),
-        })
-      );
       expect(responseStatus).toHaveBeenCalledWith(201);
       expect(responseJson).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
## Summary
- 既存の碑文データをマイグレーションで notes へ移行
- `contract_plots.inscription` カラムを削除
- API から inscription フィールドを除去

## Test plan
- [x] ローカルテスト通過
- [ ] 本番 DB マイグレーション適用（`20260705120000_drop_contract_plot_inscription`）

Made with [Cursor](https://cursor.com)